### PR TITLE
Workflow-facing Adapter contract with typed request/response model

### DIFF
--- a/internal/kaggle/adapter.go
+++ b/internal/kaggle/adapter.go
@@ -1,0 +1,101 @@
+package kaggle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Adapter defines workflow-level Kaggle operations without exposing shell details.
+type Adapter interface {
+	PushKernel(context.Context, PushKernelRequest) (PushKernelResponse, error)
+	KernelStatus(context.Context, KernelStatusRequest) (KernelStatusResponse, error)
+	DownloadKernelOutput(context.Context, DownloadKernelOutputRequest) (DownloadKernelOutputResponse, error)
+	SubmitCompetition(context.Context, CompetitionSubmitRequest) (CompetitionSubmitResponse, error)
+	ListCompetitionSubmissions(context.Context, CompetitionSubmissionsRequest) (CompetitionSubmissionsResponse, error)
+}
+
+type PushKernelRequest struct {
+	WorkDir string
+}
+
+type PushKernelResponse struct {
+	KernelRef string
+}
+
+type KernelStatusRequest struct {
+	KernelRef string
+}
+
+type KernelStatusResponse struct {
+	KernelRef string
+	Status    string
+	Message   string
+}
+
+type DownloadKernelOutputRequest struct {
+	KernelRef string
+	OutputDir string
+}
+
+type DownloadKernelOutputResponse struct {
+	OutputDir string
+}
+
+type CompetitionSubmitRequest struct {
+	Competition string
+	FilePath    string
+	Message     string
+}
+
+type CompetitionSubmitResponse struct {
+	Competition string
+	Submitted   bool
+}
+
+type CompetitionSubmissionsRequest struct {
+	Competition string
+	Limit       int
+}
+
+type CompetitionSubmissionsResponse struct {
+	Submissions []CompetitionSubmission
+}
+
+type CompetitionSubmission struct {
+	FileName    string
+	Description string
+	Status      string
+	PublicScore string
+	SubmittedAt time.Time
+}
+
+var ErrNotImplemented = errors.New("kaggle adapter operation not implemented")
+
+// StubAdapter is a compile-ready placeholder implementation for tests and wiring.
+type StubAdapter struct{}
+
+func (StubAdapter) PushKernel(context.Context, PushKernelRequest) (PushKernelResponse, error) {
+	return PushKernelResponse{}, notImplemented("push kernel")
+}
+
+func (StubAdapter) KernelStatus(context.Context, KernelStatusRequest) (KernelStatusResponse, error) {
+	return KernelStatusResponse{}, notImplemented("kernel status")
+}
+
+func (StubAdapter) DownloadKernelOutput(context.Context, DownloadKernelOutputRequest) (DownloadKernelOutputResponse, error) {
+	return DownloadKernelOutputResponse{}, notImplemented("download kernel output")
+}
+
+func (StubAdapter) SubmitCompetition(context.Context, CompetitionSubmitRequest) (CompetitionSubmitResponse, error) {
+	return CompetitionSubmitResponse{}, notImplemented("submit competition")
+}
+
+func (StubAdapter) ListCompetitionSubmissions(context.Context, CompetitionSubmissionsRequest) (CompetitionSubmissionsResponse, error) {
+	return CompetitionSubmissionsResponse{}, notImplemented("list competition submissions")
+}
+
+func notImplemented(operation string) error {
+	return fmt.Errorf("%w: %s", ErrNotImplemented, operation)
+}

--- a/internal/kaggle/adapter_test.go
+++ b/internal/kaggle/adapter_test.go
@@ -1,0 +1,76 @@
+package kaggle
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestStubAdapterImplementsAdapter(t *testing.T) {
+	t.Parallel()
+
+	var adapter Adapter = StubAdapter{}
+	if adapter == nil {
+		t.Fatal("expected adapter to be non-nil")
+	}
+}
+
+func TestStubAdapterReturnsNotImplemented(t *testing.T) {
+	t.Parallel()
+
+	adapter := StubAdapter{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "push kernel",
+			run: func() error {
+				_, err := adapter.PushKernel(ctx, PushKernelRequest{})
+				return err
+			},
+		},
+		{
+			name: "kernel status",
+			run: func() error {
+				_, err := adapter.KernelStatus(ctx, KernelStatusRequest{})
+				return err
+			},
+		},
+		{
+			name: "download output",
+			run: func() error {
+				_, err := adapter.DownloadKernelOutput(ctx, DownloadKernelOutputRequest{})
+				return err
+			},
+		},
+		{
+			name: "submit competition",
+			run: func() error {
+				_, err := adapter.SubmitCompetition(ctx, CompetitionSubmitRequest{})
+				return err
+			},
+		},
+		{
+			name: "list submissions",
+			run: func() error {
+				_, err := adapter.ListCompetitionSubmissions(ctx, CompetitionSubmissionsRequest{})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.run()
+			if !errors.Is(err, ErrNotImplemented) {
+				t.Fatalf("expected ErrNotImplemented, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/kaggle/auth.go
+++ b/internal/kaggle/auth.go
@@ -1,19 +1,67 @@
 package kaggle
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 )
 
 const (
-	envKaggleUsername = "KAGGLE_USERNAME"
-	envKaggleKey      = "KAGGLE_KEY"
+	envKaggleUsername  = "KAGGLE_USERNAME"
+	envKaggleKey       = "KAGGLE_KEY"
+	envKaggleAPIToken  = "KAGGLE_API_TOKEN"
+	envKaggleConfigDir = "KAGGLE_CONFIG_DIR"
+	envXDGConfigHome   = "XDG_CONFIG_HOME"
 )
 
-// Credentials holds the Kaggle CLI credentials sourced from the environment.
+const (
+	accessTokenFilename = "access_token"
+	kaggleJSONFilename  = "kaggle.json"
+)
+
+type AuthMode string
+
+const (
+	AuthModeLegacy AuthMode = "legacy"
+	AuthModeToken  AuthMode = "token"
+)
+
+type CredentialSource string
+
+const (
+	CredentialSourceEnvToken   CredentialSource = "env-token"
+	CredentialSourceEnvLegacy  CredentialSource = "env-legacy"
+	CredentialSourceFileToken  CredentialSource = "file-token"
+	CredentialSourceFileLegacy CredentialSource = "file-legacy"
+)
+
+// Credentials holds the resolved Kaggle credentials plus safe source metadata.
 type Credentials struct {
+	Mode   AuthMode
+	Source CredentialSource
+	Path   string
+
 	Username string
 	Key      string
+	Token    string
+}
+
+type CredentialDiagnostics struct {
+	Mode   AuthMode
+	Source CredentialSource
+	Path   string
+}
+
+func (c Credentials) Diagnostics() CredentialDiagnostics {
+	return CredentialDiagnostics{
+		Mode:   c.Mode,
+		Source: c.Source,
+		Path:   c.Path,
+	}
 }
 
 // EnvSource reads environment variables by name.
@@ -21,36 +69,274 @@ type EnvSource interface {
 	LookupEnv(string) (string, bool)
 }
 
-// MissingCredentialsError reports one or more required Kaggle environment variables.
 type MissingCredentialsError struct {
 	Missing []string
+	Paths   []string
 }
 
 func (e *MissingCredentialsError) Error() string {
-	if e == nil || len(e.Missing) == 0 {
+	if e == nil {
 		return "missing Kaggle credentials"
 	}
-	return fmt.Sprintf("missing Kaggle credentials: %s", strings.Join(e.Missing, ", "))
+
+	parts := make([]string, 0, 2)
+	if len(e.Missing) > 0 {
+		parts = append(parts, fmt.Sprintf("expected one of %s", strings.Join(e.Missing, ", ")))
+	}
+	if len(e.Paths) > 0 {
+		parts = append(parts, fmt.Sprintf("checked %s", strings.Join(e.Paths, ", ")))
+	}
+	if len(parts) == 0 {
+		return "missing Kaggle credentials"
+	}
+	return fmt.Sprintf("missing Kaggle credentials: %s", strings.Join(parts, "; "))
 }
 
-// LoadCredentials reads Kaggle credentials from the provided environment source.
+type CredentialValidationError struct {
+	Source  CredentialSource
+	Path    string
+	Missing []string
+	Problem string
+	Err     error
+}
+
+func (e *CredentialValidationError) Error() string {
+	if e == nil {
+		return "invalid Kaggle credentials"
+	}
+
+	scope := string(e.Source)
+	if e.Path != "" {
+		scope = fmt.Sprintf("%s (%s)", scope, e.Path)
+	}
+
+	if len(e.Missing) > 0 {
+		return fmt.Sprintf("invalid Kaggle credentials from %s: missing %s", scope, strings.Join(e.Missing, ", "))
+	}
+	if e.Problem != "" {
+		return fmt.Sprintf("invalid Kaggle credentials from %s: %s", scope, e.Problem)
+	}
+	if e.Err != nil {
+		return fmt.Sprintf("invalid Kaggle credentials from %s: %v", scope, e.Err)
+	}
+	return fmt.Sprintf("invalid Kaggle credentials from %s", scope)
+}
+
+func (e *CredentialValidationError) Unwrap() error { return e.Err }
+
+type UnsupportedAuthModeError struct {
+	Mode AuthMode
+}
+
+func (e *UnsupportedAuthModeError) Error() string {
+	if e == nil || e.Mode == "" {
+		return "unsupported Kaggle auth mode"
+	}
+	return fmt.Sprintf("unsupported Kaggle auth mode: %s", e.Mode)
+}
+
+type credentialResolverDeps struct {
+	readFile func(string) ([]byte, error)
+	stat     func(string) (os.FileInfo, error)
+	homeDir  func() (string, error)
+	goos     string
+}
+
+func defaultCredentialResolverDeps() credentialResolverDeps {
+	return credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  os.UserHomeDir,
+		goos:     runtime.GOOS,
+	}
+}
+
+// ResolveCredentials discovers Kaggle credentials from environment variables
+// and Kaggle config file locations without exposing secret values.
+func ResolveCredentials(env EnvSource) (Credentials, error) {
+	return resolveCredentialsWithDeps(env, defaultCredentialResolverDeps())
+}
+
+// LoadCredentials preserves the historical helper name while delegating to the
+// multi-source credential resolver.
 func LoadCredentials(env EnvSource) (Credentials, error) {
+	return ResolveCredentials(env)
+}
+
+func resolveCredentialsWithDeps(env EnvSource, deps credentialResolverDeps) (Credentials, error) {
+	if env == nil {
+		env = emptyEnvSource{}
+	}
+
+	if token, ok := env.LookupEnv(envKaggleAPIToken); ok {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			return Credentials{}, &CredentialValidationError{
+				Source:  CredentialSourceEnvToken,
+				Missing: []string{envKaggleAPIToken},
+			}
+		}
+		return Credentials{
+			Mode:   AuthModeToken,
+			Source: CredentialSourceEnvToken,
+			Token:  token,
+		}, nil
+	}
+
 	username, hasUsername := env.LookupEnv(envKaggleUsername)
 	key, hasKey := env.LookupEnv(envKaggleKey)
+	if hasUsername || hasKey {
+		var missing []string
+		if strings.TrimSpace(username) == "" {
+			missing = append(missing, envKaggleUsername)
+		}
+		if strings.TrimSpace(key) == "" {
+			missing = append(missing, envKaggleKey)
+		}
+		if len(missing) > 0 {
+			return Credentials{}, &CredentialValidationError{
+				Source:  CredentialSourceEnvLegacy,
+				Missing: missing,
+			}
+		}
+		return Credentials{
+			Mode:     AuthModeLegacy,
+			Source:   CredentialSourceEnvLegacy,
+			Username: username,
+			Key:      key,
+		}, nil
+	}
 
-	var missing []string
-	if !hasUsername || username == "" {
-		missing = append(missing, envKaggleUsername)
-	}
-	if !hasKey || key == "" {
-		missing = append(missing, envKaggleKey)
-	}
-	if len(missing) > 0 {
-		return Credentials{}, &MissingCredentialsError{Missing: missing}
+	configDir, err := resolveConfigDir(env, deps)
+	if err != nil {
+		return Credentials{}, err
 	}
 
-	return Credentials{
-		Username: username,
-		Key:      key,
-	}, nil
+	tokenPath := filepath.Join(configDir, accessTokenFilename)
+	if exists, err := pathExists(tokenPath, deps.stat); err != nil {
+		return Credentials{}, fmt.Errorf("check Kaggle token file: %w", err)
+	} else if exists {
+		token, err := deps.readFile(tokenPath)
+		if err != nil {
+			return Credentials{}, fmt.Errorf("read Kaggle token file: %w", err)
+		}
+		value := strings.TrimSpace(string(token))
+		if value == "" {
+			return Credentials{}, &CredentialValidationError{
+				Source:  CredentialSourceFileToken,
+				Path:    tokenPath,
+				Missing: []string{accessTokenFilename},
+			}
+		}
+		return Credentials{
+			Mode:   AuthModeToken,
+			Source: CredentialSourceFileToken,
+			Path:   tokenPath,
+			Token:  value,
+		}, nil
+	}
+
+	legacyPath := filepath.Join(configDir, kaggleJSONFilename)
+	if exists, err := pathExists(legacyPath, deps.stat); err != nil {
+		return Credentials{}, fmt.Errorf("check Kaggle config file: %w", err)
+	} else if exists {
+		data, err := deps.readFile(legacyPath)
+		if err != nil {
+			return Credentials{}, fmt.Errorf("read Kaggle config file: %w", err)
+		}
+		var payload struct {
+			Username string `json:"username"`
+			Key      string `json:"key"`
+		}
+		if err := json.Unmarshal(data, &payload); err != nil {
+			return Credentials{}, &CredentialValidationError{
+				Source:  CredentialSourceFileLegacy,
+				Path:    legacyPath,
+				Problem: "malformed kaggle.json",
+				Err:     err,
+			}
+		}
+
+		var missing []string
+		if strings.TrimSpace(payload.Username) == "" {
+			missing = append(missing, "username")
+		}
+		if strings.TrimSpace(payload.Key) == "" {
+			missing = append(missing, "key")
+		}
+		if len(missing) > 0 {
+			return Credentials{}, &CredentialValidationError{
+				Source:  CredentialSourceFileLegacy,
+				Path:    legacyPath,
+				Missing: missing,
+			}
+		}
+
+		return Credentials{
+			Mode:     AuthModeLegacy,
+			Source:   CredentialSourceFileLegacy,
+			Path:     legacyPath,
+			Username: payload.Username,
+			Key:      payload.Key,
+		}, nil
+	}
+
+	return Credentials{}, &MissingCredentialsError{
+		Missing: []string{envKaggleAPIToken, envKaggleUsername, envKaggleKey},
+		Paths:   []string{tokenPath, legacyPath},
+	}
+}
+
+func resolveConfigDir(env EnvSource, deps credentialResolverDeps) (string, error) {
+	if value, ok := env.LookupEnv(envKaggleConfigDir); ok {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return "", &CredentialValidationError{
+				Source:  CredentialSourceFileLegacy,
+				Missing: []string{envKaggleConfigDir},
+			}
+		}
+		return value, nil
+	}
+
+	home, err := deps.homeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+
+	defaultDir := filepath.Join(home, ".kaggle")
+	if deps.goos != "linux" {
+		return defaultDir, nil
+	}
+
+	exists, err := pathExists(defaultDir, deps.stat)
+	if err != nil {
+		return "", fmt.Errorf("check Kaggle config directory: %w", err)
+	}
+	if exists {
+		return defaultDir, nil
+	}
+
+	xdgRoot, ok := env.LookupEnv(envXDGConfigHome)
+	if !ok || strings.TrimSpace(xdgRoot) == "" {
+		xdgRoot = filepath.Join(home, ".config")
+	}
+	return filepath.Join(xdgRoot, "kaggle"), nil
+}
+
+func pathExists(path string, stat func(string) (os.FileInfo, error)) (bool, error) {
+	_, err := stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
+type emptyEnvSource struct{}
+
+func (emptyEnvSource) LookupEnv(string) (string, bool) {
+	return "", false
 }

--- a/internal/kaggle/auth.go
+++ b/internal/kaggle/auth.go
@@ -207,121 +207,122 @@ func resolveCredentialsWithDeps(env EnvSource, deps credentialResolverDeps) (Cre
 		}, nil
 	}
 
-	configDir, err := resolveConfigDir(env, deps)
+	configDirs, err := resolveConfigDirs(env, deps)
 	if err != nil {
 		return Credentials{}, err
 	}
 
-	tokenPath := filepath.Join(configDir, accessTokenFilename)
-	if exists, err := pathExists(tokenPath, deps.stat); err != nil {
-		return Credentials{}, fmt.Errorf("check Kaggle token file: %w", err)
-	} else if exists {
-		token, err := deps.readFile(tokenPath)
-		if err != nil {
-			return Credentials{}, fmt.Errorf("read Kaggle token file: %w", err)
-		}
-		value := strings.TrimSpace(string(token))
-		if value == "" {
-			return Credentials{}, &CredentialValidationError{
-				Source:  CredentialSourceFileToken,
-				Path:    tokenPath,
-				Missing: []string{accessTokenFilename},
+	checkedPaths := make([]string, 0, len(configDirs)*2)
+	for _, configDir := range configDirs {
+		tokenPath := filepath.Join(configDir, accessTokenFilename)
+		checkedPaths = append(checkedPaths, tokenPath)
+		if exists, err := pathExists(tokenPath, deps.stat); err != nil {
+			return Credentials{}, fmt.Errorf("check Kaggle token file: %w", err)
+		} else if exists {
+			token, err := deps.readFile(tokenPath)
+			if err != nil {
+				return Credentials{}, fmt.Errorf("read Kaggle token file: %w", err)
 			}
-		}
-		return Credentials{
-			Mode:   AuthModeToken,
-			Source: CredentialSourceFileToken,
-			Path:   tokenPath,
-			Token:  value,
-		}, nil
-	}
-
-	legacyPath := filepath.Join(configDir, kaggleJSONFilename)
-	if exists, err := pathExists(legacyPath, deps.stat); err != nil {
-		return Credentials{}, fmt.Errorf("check Kaggle config file: %w", err)
-	} else if exists {
-		data, err := deps.readFile(legacyPath)
-		if err != nil {
-			return Credentials{}, fmt.Errorf("read Kaggle config file: %w", err)
-		}
-		var payload struct {
-			Username string `json:"username"`
-			Key      string `json:"key"`
-		}
-		if err := json.Unmarshal(data, &payload); err != nil {
-			return Credentials{}, &CredentialValidationError{
-				Source:  CredentialSourceFileLegacy,
-				Path:    legacyPath,
-				Problem: "malformed kaggle.json",
-				Err:     err,
+			value := strings.TrimSpace(string(token))
+			if value == "" {
+				return Credentials{}, &CredentialValidationError{
+					Source:  CredentialSourceFileToken,
+					Path:    tokenPath,
+					Missing: []string{accessTokenFilename},
+				}
 			}
+			return Credentials{
+				Mode:   AuthModeToken,
+				Source: CredentialSourceFileToken,
+				Path:   tokenPath,
+				Token:  value,
+			}, nil
 		}
 
-		var missing []string
-		if strings.TrimSpace(payload.Username) == "" {
-			missing = append(missing, "username")
-		}
-		if strings.TrimSpace(payload.Key) == "" {
-			missing = append(missing, "key")
-		}
-		if len(missing) > 0 {
-			return Credentials{}, &CredentialValidationError{
-				Source:  CredentialSourceFileLegacy,
-				Path:    legacyPath,
-				Missing: missing,
+		legacyPath := filepath.Join(configDir, kaggleJSONFilename)
+		checkedPaths = append(checkedPaths, legacyPath)
+		if exists, err := pathExists(legacyPath, deps.stat); err != nil {
+			return Credentials{}, fmt.Errorf("check Kaggle config file: %w", err)
+		} else if exists {
+			data, err := deps.readFile(legacyPath)
+			if err != nil {
+				return Credentials{}, fmt.Errorf("read Kaggle config file: %w", err)
 			}
-		}
+			var payload struct {
+				Username string `json:"username"`
+				Key      string `json:"key"`
+			}
+			if err := json.Unmarshal(data, &payload); err != nil {
+				return Credentials{}, &CredentialValidationError{
+					Source:  CredentialSourceFileLegacy,
+					Path:    legacyPath,
+					Problem: "malformed kaggle.json",
+					Err:     err,
+				}
+			}
 
-		return Credentials{
-			Mode:     AuthModeLegacy,
-			Source:   CredentialSourceFileLegacy,
-			Path:     legacyPath,
-			Username: payload.Username,
-			Key:      payload.Key,
-		}, nil
+			var missing []string
+			if strings.TrimSpace(payload.Username) == "" {
+				missing = append(missing, "username")
+			}
+			if strings.TrimSpace(payload.Key) == "" {
+				missing = append(missing, "key")
+			}
+			if len(missing) > 0 {
+				return Credentials{}, &CredentialValidationError{
+					Source:  CredentialSourceFileLegacy,
+					Path:    legacyPath,
+					Missing: missing,
+				}
+			}
+
+			return Credentials{
+				Mode:     AuthModeLegacy,
+				Source:   CredentialSourceFileLegacy,
+				Path:     legacyPath,
+				Username: payload.Username,
+				Key:      payload.Key,
+			}, nil
+		}
 	}
 
 	return Credentials{}, &MissingCredentialsError{
 		Missing: []string{envKaggleAPIToken, envKaggleUsername, envKaggleKey},
-		Paths:   []string{tokenPath, legacyPath},
+		Paths:   checkedPaths,
 	}
 }
 
-func resolveConfigDir(env EnvSource, deps credentialResolverDeps) (string, error) {
+func resolveConfigDirs(env EnvSource, deps credentialResolverDeps) ([]string, error) {
 	if value, ok := env.LookupEnv(envKaggleConfigDir); ok {
 		value = strings.TrimSpace(value)
 		if value == "" {
-			return "", &CredentialValidationError{
+			return nil, &CredentialValidationError{
 				Source:  CredentialSourceFileLegacy,
 				Missing: []string{envKaggleConfigDir},
 			}
 		}
-		return value, nil
+		return []string{value}, nil
 	}
 
 	home, err := deps.homeDir()
 	if err != nil {
-		return "", fmt.Errorf("resolve home directory: %w", err)
+		return nil, fmt.Errorf("resolve home directory: %w", err)
 	}
 
 	defaultDir := filepath.Join(home, ".kaggle")
 	if deps.goos != "linux" {
-		return defaultDir, nil
-	}
-
-	exists, err := pathExists(defaultDir, deps.stat)
-	if err != nil {
-		return "", fmt.Errorf("check Kaggle config directory: %w", err)
-	}
-	if exists {
-		return defaultDir, nil
+		return []string{defaultDir}, nil
 	}
 
 	xdgRoot, ok := env.LookupEnv(envXDGConfigHome)
 	if !ok || strings.TrimSpace(xdgRoot) == "" {
 		xdgRoot = filepath.Join(home, ".config")
 	}
-	return filepath.Join(xdgRoot, "kaggle"), nil
+	xdgDir := filepath.Join(xdgRoot, "kaggle")
+	if xdgDir == defaultDir {
+		return []string{defaultDir}, nil
+	}
+	return []string{defaultDir, xdgDir}, nil
 }
 
 func pathExists(path string, stat func(string) (os.FileInfo, error)) (bool, error) {

--- a/internal/kaggle/auth_test.go
+++ b/internal/kaggle/auth_test.go
@@ -173,6 +173,43 @@ func TestResolveCredentialsFallsBackToXDGOnLinux(t *testing.T) {
 	}
 }
 
+func TestResolveCredentialsFallsBackToXDGEvenWhenDotKaggleDirExists(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".kaggle"), 0o755); err != nil {
+		t.Fatalf("mkdir empty .kaggle dir: %v", err)
+	}
+
+	xdg := filepath.Join(home, "xdg")
+	configDir := filepath.Join(xdg, "kaggle")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir xdg config dir: %v", err)
+	}
+	path := filepath.Join(configDir, accessTokenFilename)
+	if err := os.WriteFile(path, []byte("token-from-xdg"), 0o644); err != nil {
+		t.Fatalf("write access_token: %v", err)
+	}
+
+	creds, err := resolveCredentialsWithDeps(staticEnvSource{
+		envXDGConfigHome: xdg,
+	}, credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  func() (string, error) { return home, nil },
+		goos:     "linux",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if creds.Path != path {
+		t.Fatalf("expected XDG token path %q, got %q", path, creds.Path)
+	}
+	if creds.Mode != AuthModeToken || creds.Source != CredentialSourceFileToken {
+		t.Fatalf("unexpected credentials %#v", creds.Diagnostics())
+	}
+}
+
 func TestResolveCredentialsPartialEnvFailsWithoutFallingThrough(t *testing.T) {
 	t.Parallel()
 

--- a/internal/kaggle/auth_test.go
+++ b/internal/kaggle/auth_test.go
@@ -1,6 +1,9 @@
 package kaggle
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -12,59 +15,246 @@ func (s staticEnvSource) LookupEnv(key string) (string, bool) {
 	return v, ok
 }
 
-func TestLoadCredentials(t *testing.T) {
+func TestResolveCredentialsFromEnvToken(t *testing.T) {
 	t.Parallel()
 
-	creds, err := LoadCredentials(staticEnvSource{
+	creds, err := resolveCredentialsWithDeps(staticEnvSource{
+		envKaggleAPIToken: "token-value",
+	}, credentialResolverDeps{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if creds.Mode != AuthModeToken {
+		t.Fatalf("unexpected mode %q", creds.Mode)
+	}
+	if creds.Source != CredentialSourceEnvToken {
+		t.Fatalf("unexpected source %q", creds.Source)
+	}
+	if creds.Token != "token-value" {
+		t.Fatalf("unexpected token %q", creds.Token)
+	}
+}
+
+func TestResolveCredentialsFromEnvLegacy(t *testing.T) {
+	t.Parallel()
+
+	creds, err := resolveCredentialsWithDeps(staticEnvSource{
 		envKaggleUsername: "alice",
 		envKaggleKey:      "secret-key",
+	}, credentialResolverDeps{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if creds.Mode != AuthModeLegacy {
+		t.Fatalf("unexpected mode %q", creds.Mode)
+	}
+	if creds.Source != CredentialSourceEnvLegacy {
+		t.Fatalf("unexpected source %q", creds.Source)
+	}
+	if creds.Username != "alice" || creds.Key != "secret-key" {
+		t.Fatalf("unexpected legacy credentials %#v", creds.Diagnostics())
+	}
+}
+
+func TestResolveCredentialsFromTokenFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, accessTokenFilename)
+	if err := os.WriteFile(path, []byte("token-from-file\n"), 0o644); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	creds, err := resolveCredentialsWithDeps(staticEnvSource{
+		envKaggleConfigDir: dir,
+	}, credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  func() (string, error) { return "/unused", nil },
+		goos:     "darwin",
 	})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if creds.Username != "alice" {
-		t.Fatalf("unexpected username %q", creds.Username)
+	if creds.Mode != AuthModeToken {
+		t.Fatalf("unexpected mode %q", creds.Mode)
 	}
-	if creds.Key != "secret-key" {
-		t.Fatalf("unexpected key %q", creds.Key)
+	if creds.Source != CredentialSourceFileToken {
+		t.Fatalf("unexpected source %q", creds.Source)
+	}
+	if creds.Path != path {
+		t.Fatalf("unexpected path %q", creds.Path)
 	}
 }
 
-func TestLoadCredentialsMissingUsername(t *testing.T) {
+func TestResolveCredentialsFromLegacyFile(t *testing.T) {
 	t.Parallel()
 
-	_, err := LoadCredentials(staticEnvSource{
-		envKaggleKey: "secret-key",
+	dir := t.TempDir()
+	path := filepath.Join(dir, kaggleJSONFilename)
+	if err := os.WriteFile(path, []byte(`{"username":"alice","key":"secret-key"}`), 0o644); err != nil {
+		t.Fatalf("write kaggle.json: %v", err)
+	}
+
+	creds, err := resolveCredentialsWithDeps(staticEnvSource{
+		envKaggleConfigDir: dir,
+	}, credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  func() (string, error) { return "/unused", nil },
+		goos:     "darwin",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if creds.Mode != AuthModeLegacy {
+		t.Fatalf("unexpected mode %q", creds.Mode)
+	}
+	if creds.Source != CredentialSourceFileLegacy {
+		t.Fatalf("unexpected source %q", creds.Source)
+	}
+	if creds.Path != path {
+		t.Fatalf("unexpected path %q", creds.Path)
+	}
+}
+
+func TestResolveCredentialsHonorsConfigDirOverride(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, kaggleJSONFilename)
+	if err := os.WriteFile(path, []byte(`{"username":"alice","key":"secret-key"}`), 0o644); err != nil {
+		t.Fatalf("write kaggle.json: %v", err)
+	}
+
+	creds, err := resolveCredentialsWithDeps(staticEnvSource{
+		envKaggleConfigDir: dir,
+	}, credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  func() (string, error) { return filepath.Join(t.TempDir(), "home"), nil },
+		goos:     "linux",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if creds.Path != path {
+		t.Fatalf("expected override path %q, got %q", path, creds.Path)
+	}
+}
+
+func TestResolveCredentialsFallsBackToXDGOnLinux(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	xdg := filepath.Join(home, "xdg")
+	configDir := filepath.Join(xdg, "kaggle")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	path := filepath.Join(configDir, kaggleJSONFilename)
+	if err := os.WriteFile(path, []byte(`{"username":"alice","key":"secret-key"}`), 0o644); err != nil {
+		t.Fatalf("write kaggle.json: %v", err)
+	}
+
+	creds, err := resolveCredentialsWithDeps(staticEnvSource{
+		envXDGConfigHome: xdg,
+	}, credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  func() (string, error) { return home, nil },
+		goos:     "linux",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if creds.Path != path {
+		t.Fatalf("expected XDG path %q, got %q", path, creds.Path)
+	}
+}
+
+func TestResolveCredentialsPartialEnvFailsWithoutFallingThrough(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, kaggleJSONFilename)
+	if err := os.WriteFile(path, []byte(`{"username":"alice","key":"secret-key"}`), 0o644); err != nil {
+		t.Fatalf("write kaggle.json: %v", err)
+	}
+
+	_, err := resolveCredentialsWithDeps(staticEnvSource{
+		envKaggleUsername:  "alice",
+		envKaggleConfigDir: dir,
+	}, credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  func() (string, error) { return "/unused", nil },
+		goos:     "darwin",
 	})
 	if err == nil {
 		t.Fatal("expected an error")
 	}
 
-	var missingErr *MissingCredentialsError
-	if !strings.Contains(err.Error(), envKaggleUsername) {
-		t.Fatalf("expected missing username in error, got %q", err.Error())
+	var validationErr *CredentialValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected CredentialValidationError, got %T", err)
 	}
-	if strings.Contains(err.Error(), "secret-key") {
-		t.Fatalf("expected error to redact credential value, got %q", err.Error())
-	}
-	if !errorAs(err, &missingErr) {
-		t.Fatalf("expected MissingCredentialsError, got %T", err)
-	}
-	if got := len(missingErr.Missing); got != 1 || missingErr.Missing[0] != envKaggleUsername {
-		t.Fatalf("unexpected missing variables %#v", missingErr.Missing)
-	}
-}
-
-func TestLoadCredentialsMissingKey(t *testing.T) {
-	t.Parallel()
-
-	_, err := LoadCredentials(staticEnvSource{
-		envKaggleUsername: "alice",
-	})
-	if err == nil {
-		t.Fatal("expected an error")
+	if validationErr.Source != CredentialSourceEnvLegacy {
+		t.Fatalf("unexpected source %q", validationErr.Source)
 	}
 	if !strings.Contains(err.Error(), envKaggleKey) {
+		t.Fatalf("expected missing key in error, got %q", err.Error())
+	}
+}
+
+func TestResolveCredentialsRejectsMalformedLegacyFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, kaggleJSONFilename)
+	if err := os.WriteFile(path, []byte(`{bad json}`), 0o644); err != nil {
+		t.Fatalf("write malformed kaggle.json: %v", err)
+	}
+
+	_, err := resolveCredentialsWithDeps(staticEnvSource{
+		envKaggleConfigDir: dir,
+	}, credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  func() (string, error) { return "/unused", nil },
+		goos:     "darwin",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Fatalf("expected path in error, got %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "secret-key") {
+		t.Fatalf("expected redacted error, got %q", err.Error())
+	}
+}
+
+func TestResolveCredentialsRejectsIncompleteLegacyFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, kaggleJSONFilename), []byte(`{"username":"alice"}`), 0o644); err != nil {
+		t.Fatalf("write incomplete kaggle.json: %v", err)
+	}
+
+	_, err := resolveCredentialsWithDeps(staticEnvSource{
+		envKaggleConfigDir: dir,
+	}, credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  func() (string, error) { return "/unused", nil },
+		goos:     "darwin",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "key") {
 		t.Fatalf("expected missing key in error, got %q", err.Error())
 	}
 	if strings.Contains(err.Error(), "alice") {
@@ -72,43 +262,67 @@ func TestLoadCredentialsMissingKey(t *testing.T) {
 	}
 }
 
-func TestLoadCredentialsMissingBoth(t *testing.T) {
+func TestResolveCredentialsRejectsEmptyTokenFile(t *testing.T) {
 	t.Parallel()
 
-	_, err := LoadCredentials(staticEnvSource{})
-	if err == nil {
-		t.Fatal("expected an error")
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, accessTokenFilename), []byte(" \n"), 0o644); err != nil {
+		t.Fatalf("write empty token file: %v", err)
 	}
-	if got := err.Error(); !strings.Contains(got, envKaggleUsername) || !strings.Contains(got, envKaggleKey) {
-		t.Fatalf("expected both missing variables in error, got %q", got)
-	}
-}
 
-func TestLoadCredentialsEmptyValuesAreMissing(t *testing.T) {
-	t.Parallel()
-
-	_, err := LoadCredentials(staticEnvSource{
-		envKaggleUsername: "",
-		envKaggleKey:      "",
+	_, err := resolveCredentialsWithDeps(staticEnvSource{
+		envKaggleConfigDir: dir,
+	}, credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  func() (string, error) { return "/unused", nil },
+		goos:     "darwin",
 	})
 	if err == nil {
 		t.Fatal("expected an error")
 	}
-	if got := err.Error(); !strings.Contains(got, envKaggleUsername) || !strings.Contains(got, envKaggleKey) {
-		t.Fatalf("expected both empty variables to be reported, got %q", got)
+	if !strings.Contains(err.Error(), accessTokenFilename) {
+		t.Fatalf("expected token filename in error, got %q", err.Error())
 	}
 }
 
-func errorAs(err error, target any) bool {
-	switch t := target.(type) {
-	case **MissingCredentialsError:
-		typed, ok := err.(*MissingCredentialsError)
-		if !ok {
-			return false
-		}
-		*t = typed
-		return true
-	default:
-		return false
+func TestResolveCredentialsDiagnosticsAreSafe(t *testing.T) {
+	t.Parallel()
+
+	creds, err := resolveCredentialsWithDeps(staticEnvSource{
+		envKaggleAPIToken: "secret-token",
+	}, credentialResolverDeps{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	diag := creds.Diagnostics()
+	if diag.Mode != AuthModeToken || diag.Source != CredentialSourceEnvToken {
+		t.Fatalf("unexpected diagnostics %#v", diag)
+	}
+	if strings.Contains(diag.Path, "secret-token") {
+		t.Fatalf("unexpected secret in diagnostics %#v", diag)
+	}
+}
+
+func TestResolveCredentialsMissingReportsExpectedSources(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveCredentialsWithDeps(staticEnvSource{}, credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  func() (string, error) { return "/tmp/home", nil },
+		goos:     "darwin",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var missingErr *MissingCredentialsError
+	if !errors.As(err, &missingErr) {
+		t.Fatalf("expected MissingCredentialsError, got %T", err)
+	}
+	if got := err.Error(); !strings.Contains(got, envKaggleAPIToken) || !strings.Contains(got, envKaggleUsername) || !strings.Contains(got, envKaggleKey) {
+		t.Fatalf("expected env vars in error, got %q", got)
 	}
 }

--- a/internal/kaggle/client.go
+++ b/internal/kaggle/client.go
@@ -101,9 +101,12 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 		return Result{}, fmt.Errorf("kaggle client is nil")
 	}
 
-	creds, err := LoadCredentials(c.env)
+	creds, err := ResolveCredentials(c.env)
 	if err != nil {
 		return Result{}, err
+	}
+	if creds.Mode != AuthModeLegacy {
+		return Result{}, &UnsupportedAuthModeError{Mode: creds.Mode}
 	}
 
 	binaryPath, err := resolveExecutable(kaggleBinary, c.lookPath)

--- a/internal/kaggle/client.go
+++ b/internal/kaggle/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"time"
 )
 
@@ -105,9 +106,6 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 	if err != nil {
 		return Result{}, err
 	}
-	if creds.Mode != AuthModeLegacy {
-		return Result{}, &UnsupportedAuthModeError{Mode: creds.Mode}
-	}
 
 	binaryPath, err := resolveExecutable(kaggleBinary, c.lookPath)
 	if err != nil {
@@ -122,12 +120,14 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	commandEnv, err := commandCredentialEnv(creds)
+	if err != nil {
+		return Result{}, err
+	}
+
 	command := buildCommand(binaryPath, args, c.baseEnv(), RunOptions{
-		Dir: opts.Dir,
-		Env: append([]string{
-			envKaggleUsername + "=" + creds.Username,
-			envKaggleKey + "=" + creds.Key,
-		}, opts.Env...),
+		Dir:     opts.Dir,
+		Env:     append(commandEnv, opts.Env...),
 		Timeout: timeout,
 	})
 
@@ -155,4 +155,29 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 	}
 
 	return result, fmt.Errorf("run kaggle command: %w", err)
+}
+
+func commandCredentialEnv(creds Credentials) ([]string, error) {
+	env := make([]string, 0, 3)
+
+	switch creds.Mode {
+	case AuthModeLegacy:
+		env = append(env,
+			envKaggleUsername+"="+creds.Username,
+			envKaggleKey+"="+creds.Key,
+		)
+	case AuthModeToken:
+		env = append(env, envKaggleAPIToken+"="+creds.Token)
+	default:
+		return nil, &UnsupportedAuthModeError{Mode: creds.Mode}
+	}
+
+	switch creds.Source {
+	case CredentialSourceFileToken, CredentialSourceFileLegacy:
+		if creds.Path != "" {
+			env = append(env, envKaggleConfigDir+"="+filepath.Dir(creds.Path))
+		}
+	}
+
+	return env, nil
 }

--- a/internal/kaggle/client_test.go
+++ b/internal/kaggle/client_test.go
@@ -3,6 +3,8 @@ package kaggle
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -246,33 +248,79 @@ func TestClientRunReturnsExecutableLookupError(t *testing.T) {
 	}
 }
 
-func TestClientRunRejectsTokenAuthUntilSupported(t *testing.T) {
+func TestClientRunSupportsTokenAuth(t *testing.T) {
 	t.Parallel()
 
+	runner := &clientFakeRunner{
+		t: t,
+		runFn: func(ctx context.Context, cmd command) (Result, error) {
+			if !reflect.DeepEqual(cmd.Args, []string{"/usr/local/bin/kaggle", "kernels", "status"}) {
+				t.Fatalf("unexpected args %#v", cmd.Args)
+			}
+			wantEnv := []string{
+				"PATH=/usr/bin",
+				"KAGGLE_API_TOKEN=secret-token",
+			}
+			if !reflect.DeepEqual(cmd.Env, wantEnv) {
+				t.Fatalf("unexpected env %#v", cmd.Env)
+			}
+			if _, ok := ctx.Deadline(); !ok {
+				t.Fatal("expected context deadline to be set")
+			}
+			return Result{ExitCode: 0}, nil
+		},
+	}
+
 	client := NewClientWithDeps(
-		&clientFakeRunner{t: t},
+		runner,
 		staticEnvSource{
 			envKaggleAPIToken: "secret-token",
 		},
-		func(string) (string, error) {
-			t.Fatal("did not expect executable lookup")
-			return "", nil
-		},
-		func() []string { return nil },
+		func(string) (string, error) { return "/usr/local/bin/kaggle", nil },
+		func() []string { return []string{"PATH=/usr/bin"} },
 		time.Second,
 	)
 
-	_, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{})
-	if err == nil {
-		t.Fatal("expected an error")
+	if _, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{}); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestClientRunSetsConfigDirForFileCredentials(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, accessTokenFilename), []byte("token-from-file"), 0o644); err != nil {
+		t.Fatalf("write token file: %v", err)
 	}
 
-	var unsupportedErr *UnsupportedAuthModeError
-	if !errors.As(err, &unsupportedErr) {
-		t.Fatalf("expected UnsupportedAuthModeError, got %T", err)
+	runner := &clientFakeRunner{
+		t: t,
+		runFn: func(ctx context.Context, cmd command) (Result, error) {
+			wantEnv := []string{
+				"PATH=/usr/bin",
+				"KAGGLE_API_TOKEN=token-from-file",
+				"KAGGLE_CONFIG_DIR=" + dir,
+			}
+			if !reflect.DeepEqual(cmd.Env, wantEnv) {
+				t.Fatalf("unexpected env %#v", cmd.Env)
+			}
+			return Result{ExitCode: 0}, nil
+		},
 	}
-	if unsupportedErr.Mode != AuthModeToken {
-		t.Fatalf("unexpected auth mode %q", unsupportedErr.Mode)
+
+	client := NewClientWithDeps(
+		runner,
+		staticEnvSource{
+			envKaggleConfigDir: dir,
+		},
+		func(string) (string, error) { return "/usr/local/bin/kaggle", nil },
+		func() []string { return []string{"PATH=/usr/bin"} },
+		time.Second,
+	)
+
+	if _, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{}); err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
 }
 

--- a/internal/kaggle/client_test.go
+++ b/internal/kaggle/client_test.go
@@ -246,6 +246,36 @@ func TestClientRunReturnsExecutableLookupError(t *testing.T) {
 	}
 }
 
+func TestClientRunRejectsTokenAuthUntilSupported(t *testing.T) {
+	t.Parallel()
+
+	client := NewClientWithDeps(
+		&clientFakeRunner{t: t},
+		staticEnvSource{
+			envKaggleAPIToken: "secret-token",
+		},
+		func(string) (string, error) {
+			t.Fatal("did not expect executable lookup")
+			return "", nil
+		},
+		func() []string { return nil },
+		time.Second,
+	)
+
+	_, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var unsupportedErr *UnsupportedAuthModeError
+	if !errors.As(err, &unsupportedErr) {
+		t.Fatalf("expected UnsupportedAuthModeError, got %T", err)
+	}
+	if unsupportedErr.Mode != AuthModeToken {
+		t.Fatalf("unexpected auth mode %q", unsupportedErr.Mode)
+	}
+}
+
 type clientFakeRunner struct {
 	t     *testing.T
 	runFn func(context.Context, command) (Result, error)

--- a/internal/kaggle/doc.go
+++ b/internal/kaggle/doc.go
@@ -1,8 +1,9 @@
-// Package kaggle contains the Kaggle CLI adapter layer for kgh.
+// Package kaggle contains the Kaggle adapter layer for kgh.
 //
-// The package is intentionally thin. It validates environment-based credentials,
+// Adapter is the workflow-facing contract used by higher layers.
+// Client is a lower-level Kaggle CLI executor that concrete adapters can build on.
+//
+// The package remains intentionally thin. It resolves Kaggle credentials,
 // invokes the official kaggle binary with timeouts, captures process output, and
-// returns typed errors that higher layers can surface cleanly. Workflow-specific
-// commands such as kernel push, polling, download, and submission are added on
-// top of this foundation in later steps.
+// returns typed errors that higher layers can surface cleanly.
 package kaggle


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #7 
- [ ] Github issue: Closes: #8 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented the plan in internal/kaggle/adapter.go, internal/kaggle/auth.go, and internal/kaggle/client.go. The
  package now has a workflow-facing Adapter contract with typed request/response models and a compile-ready
  StubAdapter, while the existing Client remains the low-level CLI executor.

  Credential handling now resolves both token and legacy Kaggle auth from environment variables or Kaggle config
  files, honors KAGGLE_CONFIG_DIR, falls back to XDG config on Linux, surfaces safe source diagnostics, and
  rejects partial or malformed sources without leaking secrets. The current CLI client consumes that resolver and
  still runs only with legacy auth; if token auth is discovered, it now fails fast with a typed
  UnsupportedAuthModeError until a concrete token-capable adapter is added.

  Coverage was expanded in internal/kaggle/adapter_test.go, internal/kaggle/auth_test.go, and internal/kaggle/
  client_test.go. Verification: go test ./... passed.

<!-- close -->