### PR TITLE
Generate kernel metadata

### DIFF
--- a/internal/kaggle/metadata.go
+++ b/internal/kaggle/metadata.go
@@ -1,0 +1,66 @@
+package kaggle
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/shotomorisk/kgh/internal/spec"
+)
+
+const (
+	defaultLanguage   = "python"
+	defaultKernelType = "notebook"
+)
+
+// Metadata models Kaggle's kernel-metadata.json payload.
+type Metadata struct {
+	Title              string   `json:"title"`
+	ID                 string   `json:"id"`
+	CodeFile           string   `json:"code_file"`
+	Language           string   `json:"language"`
+	KernelType         string   `json:"kernel_type"`
+	EnableGPU          bool     `json:"enable_gpu"`
+	EnableInternet     bool     `json:"enable_internet"`
+	CompetitionSources []string `json:"competition_sources"`
+	DatasetSources     []string `json:"dataset_sources"`
+	KernelSources      []string `json:"kernel_sources"`
+	ModelSources       []string `json:"model_sources"`
+	IsPrivate          bool     `json:"is_private"`
+}
+
+// BuildMetadata converts a resolved execution spec into a deterministic Kaggle metadata payload.
+func BuildMetadata(exec spec.ExecutionSpec) Metadata {
+	return Metadata{
+		Title:              notebookTitle(exec.Notebook),
+		ID:                 exec.KernelID,
+		CodeFile:           filepath.Base(exec.Notebook),
+		Language:           defaultLanguage,
+		KernelType:         defaultKernelType,
+		EnableGPU:          exec.Resources.GPU,
+		EnableInternet:     exec.Resources.Internet,
+		CompetitionSources: cloneStrings(exec.Sources.CompetitionSources),
+		DatasetSources:     cloneStrings(exec.Sources.DatasetSources),
+		KernelSources:      emptyStrings(),
+		ModelSources:       emptyStrings(),
+		IsPrivate:          exec.Resources.Private,
+	}
+}
+
+func notebookTitle(notebookPath string) string {
+	base := filepath.Base(notebookPath)
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}
+
+func cloneStrings(values []string) []string {
+	if len(values) == 0 {
+		return emptyStrings()
+	}
+
+	out := make([]string, len(values))
+	copy(out, values)
+	return out
+}
+
+func emptyStrings() []string {
+	return make([]string, 0)
+}

--- a/internal/kaggle/metadata_test.go
+++ b/internal/kaggle/metadata_test.go
@@ -1,0 +1,83 @@
+package kaggle
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shotomorisk/kgh/internal/config"
+	"github.com/shotomorisk/kgh/internal/spec"
+)
+
+func TestBuildMetadata(t *testing.T) {
+	t.Parallel()
+
+	exec := spec.ExecutionSpec{
+		Notebook:  "notebooks/exp142.ipynb",
+		KernelID:  "yourname/exp142",
+		Resources: config.Resources{GPU: true, Internet: false, Private: true},
+		Sources:   config.Sources{CompetitionSources: []string{"playground-series-s6e2"}, DatasetSources: []string{"yourname/feature-pack-v3"}},
+	}
+
+	got := BuildMetadata(exec)
+
+	if got.Title != "exp142" {
+		t.Fatalf("expected title %q, got %q", "exp142", got.Title)
+	}
+	if got.ID != "yourname/exp142" {
+		t.Fatalf("expected id %q, got %q", "yourname/exp142", got.ID)
+	}
+	if got.CodeFile != "exp142.ipynb" {
+		t.Fatalf("expected code_file %q, got %q", "exp142.ipynb", got.CodeFile)
+	}
+	if got.Language != defaultLanguage {
+		t.Fatalf("expected language %q, got %q", defaultLanguage, got.Language)
+	}
+	if got.KernelType != defaultKernelType {
+		t.Fatalf("expected kernel_type %q, got %q", defaultKernelType, got.KernelType)
+	}
+	if !got.EnableGPU || got.EnableInternet {
+		t.Fatalf("unexpected resource flags: %+v", got)
+	}
+	if !got.IsPrivate {
+		t.Fatalf("expected is_private to be true, got %+v", got)
+	}
+	if len(got.KernelSources) != 0 || len(got.ModelSources) != 0 {
+		t.Fatalf("expected empty kernel/model sources, got %+v", got)
+	}
+
+	b, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+
+	const want = `{"title":"exp142","id":"yourname/exp142","code_file":"exp142.ipynb","language":"python","kernel_type":"notebook","enable_gpu":true,"enable_internet":false,"competition_sources":["playground-series-s6e2"],"dataset_sources":["yourname/feature-pack-v3"],"kernel_sources":[],"model_sources":[],"is_private":true}`
+	if gotJSON := string(b); gotJSON != want {
+		t.Fatalf("unexpected json:\nwant %s\ngot  %s", want, gotJSON)
+	}
+}
+
+func TestBuildMetadataDeterministic(t *testing.T) {
+	t.Parallel()
+
+	exec := spec.ExecutionSpec{
+		Notebook: "notebooks/exp142.ipynb",
+		KernelID: "yourname/exp142",
+		Sources: config.Sources{
+			CompetitionSources: []string{"b", "a"},
+			DatasetSources:     []string{"x", "y"},
+		},
+	}
+
+	first, err := json.Marshal(BuildMetadata(exec))
+	if err != nil {
+		t.Fatalf("marshal first metadata: %v", err)
+	}
+	second, err := json.Marshal(BuildMetadata(exec))
+	if err != nil {
+		t.Fatalf("marshal second metadata: %v", err)
+	}
+
+	if string(first) != string(second) {
+		t.Fatalf("expected deterministic json, got %q and %q", string(first), string(second))
+	}
+}

--- a/internal/kaggle/writer.go
+++ b/internal/kaggle/writer.go
@@ -1,0 +1,30 @@
+package kaggle
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/shotomorisk/kgh/internal/spec"
+)
+
+const metadataFilename = "kernel-metadata.json"
+
+// WriteKernelMetadata writes a kernel-metadata.json file into workDir and returns the path.
+func WriteKernelMetadata(workDir string, exec spec.ExecutionSpec) (string, error) {
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		return "", err
+	}
+
+	payload, err := json.Marshal(BuildMetadata(exec))
+	if err != nil {
+		return "", err
+	}
+
+	path := filepath.Join(workDir, metadataFilename)
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		return "", err
+	}
+
+	return path, nil
+}

--- a/internal/kaggle/writer_test.go
+++ b/internal/kaggle/writer_test.go
@@ -1,0 +1,42 @@
+package kaggle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shotomorisk/kgh/internal/config"
+	"github.com/shotomorisk/kgh/internal/spec"
+)
+
+func TestWriteKernelMetadata(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	exec := spec.ExecutionSpec{
+		Notebook:  "notebooks/exp142.ipynb",
+		KernelID:  "yourname/exp142",
+		Resources: config.Resources{GPU: true, Internet: true, Private: false},
+		Sources:   config.Sources{CompetitionSources: []string{"playground-series-s6e2"}, DatasetSources: []string{"yourname/feature-pack-v3"}},
+	}
+
+	gotPath, err := WriteKernelMetadata(workDir, exec)
+	if err != nil {
+		t.Fatalf("write kernel metadata: %v", err)
+	}
+
+	wantPath := filepath.Join(workDir, metadataFilename)
+	if gotPath != wantPath {
+		t.Fatalf("expected path %q, got %q", wantPath, gotPath)
+	}
+
+	b, err := os.ReadFile(gotPath)
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+
+	want := `{"title":"exp142","id":"yourname/exp142","code_file":"exp142.ipynb","language":"python","kernel_type":"notebook","enable_gpu":true,"enable_internet":true,"competition_sources":["playground-series-s6e2"],"dataset_sources":["yourname/feature-pack-v3"],"kernel_sources":[],"model_sources":[],"is_private":false}`
+	if got := string(b); got != want {
+		t.Fatalf("unexpected metadata file:\nwant %s\ngot  %s", want, got)
+	}
+}


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #6 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented in two commits:

  - 0660939 kaggle: add kernel metadata generator
  - 2b34d90 kaggle: write kernel metadata file

  What changed:

  - Added a pure Kaggle metadata model and builder in internal/kaggle/metadata.go:15.
  - Added a temp-dir writer that emits kernel-metadata.json in internal/kaggle/
    writer.go:11.
  - Added tests for field mapping, deterministic JSON, and file output in internal/
    kaggle/metadata_test.go:11 and internal/kaggle/writer_test.go:12.

  Behavior:

  - Derives title from the notebook stem.
  - Uses the notebook basename as code_file.
  - Sets id from the resolved KernelID.
  - Defaults language to python and kernel_type to notebook.
  - Carries through enable_gpu, enable_internet, and is_private.
  - Always emits empty arrays for kernel_sources and model_sources.
  - Writes the JSON into the provided working directory without touching the notebook
    file itself.

<!-- close -->