### PR TITLE
add: commit message parser

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,0 +1,93 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Trigger is the parsed commit-message command for a single kgh run.
+type Trigger struct {
+	Command  string
+	Target   string
+	GPU      *bool
+	Internet *bool
+}
+
+// ParseCommitMessage scans a full commit message and extracts a single submit trigger.
+func ParseCommitMessage(message string) (Trigger, error) {
+	var triggerLine string
+
+	for _, line := range strings.Split(message, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "submit:") {
+			continue
+		}
+		if triggerLine != "" {
+			return Trigger{}, fmt.Errorf("multiple submit commands found")
+		}
+		triggerLine = trimmed
+	}
+
+	if triggerLine == "" {
+		return Trigger{}, fmt.Errorf("no submit command found")
+	}
+
+	return parseTriggerLine(triggerLine)
+}
+
+func parseTriggerLine(line string) (Trigger, error) {
+	fields := strings.Fields(line)
+	if len(fields) == 0 || fields[0] != "submit:" {
+		return Trigger{}, fmt.Errorf("invalid submit syntax: expected 'submit:' followed by target")
+	}
+	if len(fields) == 1 || strings.Contains(fields[1], "=") {
+		return Trigger{}, fmt.Errorf("missing target after 'submit:'")
+	}
+
+	trigger := Trigger{
+		Command: "submit",
+		Target:  fields[1],
+	}
+
+	for _, token := range fields[2:] {
+		key, value, ok := strings.Cut(token, "=")
+		if !ok || key == "" || value == "" {
+			return Trigger{}, fmt.Errorf("invalid override format %q: expected key=value", token)
+		}
+
+		parsed, err := parseBoolOverride(key, value)
+		if err != nil {
+			return Trigger{}, err
+		}
+
+		switch key {
+		case "gpu":
+			if trigger.GPU != nil {
+				return Trigger{}, fmt.Errorf("duplicate override key %q", key)
+			}
+			trigger.GPU = parsed
+		case "internet":
+			if trigger.Internet != nil {
+				return Trigger{}, fmt.Errorf("duplicate override key %q", key)
+			}
+			trigger.Internet = parsed
+		default:
+			return Trigger{}, fmt.Errorf("unsupported override key %q", key)
+		}
+	}
+
+	return trigger, nil
+}
+
+func parseBoolOverride(key, value string) (*bool, error) {
+	switch value {
+	case "true":
+		parsed := true
+		return &parsed, nil
+	case "false":
+		parsed := false
+		return &parsed, nil
+	default:
+		return nil, fmt.Errorf("invalid boolean value for %q: expected true or false, got %q", key, value)
+	}
+}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,0 +1,188 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseCommitMessageValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		message  string
+		target   string
+		gpu      *bool
+		internet *bool
+	}{
+		{
+			name:    "target only",
+			message: "submit: exp142",
+			target:  "exp142",
+		},
+		{
+			name:    "gpu override",
+			message: "submit: exp142 gpu=false",
+			target:  "exp142",
+			gpu:     boolPtr(false),
+		},
+		{
+			name:     "internet override",
+			message:  "submit: exp142 internet=true",
+			target:   "exp142",
+			internet: boolPtr(true),
+		},
+		{
+			name:     "both overrides",
+			message:  "submit: exp142 gpu=false internet=true",
+			target:   "exp142",
+			gpu:      boolPtr(false),
+			internet: boolPtr(true),
+		},
+		{
+			name:     "both overrides reversed",
+			message:  "submit: exp142 internet=true gpu=false",
+			target:   "exp142",
+			gpu:      boolPtr(false),
+			internet: boolPtr(true),
+		},
+		{
+			name: "multiline commit message",
+			message: strings.Join([]string{
+				"feat: tune notebook thresholds",
+				"",
+				"Run the latest experiment on Kaggle.",
+				"submit: exp142 gpu=false",
+			}, "\n"),
+			target: "exp142",
+			gpu:    boolPtr(false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseCommitMessage(tt.message)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if got.Command != "submit" {
+				t.Fatalf("expected command submit, got %q", got.Command)
+			}
+			if got.Target != tt.target {
+				t.Fatalf("expected target %q, got %q", tt.target, got.Target)
+			}
+			assertOptionalBool(t, "gpu", got.GPU, tt.gpu)
+			assertOptionalBool(t, "internet", got.Internet, tt.internet)
+		})
+	}
+}
+
+func TestParseCommitMessageInvalid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		message string
+		wantErr string
+	}{
+		{
+			name:    "no trigger",
+			message: "feat: tune notebook thresholds",
+			wantErr: "no submit command found",
+		},
+		{
+			name:    "missing target",
+			message: "submit:",
+			wantErr: "missing target after 'submit:'",
+		},
+		{
+			name:    "missing target before override",
+			message: "submit: gpu=false",
+			wantErr: "missing target after 'submit:'",
+		},
+		{
+			name:    "multiple targets",
+			message: "submit: exp142 exp143",
+			wantErr: "invalid override format \"exp143\": expected key=value",
+		},
+		{
+			name:    "malformed override",
+			message: "submit: exp142 gpu",
+			wantErr: "invalid override format \"gpu\": expected key=value",
+		},
+		{
+			name:    "unknown override",
+			message: "submit: exp142 private=true",
+			wantErr: "unsupported override key \"private\"",
+		},
+		{
+			name:    "duplicate gpu override",
+			message: "submit: exp142 gpu=false gpu=true",
+			wantErr: "duplicate override key \"gpu\"",
+		},
+		{
+			name:    "duplicate internet override",
+			message: "submit: exp142 internet=false internet=true",
+			wantErr: "duplicate override key \"internet\"",
+		},
+		{
+			name:    "invalid boolean",
+			message: "submit: exp142 gpu=TRUE",
+			wantErr: "invalid boolean value for \"gpu\": expected true or false, got \"TRUE\"",
+		},
+		{
+			name: "multiple submit commands",
+			message: strings.Join([]string{
+				"submit: exp142",
+				"",
+				"submit: exp143",
+			}, "\n"),
+			wantErr: "multiple submit commands found",
+		},
+		{
+			name:    "missing space after command",
+			message: "submit:exp142",
+			wantErr: "invalid submit syntax: expected 'submit:' followed by target",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseCommitMessage(tt.message)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if got := err.Error(); got != tt.wantErr {
+				t.Fatalf("expected error %q, got %q", tt.wantErr, got)
+			}
+		})
+	}
+}
+
+func assertOptionalBool(t *testing.T, name string, got, want *bool) {
+	t.Helper()
+
+	switch {
+	case got == nil && want == nil:
+		return
+	case got == nil || want == nil:
+		t.Fatalf("expected %s %v, got %v", name, valueOrNil(want), valueOrNil(got))
+	case *got != *want:
+		t.Fatalf("expected %s %t, got %t", name, *want, *got)
+	}
+}
+
+func valueOrNil(v *bool) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
• Implemented the v1 commit-message parser in internal/parser/parser.go and added unit
  coverage in internal/parser/parser_test.go.

  ParseCommitMessage now scans the full commit message, accepts exactly one submit: line,
  extracts command, target, and optional gpu / internet overrides, and returns clear
  errors for invalid syntax, duplicate keys, unsupported keys, invalid booleans, missing
  targets, and multiple submit commands. Optional booleans are represented as pointers so
  downstream code can distinguish “unset” from false.

  Verification: gofmt -w internal/parser/parser.go internal/parser/parser_test.go and go
  test ./... both passed.
<!-- close -->