### PR TITLE
Kaggle adapter foundation 

### DIFF
--- a/internal/kaggle/auth.go
+++ b/internal/kaggle/auth.go
@@ -1,0 +1,56 @@
+package kaggle
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	envKaggleUsername = "KAGGLE_USERNAME"
+	envKaggleKey      = "KAGGLE_KEY"
+)
+
+// Credentials holds the Kaggle CLI credentials sourced from the environment.
+type Credentials struct {
+	Username string
+	Key      string
+}
+
+// EnvSource reads environment variables by name.
+type EnvSource interface {
+	LookupEnv(string) (string, bool)
+}
+
+// MissingCredentialsError reports one or more required Kaggle environment variables.
+type MissingCredentialsError struct {
+	Missing []string
+}
+
+func (e *MissingCredentialsError) Error() string {
+	if e == nil || len(e.Missing) == 0 {
+		return "missing Kaggle credentials"
+	}
+	return fmt.Sprintf("missing Kaggle credentials: %s", strings.Join(e.Missing, ", "))
+}
+
+// LoadCredentials reads Kaggle credentials from the provided environment source.
+func LoadCredentials(env EnvSource) (Credentials, error) {
+	username, hasUsername := env.LookupEnv(envKaggleUsername)
+	key, hasKey := env.LookupEnv(envKaggleKey)
+
+	var missing []string
+	if !hasUsername || username == "" {
+		missing = append(missing, envKaggleUsername)
+	}
+	if !hasKey || key == "" {
+		missing = append(missing, envKaggleKey)
+	}
+	if len(missing) > 0 {
+		return Credentials{}, &MissingCredentialsError{Missing: missing}
+	}
+
+	return Credentials{
+		Username: username,
+		Key:      key,
+	}, nil
+}

--- a/internal/kaggle/auth_test.go
+++ b/internal/kaggle/auth_test.go
@@ -1,0 +1,114 @@
+package kaggle
+
+import (
+	"strings"
+	"testing"
+)
+
+type staticEnvSource map[string]string
+
+func (s staticEnvSource) LookupEnv(key string) (string, bool) {
+	v, ok := s[key]
+	return v, ok
+}
+
+func TestLoadCredentials(t *testing.T) {
+	t.Parallel()
+
+	creds, err := LoadCredentials(staticEnvSource{
+		envKaggleUsername: "alice",
+		envKaggleKey:      "secret-key",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if creds.Username != "alice" {
+		t.Fatalf("unexpected username %q", creds.Username)
+	}
+	if creds.Key != "secret-key" {
+		t.Fatalf("unexpected key %q", creds.Key)
+	}
+}
+
+func TestLoadCredentialsMissingUsername(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadCredentials(staticEnvSource{
+		envKaggleKey: "secret-key",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var missingErr *MissingCredentialsError
+	if !strings.Contains(err.Error(), envKaggleUsername) {
+		t.Fatalf("expected missing username in error, got %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "secret-key") {
+		t.Fatalf("expected error to redact credential value, got %q", err.Error())
+	}
+	if !errorAs(err, &missingErr) {
+		t.Fatalf("expected MissingCredentialsError, got %T", err)
+	}
+	if got := len(missingErr.Missing); got != 1 || missingErr.Missing[0] != envKaggleUsername {
+		t.Fatalf("unexpected missing variables %#v", missingErr.Missing)
+	}
+}
+
+func TestLoadCredentialsMissingKey(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadCredentials(staticEnvSource{
+		envKaggleUsername: "alice",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), envKaggleKey) {
+		t.Fatalf("expected missing key in error, got %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "alice") {
+		t.Fatalf("expected error to redact credential value, got %q", err.Error())
+	}
+}
+
+func TestLoadCredentialsMissingBoth(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadCredentials(staticEnvSource{})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); !strings.Contains(got, envKaggleUsername) || !strings.Contains(got, envKaggleKey) {
+		t.Fatalf("expected both missing variables in error, got %q", got)
+	}
+}
+
+func TestLoadCredentialsEmptyValuesAreMissing(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadCredentials(staticEnvSource{
+		envKaggleUsername: "",
+		envKaggleKey:      "",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); !strings.Contains(got, envKaggleUsername) || !strings.Contains(got, envKaggleKey) {
+		t.Fatalf("expected both empty variables to be reported, got %q", got)
+	}
+}
+
+func errorAs(err error, target any) bool {
+	switch t := target.(type) {
+	case **MissingCredentialsError:
+		typed, ok := err.(*MissingCredentialsError)
+		if !ok {
+			return false
+		}
+		*t = typed
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/kaggle/client.go
+++ b/internal/kaggle/client.go
@@ -1,0 +1,155 @@
+package kaggle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+const defaultTimeout = 30 * time.Second
+
+// Client is a thin, testable adapter around the Kaggle CLI.
+type Client struct {
+	runner         Runner
+	env            EnvSource
+	lookPath       LookPathFunc
+	baseEnv        func() []string
+	defaultTimeout time.Duration
+}
+
+type osEnvSource struct{}
+
+func (osEnvSource) LookupEnv(key string) (string, bool) {
+	return lookupEnv(key)
+}
+
+func lookupEnv(key string) (string, bool) {
+	return syscallLookupEnv(key)
+}
+
+// CommandError reports a non-zero Kaggle CLI process exit.
+type CommandError struct {
+	Args     []string
+	ExitCode int
+	Stdout   string
+	Stderr   string
+	Err      error
+}
+
+func (e *CommandError) Error() string {
+	if e == nil {
+		return "kaggle command failed"
+	}
+	return fmt.Sprintf("kaggle command failed (exit code %d): %v", e.ExitCode, e.Err)
+}
+
+func (e *CommandError) Unwrap() error { return e.Err }
+
+// TimeoutError reports a Kaggle CLI invocation that exceeded its timeout.
+type TimeoutError struct {
+	Args    []string
+	Timeout time.Duration
+	Err     error
+}
+
+func (e *TimeoutError) Error() string {
+	if e == nil {
+		return "kaggle command timed out"
+	}
+	return fmt.Sprintf("kaggle command timed out after %s", e.Timeout)
+}
+
+func (e *TimeoutError) Unwrap() error { return e.Err }
+
+// NewClient constructs a Kaggle CLI adapter with production dependencies.
+func NewClient() *Client {
+	return NewClientWithDeps(execRunner{}, osEnvSource{}, exec.LookPath, currentEnv, defaultTimeout)
+}
+
+// NewClientWithDeps constructs a Kaggle CLI adapter with injected dependencies for tests.
+func NewClientWithDeps(runner Runner, env EnvSource, lookPath LookPathFunc, baseEnv func() []string, timeout time.Duration) *Client {
+	if runner == nil {
+		runner = execRunner{}
+	}
+	if env == nil {
+		env = osEnvSource{}
+	}
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	if baseEnv == nil {
+		baseEnv = currentEnv
+	}
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+
+	return &Client{
+		runner:         runner,
+		env:            env,
+		lookPath:       lookPath,
+		baseEnv:        baseEnv,
+		defaultTimeout: timeout,
+	}
+}
+
+// Run invokes the Kaggle CLI with the provided arguments and execution options.
+func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Result, error) {
+	if c == nil {
+		return Result{}, fmt.Errorf("kaggle client is nil")
+	}
+
+	creds, err := LoadCredentials(c.env)
+	if err != nil {
+		return Result{}, err
+	}
+
+	binaryPath, err := resolveExecutable(kaggleBinary, c.lookPath)
+	if err != nil {
+		return Result{}, err
+	}
+
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = c.defaultTimeout
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	command := buildCommand(binaryPath, args, c.baseEnv(), RunOptions{
+		Dir: opts.Dir,
+		Env: append([]string{
+			envKaggleUsername + "=" + creds.Username,
+			envKaggleKey + "=" + creds.Key,
+		}, opts.Env...),
+		Timeout: timeout,
+	})
+
+	result, err := c.runner.Run(runCtx, command)
+	if err == nil {
+		return result, nil
+	}
+
+	if errors.Is(runCtx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
+		return result, &TimeoutError{
+			Args:    append([]string(nil), args...),
+			Timeout: timeout,
+			Err:     err,
+		}
+	}
+
+	if result.ExitCode != 0 {
+		return result, &CommandError{
+			Args:     append([]string(nil), args...),
+			ExitCode: result.ExitCode,
+			Stdout:   result.Stdout,
+			Stderr:   result.Stderr,
+			Err:      err,
+		}
+	}
+
+	return result, fmt.Errorf("run kaggle command: %w", err)
+}

--- a/internal/kaggle/client_test.go
+++ b/internal/kaggle/client_test.go
@@ -1,0 +1,259 @@
+package kaggle
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestClientRunSuccess(t *testing.T) {
+	t.Parallel()
+
+	runner := &clientFakeRunner{
+		t: t,
+		runFn: func(ctx context.Context, cmd command) (Result, error) {
+			if cmd.Path != "/usr/local/bin/kaggle" {
+				t.Fatalf("unexpected path %q", cmd.Path)
+			}
+			if !reflect.DeepEqual(cmd.Args, []string{"/usr/local/bin/kaggle", "kernels", "status"}) {
+				t.Fatalf("unexpected args %#v", cmd.Args)
+			}
+			if cmd.Dir != "/repo" {
+				t.Fatalf("unexpected dir %q", cmd.Dir)
+			}
+			wantEnv := []string{
+				"PATH=/usr/bin",
+				"HOME=/tmp/home",
+				"KAGGLE_USERNAME=alice",
+				"KAGGLE_KEY=secret-key",
+			}
+			if !reflect.DeepEqual(cmd.Env, wantEnv) {
+				t.Fatalf("unexpected env %#v", cmd.Env)
+			}
+			if _, ok := ctx.Deadline(); !ok {
+				t.Fatal("expected context deadline to be set")
+			}
+			return Result{
+				Stdout:   "ok",
+				Stderr:   "",
+				ExitCode: 0,
+			}, nil
+		},
+	}
+
+	client := NewClientWithDeps(
+		runner,
+		staticEnvSource{
+			envKaggleUsername: "alice",
+			envKaggleKey:      "secret-key",
+		},
+		func(name string) (string, error) {
+			if name != kaggleBinary {
+				t.Fatalf("unexpected executable name %q", name)
+			}
+			return "/usr/local/bin/kaggle", nil
+		},
+		func() []string {
+			return []string{
+				"PATH=/usr/bin",
+				"HOME=/base/home",
+			}
+		},
+		30*time.Second,
+	)
+
+	result, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{
+		Dir: "/repo",
+		Env: []string{"HOME=/tmp/home"},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Stdout != "ok" {
+		t.Fatalf("unexpected stdout %q", result.Stdout)
+	}
+}
+
+func TestClientRunUsesDefaultTimeout(t *testing.T) {
+	t.Parallel()
+
+	client := NewClientWithDeps(
+		&clientFakeRunner{
+			t: t,
+			runFn: func(ctx context.Context, cmd command) (Result, error) {
+				deadline, ok := ctx.Deadline()
+				if !ok {
+					t.Fatal("expected deadline to be set")
+				}
+				remaining := time.Until(deadline)
+				if remaining <= 0 || remaining > 5*time.Second {
+					t.Fatalf("unexpected deadline window %s", remaining)
+				}
+				return Result{}, nil
+			},
+		},
+		staticEnvSource{
+			envKaggleUsername: "alice",
+			envKaggleKey:      "secret-key",
+		},
+		func(string) (string, error) { return "/usr/local/bin/kaggle", nil },
+		func() []string { return nil },
+		2*time.Second,
+	)
+
+	if _, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{}); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestClientRunUsesExplicitTimeoutOverride(t *testing.T) {
+	t.Parallel()
+
+	client := NewClientWithDeps(
+		&clientFakeRunner{
+			t: t,
+			runFn: func(ctx context.Context, cmd command) (Result, error) {
+				deadline, ok := ctx.Deadline()
+				if !ok {
+					t.Fatal("expected deadline to be set")
+				}
+				remaining := time.Until(deadline)
+				if remaining <= 0 || remaining > 1500*time.Millisecond {
+					t.Fatalf("unexpected deadline window %s", remaining)
+				}
+				return Result{}, nil
+			},
+		},
+		staticEnvSource{
+			envKaggleUsername: "alice",
+			envKaggleKey:      "secret-key",
+		},
+		func(string) (string, error) { return "/usr/local/bin/kaggle", nil },
+		func() []string { return nil },
+		10*time.Second,
+	)
+
+	if _, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{
+		Timeout: time.Second,
+	}); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestClientRunClassifiesTimeout(t *testing.T) {
+	t.Parallel()
+
+	client := NewClientWithDeps(
+		&clientFakeRunner{
+			t: t,
+			runFn: func(ctx context.Context, cmd command) (Result, error) {
+				<-ctx.Done()
+				return Result{}, ctx.Err()
+			},
+		},
+		staticEnvSource{
+			envKaggleUsername: "alice",
+			envKaggleKey:      "secret-key",
+		},
+		func(string) (string, error) { return "/usr/local/bin/kaggle", nil },
+		func() []string { return nil },
+		10*time.Millisecond,
+	)
+
+	_, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var timeoutErr *TimeoutError
+	if !errors.As(err, &timeoutErr) {
+		t.Fatalf("expected TimeoutError, got %T", err)
+	}
+	if timeoutErr.Timeout != 10*time.Millisecond {
+		t.Fatalf("unexpected timeout %s", timeoutErr.Timeout)
+	}
+}
+
+func TestClientRunClassifiesCommandFailure(t *testing.T) {
+	t.Parallel()
+
+	client := NewClientWithDeps(
+		&clientFakeRunner{
+			t: t,
+			runFn: func(context.Context, command) (Result, error) {
+				return Result{
+					Stdout:   "partial output",
+					Stderr:   "bad things happened",
+					ExitCode: 2,
+				}, errors.New("exit status 2")
+			},
+		},
+		staticEnvSource{
+			envKaggleUsername: "alice",
+			envKaggleKey:      "secret-key",
+		},
+		func(string) (string, error) { return "/usr/local/bin/kaggle", nil },
+		func() []string { return nil },
+		time.Second,
+	)
+
+	result, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var commandErr *CommandError
+	if !errors.As(err, &commandErr) {
+		t.Fatalf("expected CommandError, got %T", err)
+	}
+	if commandErr.ExitCode != 2 {
+		t.Fatalf("unexpected exit code %d", commandErr.ExitCode)
+	}
+	if commandErr.Stderr != "bad things happened" {
+		t.Fatalf("unexpected stderr %q", commandErr.Stderr)
+	}
+	if result.Stdout != "partial output" {
+		t.Fatalf("unexpected result stdout %q", result.Stdout)
+	}
+}
+
+func TestClientRunReturnsExecutableLookupError(t *testing.T) {
+	t.Parallel()
+
+	client := NewClientWithDeps(
+		&clientFakeRunner{t: t},
+		staticEnvSource{
+			envKaggleUsername: "alice",
+			envKaggleKey:      "secret-key",
+		},
+		func(string) (string, error) {
+			return "", &ExecutableNotFoundError{Name: kaggleBinary}
+		},
+		func() []string { return nil },
+		time.Second,
+	)
+
+	_, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var notFoundErr *ExecutableNotFoundError
+	if !errors.As(err, &notFoundErr) {
+		t.Fatalf("expected ExecutableNotFoundError, got %T", err)
+	}
+}
+
+type clientFakeRunner struct {
+	t     *testing.T
+	runFn func(context.Context, command) (Result, error)
+}
+
+func (f *clientFakeRunner) Run(ctx context.Context, cmd command) (Result, error) {
+	if f.runFn == nil {
+		f.t.Fatal("runFn must be set")
+	}
+	return f.runFn(ctx, cmd)
+}

--- a/internal/kaggle/client_unix.go
+++ b/internal/kaggle/client_unix.go
@@ -1,0 +1,9 @@
+//go:build unix
+
+package kaggle
+
+import "os"
+
+func syscallLookupEnv(key string) (string, bool) {
+	return os.LookupEnv(key)
+}

--- a/internal/kaggle/doc.go
+++ b/internal/kaggle/doc.go
@@ -1,2 +1,8 @@
-// Package kaggle contains the kaggle layer for kh.
+// Package kaggle contains the Kaggle CLI adapter layer for kgh.
+//
+// The package is intentionally thin. It validates environment-based credentials,
+// invokes the official kaggle binary with timeouts, captures process output, and
+// returns typed errors that higher layers can surface cleanly. Workflow-specific
+// commands such as kernel push, polling, download, and submission are added on
+// top of this foundation in later steps.
 package kaggle

--- a/internal/kaggle/runner.go
+++ b/internal/kaggle/runner.go
@@ -1,0 +1,153 @@
+package kaggle
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const kaggleBinary = "kaggle"
+
+// RunOptions configures a Kaggle CLI process execution.
+type RunOptions struct {
+	Timeout time.Duration
+	Dir     string
+	Env     []string
+}
+
+// Result captures the observable output from a Kaggle CLI process.
+type Result struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+type command struct {
+	Path string
+	Args []string
+	Dir  string
+	Env  []string
+}
+
+// Runner executes a prepared process invocation.
+type Runner interface {
+	Run(context.Context, command) (Result, error)
+}
+
+// LookPathFunc resolves an executable from PATH.
+type LookPathFunc func(string) (string, error)
+
+// ExecutableNotFoundError reports a missing executable lookup failure.
+type ExecutableNotFoundError struct {
+	Name string
+}
+
+func (e *ExecutableNotFoundError) Error() string {
+	if e == nil || e.Name == "" {
+		return "required executable not found"
+	}
+	return fmt.Sprintf("required executable %q not found on PATH", e.Name)
+}
+
+func resolveExecutable(name string, lookPath LookPathFunc) (string, error) {
+	path, err := lookPath(name)
+	if err == nil {
+		return path, nil
+	}
+	var execErr *exec.Error
+	if errors.As(err, &execErr) && errors.Is(execErr.Err, exec.ErrNotFound) {
+		return "", &ExecutableNotFoundError{Name: name}
+	}
+	if errors.Is(err, exec.ErrNotFound) {
+		return "", &ExecutableNotFoundError{Name: name}
+	}
+	return "", fmt.Errorf("resolve executable %q: %w", name, err)
+}
+
+func buildCommand(path string, args []string, baseEnv []string, opts RunOptions) command {
+	return command{
+		Path: path,
+		Args: append([]string{path}, args...),
+		Dir:  opts.Dir,
+		Env:  mergeEnv(baseEnv, opts.Env),
+	}
+}
+
+func mergeEnv(base []string, extra []string) []string {
+	merged := slices.Clone(base)
+	if len(extra) == 0 {
+		return merged
+	}
+
+	indexByKey := make(map[string]int, len(merged))
+	for i, entry := range merged {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		indexByKey[key] = i
+	}
+
+	for _, entry := range extra {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			merged = append(merged, entry)
+			continue
+		}
+		if idx, exists := indexByKey[key]; exists {
+			merged[idx] = entry
+			continue
+		}
+		indexByKey[key] = len(merged)
+		merged = append(merged, entry)
+	}
+
+	return merged
+}
+
+type execRunner struct{}
+
+func (execRunner) Run(ctx context.Context, cmd command) (Result, error) {
+	execCmd := exec.CommandContext(ctx, cmd.Path, cmd.Args[1:]...)
+	execCmd.Dir = cmd.Dir
+	execCmd.Env = cmd.Env
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	execCmd.Stdout = &stdout
+	execCmd.Stderr = &stderr
+
+	err := execCmd.Run()
+
+	result := Result{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}
+
+	if execCmd.ProcessState != nil {
+		result.ExitCode = execCmd.ProcessState.ExitCode()
+	}
+
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+				result.ExitCode = status.ExitStatus()
+			}
+		}
+		return result, err
+	}
+
+	return result, nil
+}
+
+func currentEnv() []string {
+	return os.Environ()
+}

--- a/internal/kaggle/runner_test.go
+++ b/internal/kaggle/runner_test.go
@@ -1,0 +1,105 @@
+package kaggle
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestResolveExecutable(t *testing.T) {
+	t.Parallel()
+
+	path, err := resolveExecutable(kaggleBinary, func(name string) (string, error) {
+		if name != kaggleBinary {
+			t.Fatalf("unexpected executable lookup %q", name)
+		}
+		return "/usr/local/bin/kaggle", nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if path != "/usr/local/bin/kaggle" {
+		t.Fatalf("unexpected path %q", path)
+	}
+}
+
+func TestResolveExecutableMissing(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveExecutable(kaggleBinary, func(string) (string, error) {
+		return "", &exec.Error{Name: kaggleBinary, Err: exec.ErrNotFound}
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var notFoundErr *ExecutableNotFoundError
+	if !errors.As(err, &notFoundErr) {
+		t.Fatalf("expected ExecutableNotFoundError, got %T", err)
+	}
+}
+
+func TestBuildCommandMergesEnvironment(t *testing.T) {
+	t.Parallel()
+
+	cmd := buildCommand("/usr/local/bin/kaggle", []string{"kernels", "status"}, []string{
+		"PATH=/usr/bin",
+		"HOME=/tmp/home",
+	}, RunOptions{
+		Dir: "/work",
+		Env: []string{
+			"HOME=/override/home",
+			"KAGGLE_USERNAME=alice",
+		},
+		Timeout: 5 * time.Second,
+	})
+
+	if cmd.Path != "/usr/local/bin/kaggle" {
+		t.Fatalf("unexpected path %q", cmd.Path)
+	}
+	if !reflect.DeepEqual(cmd.Args, []string{"/usr/local/bin/kaggle", "kernels", "status"}) {
+		t.Fatalf("unexpected args %#v", cmd.Args)
+	}
+	if cmd.Dir != "/work" {
+		t.Fatalf("unexpected dir %q", cmd.Dir)
+	}
+	wantEnv := []string{
+		"PATH=/usr/bin",
+		"HOME=/override/home",
+		"KAGGLE_USERNAME=alice",
+	}
+	if !reflect.DeepEqual(cmd.Env, wantEnv) {
+		t.Fatalf("unexpected env %#v", cmd.Env)
+	}
+}
+
+func TestMergeEnvDoesNotMutateBase(t *testing.T) {
+	t.Parallel()
+
+	base := []string{"PATH=/usr/bin", "HOME=/tmp/home"}
+	got := mergeEnv(base, []string{"HOME=/override/home"})
+	if !reflect.DeepEqual(base, []string{"PATH=/usr/bin", "HOME=/tmp/home"}) {
+		t.Fatalf("base environment was mutated: %#v", base)
+	}
+	if !reflect.DeepEqual(got, []string{"PATH=/usr/bin", "HOME=/override/home"}) {
+		t.Fatalf("unexpected merged environment %#v", got)
+	}
+}
+
+type fakeRunner struct {
+	t      *testing.T
+	result Result
+	err    error
+	seen   command
+}
+
+func (f *fakeRunner) Run(_ context.Context, cmd command) (Result, error) {
+	if f.t == nil {
+		panic("fakeRunner.t must be set")
+	}
+	f.seen = cmd
+	return f.result, f.err
+}


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented the Kaggle adapter foundation in four commits:

  1. 48aec12 kaggle: add env-based credential validation
  2. 42609ba kaggle: add command runner abstraction and result model
  3. fc6b0e4 kaggle: add CLI adapter error handling and timeout policy
  4. 4abafc6 kaggle: document adapter package foundation

  What changed:

  - Added env-based credential loading and typed missing-credential errors in internal/
    kaggle/auth.go
  - Added process runner abstraction, result/options types, env merge logic, and
    executable lookup handling in internal/kaggle/runner.go
  - Added the thin Kaggle CLI client with default timeout, per-call override, injected
    test dependencies, and classified timeout/command errors in internal/kaggle/client.go
  - Documented the package role and boundaries in internal/kaggle/doc.go

  Tests added:

  - internal/kaggle/auth_test.go
  - internal/kaggle/runner_test.go
  - internal/kaggle/client_test.go

  Verification:

  - go test ./... passed
  - Working tree is clean
<!-- close -->