### PR TITLE
Runtime override

### DIFF
--- a/internal/planner/doc.go
+++ b/internal/planner/doc.go
@@ -1,0 +1,2 @@
+// Package planner resolves parsed triggers against repository config.
+package planner

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -1,0 +1,22 @@
+package planner
+
+import (
+	"fmt"
+
+	"github.com/shotomorisk/kgh/internal/config"
+	"github.com/shotomorisk/kgh/internal/parser"
+	"github.com/shotomorisk/kgh/internal/spec"
+)
+
+// Resolve turns a parsed trigger and repository config into a fully resolved execution spec.
+func Resolve(cfg config.Config, trigger parser.Trigger) (spec.ExecutionSpec, error) {
+	target, ok := cfg.Targets[trigger.Target]
+	if !ok {
+		return spec.ExecutionSpec{}, fmt.Errorf("unknown target %q", trigger.Target)
+	}
+
+	return spec.NewExecutionSpec(trigger.Target, target, spec.RuntimeOverrides{
+		GPU:      trigger.GPU,
+		Internet: trigger.Internet,
+	}), nil
+}

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -1,0 +1,117 @@
+package planner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/shotomorisk/kgh/internal/config"
+	"github.com/shotomorisk/kgh/internal/parser"
+)
+
+func TestResolveUsesTargetDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Targets: map[string]config.Target{
+			"exp142": {
+				Notebook:    "notebooks/exp142.ipynb",
+				KernelID:    "yourname/exp142",
+				Competition: "playground-series-s6e2",
+				Submit:      true,
+				Resources: config.Resources{
+					GPU:      true,
+					Internet: false,
+					Private:  true,
+				},
+				Sources: config.Sources{
+					CompetitionSources: []string{"playground-series-s6e2"},
+					DatasetSources:     []string{"yourname/feature-pack-v3"},
+				},
+				Outputs: config.Outputs{
+					Submission: "submission.csv",
+					Metrics:    "metrics.json",
+				},
+			},
+		},
+	}
+
+	got, err := Resolve(cfg, parser.Trigger{Target: "exp142"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if got.TargetName != "exp142" {
+		t.Fatalf("expected target name %q, got %q", "exp142", got.TargetName)
+	}
+	if got.Notebook != "notebooks/exp142.ipynb" {
+		t.Fatalf("unexpected notebook %q", got.Notebook)
+	}
+	if got.KernelID != "yourname/exp142" {
+		t.Fatalf("unexpected kernel id %q", got.KernelID)
+	}
+	if got.Resources.GPU != true || got.Resources.Internet != false || got.Resources.Private != true {
+		t.Fatalf("unexpected resources: %+v", got.Resources)
+	}
+	if got.Overrides.GPU != nil || got.Overrides.Internet != nil {
+		t.Fatalf("expected no overrides, got %+v", got.Overrides)
+	}
+}
+
+func TestResolveAppliesOverrides(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Targets: map[string]config.Target{
+			"exp142": {
+				Notebook:    "notebooks/exp142.ipynb",
+				KernelID:    "yourname/exp142",
+				Competition: "playground-series-s6e2",
+				Submit:      true,
+				Resources: config.Resources{
+					GPU:      true,
+					Internet: false,
+					Private:  true,
+				},
+			},
+		},
+	}
+	gpu := false
+	internet := true
+
+	got, err := Resolve(cfg, parser.Trigger{
+		Target:   "exp142",
+		GPU:      &gpu,
+		Internet: &internet,
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if got.Resources.GPU != false {
+		t.Fatalf("expected gpu override to false, got %+v", got.Resources)
+	}
+	if got.Resources.Internet != true {
+		t.Fatalf("expected internet override to true, got %+v", got.Resources)
+	}
+	if got.Resources.Private != true {
+		t.Fatalf("expected private to remain true, got %+v", got.Resources)
+	}
+	if got.Overrides.GPU == nil || *got.Overrides.GPU != false {
+		t.Fatalf("expected gpu override to be preserved in spec, got %+v", got.Overrides)
+	}
+	if got.Overrides.Internet == nil || *got.Overrides.Internet != true {
+		t.Fatalf("expected internet override to be preserved in spec, got %+v", got.Overrides)
+	}
+}
+
+func TestResolveUnknownTarget(t *testing.T) {
+	t.Parallel()
+
+	_, err := Resolve(config.Config{Targets: map[string]config.Target{}}, parser.Trigger{Target: "missing"})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); !strings.Contains(got, `unknown target "missing"`) {
+		t.Fatalf("expected unknown target error, got %q", got)
+	}
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1,0 +1,45 @@
+package spec
+
+import "github.com/shotomorisk/kgh/internal/config"
+
+// RuntimeOverrides contains the subset of trigger-level fields that can override a target.
+type RuntimeOverrides struct {
+	GPU      *bool `json:"gpu,omitempty" yaml:"gpu,omitempty"`
+	Internet *bool `json:"internet,omitempty" yaml:"internet,omitempty"`
+}
+
+// ExecutionSpec is the fully resolved target configuration used by later execution layers.
+type ExecutionSpec struct {
+	TargetName  string           `json:"target_name" yaml:"target_name"`
+	Notebook    string           `json:"notebook" yaml:"notebook"`
+	KernelID    string           `json:"kernel_id" yaml:"kernel_id"`
+	Competition string           `json:"competition" yaml:"competition"`
+	Submit      bool             `json:"submit" yaml:"submit"`
+	Resources   config.Resources `json:"resources" yaml:"resources"`
+	Sources     config.Sources   `json:"sources" yaml:"sources"`
+	Outputs     config.Outputs   `json:"outputs" yaml:"outputs"`
+	Overrides   RuntimeOverrides `json:"overrides,omitempty" yaml:"overrides,omitempty"`
+}
+
+// NewExecutionSpec merges a target definition with supported runtime overrides.
+func NewExecutionSpec(name string, target config.Target, overrides RuntimeOverrides) ExecutionSpec {
+	resources := target.Resources
+	if overrides.GPU != nil {
+		resources.GPU = *overrides.GPU
+	}
+	if overrides.Internet != nil {
+		resources.Internet = *overrides.Internet
+	}
+
+	return ExecutionSpec{
+		TargetName:  name,
+		Notebook:    target.Notebook,
+		KernelID:    target.KernelID,
+		Competition: target.Competition,
+		Submit:      target.Submit,
+		Resources:   resources,
+		Sources:     target.Sources,
+		Outputs:     target.Outputs,
+		Overrides:   overrides,
+	}
+}


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #5

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented on feat/issue-5-target-resolution-runtime-override-merge in two commits:

  - 727ace5 Add resolved execution spec types
  - 55532b0 Add target resolver and merge tests

  What changed:

  - Added internal/spec/spec.go with ExecutionSpec and RuntimeOverrides.
  - Added internal/planner/planner.go with Resolve(cfg, trigger) to look up the target
    and merge gpu / internet overrides.
  - Added internal/planner/planner_test.go for default resolution, override merging, and
    unknown-target failure.

  Verification:

  - go test ./... passes.
  - Working tree is clean and the branch is ahead of origin/main by 2 commits.
<!-- close -->