### PR TITLE
Kaggle auth runtime

### DIFF
--- a/internal/kaggle/auth.go
+++ b/internal/kaggle/auth.go
@@ -2,11 +2,9 @@ package kaggle
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
@@ -15,7 +13,6 @@ const (
 	envKaggleKey       = "KAGGLE_KEY"
 	envKaggleAPIToken  = "KAGGLE_API_TOKEN"
 	envKaggleConfigDir = "KAGGLE_CONFIG_DIR"
-	envXDGConfigHome   = "XDG_CONFIG_HOME"
 )
 
 const (
@@ -33,35 +30,18 @@ const (
 type CredentialSource string
 
 const (
-	CredentialSourceEnvToken   CredentialSource = "env-token"
-	CredentialSourceEnvLegacy  CredentialSource = "env-legacy"
-	CredentialSourceFileToken  CredentialSource = "file-token"
-	CredentialSourceFileLegacy CredentialSource = "file-legacy"
+	CredentialSourceEnvLegacy CredentialSource = "env-legacy"
+	CredentialSourceEnvToken  CredentialSource = "env-token"
 )
 
-// Credentials holds the resolved Kaggle credentials plus safe source metadata.
+// Credentials holds the Kaggle auth material resolved from environment input.
 type Credentials struct {
 	Mode   AuthMode
 	Source CredentialSource
-	Path   string
 
 	Username string
 	Key      string
 	Token    string
-}
-
-type CredentialDiagnostics struct {
-	Mode   AuthMode
-	Source CredentialSource
-	Path   string
-}
-
-func (c Credentials) Diagnostics() CredentialDiagnostics {
-	return CredentialDiagnostics{
-		Mode:   c.Mode,
-		Source: c.Source,
-		Path:   c.Path,
-	}
 }
 
 // EnvSource reads environment variables by name.
@@ -71,110 +51,90 @@ type EnvSource interface {
 
 type MissingCredentialsError struct {
 	Missing []string
-	Paths   []string
 }
 
 func (e *MissingCredentialsError) Error() string {
-	if e == nil {
+	if e == nil || len(e.Missing) == 0 {
 		return "missing Kaggle credentials"
 	}
-
-	parts := make([]string, 0, 2)
-	if len(e.Missing) > 0 {
-		parts = append(parts, fmt.Sprintf("expected one of %s", strings.Join(e.Missing, ", ")))
-	}
-	if len(e.Paths) > 0 {
-		parts = append(parts, fmt.Sprintf("checked %s", strings.Join(e.Paths, ", ")))
-	}
-	if len(parts) == 0 {
-		return "missing Kaggle credentials"
-	}
-	return fmt.Sprintf("missing Kaggle credentials: %s", strings.Join(parts, "; "))
+	return fmt.Sprintf("missing Kaggle credentials: %s", strings.Join(e.Missing, ", "))
 }
 
 type CredentialValidationError struct {
-	Source  CredentialSource
-	Path    string
-	Missing []string
+	Fields  []string
 	Problem string
-	Err     error
 }
 
 func (e *CredentialValidationError) Error() string {
 	if e == nil {
 		return "invalid Kaggle credentials"
 	}
-
-	scope := string(e.Source)
-	if e.Path != "" {
-		scope = fmt.Sprintf("%s (%s)", scope, e.Path)
-	}
-
-	if len(e.Missing) > 0 {
-		return fmt.Sprintf("invalid Kaggle credentials from %s: missing %s", scope, strings.Join(e.Missing, ", "))
+	if len(e.Fields) > 0 {
+		return fmt.Sprintf("invalid Kaggle credentials: %s", strings.Join(e.Fields, ", "))
 	}
 	if e.Problem != "" {
-		return fmt.Sprintf("invalid Kaggle credentials from %s: %s", scope, e.Problem)
+		return fmt.Sprintf("invalid Kaggle credentials: %s", e.Problem)
 	}
-	if e.Err != nil {
-		return fmt.Sprintf("invalid Kaggle credentials from %s: %v", scope, e.Err)
+	return "invalid Kaggle credentials"
+}
+
+type RuntimeSetup struct {
+	Env       []string
+	ConfigDir string
+	AuthMode  AuthMode
+	Source    CredentialSource
+	Cleanup   func() error
+}
+
+type RuntimeSetupError struct {
+	Op   string
+	Path string
+	Err  error
+}
+
+func (e *RuntimeSetupError) Error() string {
+	if e == nil {
+		return "prepare Kaggle runtime"
 	}
-	return fmt.Sprintf("invalid Kaggle credentials from %s", scope)
-}
-
-func (e *CredentialValidationError) Unwrap() error { return e.Err }
-
-type UnsupportedAuthModeError struct {
-	Mode AuthMode
-}
-
-func (e *UnsupportedAuthModeError) Error() string {
-	if e == nil || e.Mode == "" {
-		return "unsupported Kaggle auth mode"
+	if e.Path != "" {
+		return fmt.Sprintf("prepare Kaggle runtime: %s %s: %v", e.Op, e.Path, e.Err)
 	}
-	return fmt.Sprintf("unsupported Kaggle auth mode: %s", e.Mode)
+	return fmt.Sprintf("prepare Kaggle runtime: %s: %v", e.Op, e.Err)
 }
 
-type credentialResolverDeps struct {
-	readFile func(string) ([]byte, error)
-	stat     func(string) (os.FileInfo, error)
-	homeDir  func() (string, error)
-	goos     string
+func (e *RuntimeSetupError) Unwrap() error { return e.Err }
+
+type runtimeSetupDeps struct {
+	mkdirTemp func(string, string) (string, error)
+	writeFile func(string, []byte, os.FileMode) error
+	chmod     func(string, os.FileMode) error
+	removeAll func(string) error
 }
 
-func defaultCredentialResolverDeps() credentialResolverDeps {
-	return credentialResolverDeps{
-		readFile: os.ReadFile,
-		stat:     os.Stat,
-		homeDir:  os.UserHomeDir,
-		goos:     runtime.GOOS,
+func defaultRuntimeSetupDeps() runtimeSetupDeps {
+	return runtimeSetupDeps{
+		mkdirTemp: os.MkdirTemp,
+		writeFile: os.WriteFile,
+		chmod:     os.Chmod,
+		removeAll: os.RemoveAll,
 	}
 }
 
-// ResolveCredentials discovers Kaggle credentials from environment variables
-// and Kaggle config file locations without exposing secret values.
-func ResolveCredentials(env EnvSource) (Credentials, error) {
-	return resolveCredentialsWithDeps(env, defaultCredentialResolverDeps())
-}
-
-// LoadCredentials preserves the historical helper name while delegating to the
-// multi-source credential resolver.
+// LoadCredentials reads Kaggle credentials from the provided environment source.
 func LoadCredentials(env EnvSource) (Credentials, error) {
 	return ResolveCredentials(env)
 }
 
-func resolveCredentialsWithDeps(env EnvSource, deps credentialResolverDeps) (Credentials, error) {
+// ResolveCredentials validates Kaggle credentials sourced from the process environment.
+func ResolveCredentials(env EnvSource) (Credentials, error) {
 	if env == nil {
-		env = emptyEnvSource{}
+		return Credentials{}, &MissingCredentialsError{Missing: []string{envKaggleAPIToken, envKaggleUsername, envKaggleKey}}
 	}
 
 	if token, ok := env.LookupEnv(envKaggleAPIToken); ok {
 		token = strings.TrimSpace(token)
 		if token == "" {
-			return Credentials{}, &CredentialValidationError{
-				Source:  CredentialSourceEnvToken,
-				Missing: []string{envKaggleAPIToken},
-			}
+			return Credentials{}, &CredentialValidationError{Fields: []string{envKaggleAPIToken}}
 		}
 		return Credentials{
 			Mode:   AuthModeToken,
@@ -185,19 +145,17 @@ func resolveCredentialsWithDeps(env EnvSource, deps credentialResolverDeps) (Cre
 
 	username, hasUsername := env.LookupEnv(envKaggleUsername)
 	key, hasKey := env.LookupEnv(envKaggleKey)
+
 	if hasUsername || hasKey {
-		var missing []string
+		var invalid []string
 		if strings.TrimSpace(username) == "" {
-			missing = append(missing, envKaggleUsername)
+			invalid = append(invalid, envKaggleUsername)
 		}
 		if strings.TrimSpace(key) == "" {
-			missing = append(missing, envKaggleKey)
+			invalid = append(invalid, envKaggleKey)
 		}
-		if len(missing) > 0 {
-			return Credentials{}, &CredentialValidationError{
-				Source:  CredentialSourceEnvLegacy,
-				Missing: missing,
-			}
+		if len(invalid) > 0 {
+			return Credentials{}, &CredentialValidationError{Fields: invalid}
 		}
 		return Credentials{
 			Mode:     AuthModeLegacy,
@@ -207,137 +165,90 @@ func resolveCredentialsWithDeps(env EnvSource, deps credentialResolverDeps) (Cre
 		}, nil
 	}
 
-	configDirs, err := resolveConfigDirs(env, deps)
+	return Credentials{}, &MissingCredentialsError{Missing: []string{envKaggleAPIToken, envKaggleUsername, envKaggleKey}}
+}
+
+// PrepareRuntime converts GitHub Actions environment credentials into a Kaggle CLI-ready runtime.
+func PrepareRuntime(env EnvSource) (RuntimeSetup, error) {
+	return prepareRuntimeWithDeps(env, defaultRuntimeSetupDeps())
+}
+
+func prepareRuntimeWithDeps(env EnvSource, deps runtimeSetupDeps) (RuntimeSetup, error) {
+	creds, err := ResolveCredentials(env)
 	if err != nil {
-		return Credentials{}, err
+		return RuntimeSetup{}, err
 	}
 
-	checkedPaths := make([]string, 0, len(configDirs)*2)
-	for _, configDir := range configDirs {
-		tokenPath := filepath.Join(configDir, accessTokenFilename)
-		checkedPaths = append(checkedPaths, tokenPath)
-		if exists, err := pathExists(tokenPath, deps.stat); err != nil {
-			return Credentials{}, fmt.Errorf("check Kaggle token file: %w", err)
-		} else if exists {
-			token, err := deps.readFile(tokenPath)
-			if err != nil {
-				return Credentials{}, fmt.Errorf("read Kaggle token file: %w", err)
-			}
-			value := strings.TrimSpace(string(token))
-			if value == "" {
-				return Credentials{}, &CredentialValidationError{
-					Source:  CredentialSourceFileToken,
-					Path:    tokenPath,
-					Missing: []string{accessTokenFilename},
-				}
-			}
-			return Credentials{
-				Mode:   AuthModeToken,
-				Source: CredentialSourceFileToken,
-				Path:   tokenPath,
-				Token:  value,
-			}, nil
-		}
-
-		legacyPath := filepath.Join(configDir, kaggleJSONFilename)
-		checkedPaths = append(checkedPaths, legacyPath)
-		if exists, err := pathExists(legacyPath, deps.stat); err != nil {
-			return Credentials{}, fmt.Errorf("check Kaggle config file: %w", err)
-		} else if exists {
-			data, err := deps.readFile(legacyPath)
-			if err != nil {
-				return Credentials{}, fmt.Errorf("read Kaggle config file: %w", err)
-			}
-			var payload struct {
-				Username string `json:"username"`
-				Key      string `json:"key"`
-			}
-			if err := json.Unmarshal(data, &payload); err != nil {
-				return Credentials{}, &CredentialValidationError{
-					Source:  CredentialSourceFileLegacy,
-					Path:    legacyPath,
-					Problem: "malformed kaggle.json",
-					Err:     err,
-				}
-			}
-
-			var missing []string
-			if strings.TrimSpace(payload.Username) == "" {
-				missing = append(missing, "username")
-			}
-			if strings.TrimSpace(payload.Key) == "" {
-				missing = append(missing, "key")
-			}
-			if len(missing) > 0 {
-				return Credentials{}, &CredentialValidationError{
-					Source:  CredentialSourceFileLegacy,
-					Path:    legacyPath,
-					Missing: missing,
-				}
-			}
-
-			return Credentials{
-				Mode:     AuthModeLegacy,
-				Source:   CredentialSourceFileLegacy,
-				Path:     legacyPath,
-				Username: payload.Username,
-				Key:      payload.Key,
-			}, nil
-		}
-	}
-
-	return Credentials{}, &MissingCredentialsError{
-		Missing: []string{envKaggleAPIToken, envKaggleUsername, envKaggleKey},
-		Paths:   checkedPaths,
-	}
-}
-
-func resolveConfigDirs(env EnvSource, deps credentialResolverDeps) ([]string, error) {
-	if value, ok := env.LookupEnv(envKaggleConfigDir); ok {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			return nil, &CredentialValidationError{
-				Source:  CredentialSourceFileLegacy,
-				Missing: []string{envKaggleConfigDir},
-			}
-		}
-		return []string{value}, nil
-	}
-
-	home, err := deps.homeDir()
+	dir, err := deps.mkdirTemp("", "kgh-kaggle-*")
 	if err != nil {
-		return nil, fmt.Errorf("resolve home directory: %w", err)
+		return RuntimeSetup{}, &RuntimeSetupError{Op: "create temp dir", Err: err}
+	}
+	cleanup := func() error {
+		if err := deps.removeAll(dir); err != nil {
+			return &RuntimeSetupError{Op: "cleanup", Path: dir, Err: err}
+		}
+		return nil
 	}
 
-	defaultDir := filepath.Join(home, ".kaggle")
-	if deps.goos != "linux" {
-		return []string{defaultDir}, nil
+	if err := deps.chmod(dir, 0o700); err != nil {
+		_ = cleanup()
+		return RuntimeSetup{}, &RuntimeSetupError{Op: "chmod", Path: dir, Err: err}
 	}
 
-	xdgRoot, ok := env.LookupEnv(envXDGConfigHome)
-	if !ok || strings.TrimSpace(xdgRoot) == "" {
-		xdgRoot = filepath.Join(home, ".config")
+	setup := RuntimeSetup{
+		ConfigDir: dir,
+		AuthMode:  creds.Mode,
+		Source:    creds.Source,
+		Cleanup:   cleanup,
 	}
-	xdgDir := filepath.Join(xdgRoot, "kaggle")
-	if xdgDir == defaultDir {
-		return []string{defaultDir}, nil
+
+	switch creds.Mode {
+	case AuthModeToken:
+		tokenPath := filepath.Join(dir, accessTokenFilename)
+		if err := writeSecretFile(tokenPath, []byte(creds.Token), deps); err != nil {
+			_ = cleanup()
+			return RuntimeSetup{}, err
+		}
+		setup.Env = []string{
+			envKaggleConfigDir + "=" + dir,
+			envKaggleAPIToken + "=" + creds.Token,
+		}
+	case AuthModeLegacy:
+		payload, err := json.Marshal(struct {
+			Username string `json:"username"`
+			Key      string `json:"key"`
+		}{
+			Username: creds.Username,
+			Key:      creds.Key,
+		})
+		if err != nil {
+			_ = cleanup()
+			return RuntimeSetup{}, &RuntimeSetupError{Op: "marshal", Path: filepath.Join(dir, kaggleJSONFilename), Err: err}
+		}
+		configPath := filepath.Join(dir, kaggleJSONFilename)
+		if err := writeSecretFile(configPath, payload, deps); err != nil {
+			_ = cleanup()
+			return RuntimeSetup{}, err
+		}
+		setup.Env = []string{
+			envKaggleConfigDir + "=" + dir,
+			envKaggleUsername + "=" + creds.Username,
+			envKaggleKey + "=" + creds.Key,
+		}
+	default:
+		_ = cleanup()
+		return RuntimeSetup{}, &CredentialValidationError{Problem: "unsupported auth mode"}
 	}
-	return []string{defaultDir, xdgDir}, nil
+
+	return setup, nil
 }
 
-func pathExists(path string, stat func(string) (os.FileInfo, error)) (bool, error) {
-	_, err := stat(path)
-	if err == nil {
-		return true, nil
+func writeSecretFile(path string, content []byte, deps runtimeSetupDeps) error {
+	if err := deps.writeFile(path, content, 0o600); err != nil {
+		return &RuntimeSetupError{Op: "write", Path: path, Err: err}
 	}
-	if errors.Is(err, os.ErrNotExist) {
-		return false, nil
+	if err := deps.chmod(path, 0o600); err != nil {
+		return &RuntimeSetupError{Op: "chmod", Path: path, Err: err}
 	}
-	return false, err
-}
-
-type emptyEnvSource struct{}
-
-func (emptyEnvSource) LookupEnv(string) (string, bool) {
-	return "", false
+	return nil
 }

--- a/internal/kaggle/auth.go
+++ b/internal/kaggle/auth.go
@@ -349,7 +349,6 @@ func prepareRuntimeWithDeps(env EnvSource, deps runtimeSetupDeps) (RuntimeSetup,
 		}
 		setup.Env = []string{
 			envKaggleConfigDir + "=" + dir,
-			envKaggleAPIToken + "=" + creds.Token,
 		}
 	case AuthModeLegacy:
 		payload, err := json.Marshal(struct {
@@ -370,8 +369,6 @@ func prepareRuntimeWithDeps(env EnvSource, deps runtimeSetupDeps) (RuntimeSetup,
 		}
 		setup.Env = []string{
 			envKaggleConfigDir + "=" + dir,
-			envKaggleUsername + "=" + creds.Username,
-			envKaggleKey + "=" + creds.Key,
 		}
 	default:
 		_ = cleanup()

--- a/internal/kaggle/auth.go
+++ b/internal/kaggle/auth.go
@@ -2,9 +2,11 @@ package kaggle
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -13,6 +15,7 @@ const (
 	envKaggleKey       = "KAGGLE_KEY"
 	envKaggleAPIToken  = "KAGGLE_API_TOKEN"
 	envKaggleConfigDir = "KAGGLE_CONFIG_DIR"
+	envXDGConfigHome   = "XDG_CONFIG_HOME"
 )
 
 const (
@@ -30,14 +33,17 @@ const (
 type CredentialSource string
 
 const (
-	CredentialSourceEnvLegacy CredentialSource = "env-legacy"
-	CredentialSourceEnvToken  CredentialSource = "env-token"
+	CredentialSourceEnvLegacy  CredentialSource = "env-legacy"
+	CredentialSourceEnvToken   CredentialSource = "env-token"
+	CredentialSourceFileLegacy CredentialSource = "file-legacy"
+	CredentialSourceFileToken  CredentialSource = "file-token"
 )
 
 // Credentials holds the Kaggle auth material resolved from environment input.
 type Credentials struct {
 	Mode   AuthMode
 	Source CredentialSource
+	Path   string
 
 	Username string
 	Key      string
@@ -51,32 +57,58 @@ type EnvSource interface {
 
 type MissingCredentialsError struct {
 	Missing []string
+	Paths   []string
 }
 
 func (e *MissingCredentialsError) Error() string {
-	if e == nil || len(e.Missing) == 0 {
+	if e == nil {
 		return "missing Kaggle credentials"
 	}
-	return fmt.Sprintf("missing Kaggle credentials: %s", strings.Join(e.Missing, ", "))
+	parts := make([]string, 0, 2)
+	if len(e.Missing) > 0 {
+		parts = append(parts, strings.Join(e.Missing, ", "))
+	}
+	if len(e.Paths) > 0 {
+		parts = append(parts, "checked "+strings.Join(e.Paths, ", "))
+	}
+	if len(parts) == 0 {
+		return "missing Kaggle credentials"
+	}
+	return fmt.Sprintf("missing Kaggle credentials: %s", strings.Join(parts, "; "))
 }
 
 type CredentialValidationError struct {
 	Fields  []string
 	Problem string
+	Source  CredentialSource
+	Path    string
+	Err     error
 }
 
 func (e *CredentialValidationError) Error() string {
 	if e == nil {
 		return "invalid Kaggle credentials"
 	}
+	scope := "credentials"
+	if e.Source != "" {
+		scope = string(e.Source)
+	}
+	if e.Path != "" {
+		scope += " (" + e.Path + ")"
+	}
 	if len(e.Fields) > 0 {
-		return fmt.Sprintf("invalid Kaggle credentials: %s", strings.Join(e.Fields, ", "))
+		return fmt.Sprintf("invalid Kaggle credentials from %s: %s", scope, strings.Join(e.Fields, ", "))
 	}
 	if e.Problem != "" {
-		return fmt.Sprintf("invalid Kaggle credentials: %s", e.Problem)
+		return fmt.Sprintf("invalid Kaggle credentials from %s: %s", scope, e.Problem)
+	}
+	if e.Err != nil {
+		return fmt.Sprintf("invalid Kaggle credentials from %s: %v", scope, e.Err)
 	}
 	return "invalid Kaggle credentials"
 }
+
+func (e *CredentialValidationError) Unwrap() error { return e.Err }
 
 type RuntimeSetup struct {
 	Env       []string
@@ -120,21 +152,44 @@ func defaultRuntimeSetupDeps() runtimeSetupDeps {
 	}
 }
 
+type credentialResolverDeps struct {
+	readFile func(string) ([]byte, error)
+	stat     func(string) (os.FileInfo, error)
+	homeDir  func() (string, error)
+	goos     string
+}
+
+func defaultCredentialResolverDeps() credentialResolverDeps {
+	return credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  os.UserHomeDir,
+		goos:     runtime.GOOS,
+	}
+}
+
 // LoadCredentials reads Kaggle credentials from the provided environment source.
 func LoadCredentials(env EnvSource) (Credentials, error) {
 	return ResolveCredentials(env)
 }
 
-// ResolveCredentials validates Kaggle credentials sourced from the process environment.
+// ResolveCredentials discovers Kaggle credentials from the process environment and Kaggle config files.
 func ResolveCredentials(env EnvSource) (Credentials, error) {
+	return resolveCredentialsWithDeps(env, defaultCredentialResolverDeps())
+}
+
+func resolveCredentialsWithDeps(env EnvSource, deps credentialResolverDeps) (Credentials, error) {
 	if env == nil {
-		return Credentials{}, &MissingCredentialsError{Missing: []string{envKaggleAPIToken, envKaggleUsername, envKaggleKey}}
+		env = emptyEnvSource{}
 	}
 
 	if token, ok := env.LookupEnv(envKaggleAPIToken); ok {
 		token = strings.TrimSpace(token)
 		if token == "" {
-			return Credentials{}, &CredentialValidationError{Fields: []string{envKaggleAPIToken}}
+			return Credentials{}, &CredentialValidationError{
+				Fields: []string{envKaggleAPIToken},
+				Source: CredentialSourceEnvToken,
+			}
 		}
 		return Credentials{
 			Mode:   AuthModeToken,
@@ -155,7 +210,10 @@ func ResolveCredentials(env EnvSource) (Credentials, error) {
 			invalid = append(invalid, envKaggleKey)
 		}
 		if len(invalid) > 0 {
-			return Credentials{}, &CredentialValidationError{Fields: invalid}
+			return Credentials{}, &CredentialValidationError{
+				Fields: invalid,
+				Source: CredentialSourceEnvLegacy,
+			}
 		}
 		return Credentials{
 			Mode:     AuthModeLegacy,
@@ -165,7 +223,87 @@ func ResolveCredentials(env EnvSource) (Credentials, error) {
 		}, nil
 	}
 
-	return Credentials{}, &MissingCredentialsError{Missing: []string{envKaggleAPIToken, envKaggleUsername, envKaggleKey}}
+	configDirs, err := resolveConfigDirs(env, deps)
+	if err != nil {
+		return Credentials{}, err
+	}
+
+	checkedPaths := make([]string, 0, len(configDirs)*2)
+	for _, dir := range configDirs {
+		tokenPath := filepath.Join(dir, accessTokenFilename)
+		checkedPaths = append(checkedPaths, tokenPath)
+		if exists, err := pathExists(tokenPath, deps.stat); err != nil {
+			return Credentials{}, fmt.Errorf("check Kaggle token file: %w", err)
+		} else if exists {
+			content, err := deps.readFile(tokenPath)
+			if err != nil {
+				return Credentials{}, fmt.Errorf("read Kaggle token file: %w", err)
+			}
+			token := strings.TrimSpace(string(content))
+			if token == "" {
+				return Credentials{}, &CredentialValidationError{
+					Fields: []string{accessTokenFilename},
+					Source: CredentialSourceFileToken,
+					Path:   tokenPath,
+				}
+			}
+			return Credentials{
+				Mode:   AuthModeToken,
+				Source: CredentialSourceFileToken,
+				Path:   tokenPath,
+				Token:  token,
+			}, nil
+		}
+
+		configPath := filepath.Join(dir, kaggleJSONFilename)
+		checkedPaths = append(checkedPaths, configPath)
+		if exists, err := pathExists(configPath, deps.stat); err != nil {
+			return Credentials{}, fmt.Errorf("check Kaggle config file: %w", err)
+		} else if exists {
+			content, err := deps.readFile(configPath)
+			if err != nil {
+				return Credentials{}, fmt.Errorf("read Kaggle config file: %w", err)
+			}
+			var payload struct {
+				Username string `json:"username"`
+				Key      string `json:"key"`
+			}
+			if err := json.Unmarshal(content, &payload); err != nil {
+				return Credentials{}, &CredentialValidationError{
+					Problem: "malformed kaggle.json",
+					Source:  CredentialSourceFileLegacy,
+					Path:    configPath,
+					Err:     err,
+				}
+			}
+			var invalid []string
+			if strings.TrimSpace(payload.Username) == "" {
+				invalid = append(invalid, "username")
+			}
+			if strings.TrimSpace(payload.Key) == "" {
+				invalid = append(invalid, "key")
+			}
+			if len(invalid) > 0 {
+				return Credentials{}, &CredentialValidationError{
+					Fields: invalid,
+					Source: CredentialSourceFileLegacy,
+					Path:   configPath,
+				}
+			}
+			return Credentials{
+				Mode:     AuthModeLegacy,
+				Source:   CredentialSourceFileLegacy,
+				Path:     configPath,
+				Username: payload.Username,
+				Key:      payload.Key,
+			}, nil
+		}
+	}
+
+	return Credentials{}, &MissingCredentialsError{
+		Missing: []string{envKaggleAPIToken, envKaggleUsername, envKaggleKey},
+		Paths:   checkedPaths,
+	}
 }
 
 // PrepareRuntime converts GitHub Actions environment credentials into a Kaggle CLI-ready runtime.
@@ -243,6 +381,39 @@ func prepareRuntimeWithDeps(env EnvSource, deps runtimeSetupDeps) (RuntimeSetup,
 	return setup, nil
 }
 
+func resolveConfigDirs(env EnvSource, deps credentialResolverDeps) ([]string, error) {
+	if value, ok := env.LookupEnv(envKaggleConfigDir); ok {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return nil, &CredentialValidationError{
+				Fields: []string{envKaggleConfigDir},
+				Source: CredentialSourceFileLegacy,
+			}
+		}
+		return []string{value}, nil
+	}
+
+	home, err := deps.homeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home directory: %w", err)
+	}
+
+	defaultDir := filepath.Join(home, ".kaggle")
+	if deps.goos != "linux" {
+		return []string{defaultDir}, nil
+	}
+
+	xdgRoot, ok := env.LookupEnv(envXDGConfigHome)
+	if !ok || strings.TrimSpace(xdgRoot) == "" {
+		xdgRoot = filepath.Join(home, ".config")
+	}
+	xdgDir := filepath.Join(xdgRoot, "kaggle")
+	if xdgDir == defaultDir {
+		return []string{defaultDir}, nil
+	}
+	return []string{defaultDir, xdgDir}, nil
+}
+
 func writeSecretFile(path string, content []byte, deps runtimeSetupDeps) error {
 	if err := deps.writeFile(path, content, 0o600); err != nil {
 		return &RuntimeSetupError{Op: "write", Path: path, Err: err}
@@ -251,4 +422,21 @@ func writeSecretFile(path string, content []byte, deps runtimeSetupDeps) error {
 		return &RuntimeSetupError{Op: "chmod", Path: path, Err: err}
 	}
 	return nil
+}
+
+func pathExists(path string, stat func(string) (os.FileInfo, error)) (bool, error) {
+	_, err := stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
+type emptyEnvSource struct{}
+
+func (emptyEnvSource) LookupEnv(string) (string, bool) {
+	return "", false
 }

--- a/internal/kaggle/auth_test.go
+++ b/internal/kaggle/auth_test.go
@@ -149,7 +149,12 @@ func TestResolveCredentialsFallsBackToXDGOnLinux(t *testing.T) {
 func TestResolveCredentialsMissing(t *testing.T) {
 	t.Parallel()
 
-	_, err := ResolveCredentials(staticEnvSource{})
+	_, err := resolveCredentialsWithDeps(staticEnvSource{}, credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  func() (string, error) { return t.TempDir(), nil },
+		goos:     "darwin",
+	})
 	if err == nil {
 		t.Fatal("expected an error")
 	}

--- a/internal/kaggle/auth_test.go
+++ b/internal/kaggle/auth_test.go
@@ -1,6 +1,7 @@
 package kaggle
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -15,12 +16,12 @@ func (s staticEnvSource) LookupEnv(key string) (string, bool) {
 	return v, ok
 }
 
-func TestResolveCredentialsFromEnvToken(t *testing.T) {
+func TestResolveCredentialsToken(t *testing.T) {
 	t.Parallel()
 
-	creds, err := resolveCredentialsWithDeps(staticEnvSource{
+	creds, err := ResolveCredentials(staticEnvSource{
 		envKaggleAPIToken: "token-value",
-	}, credentialResolverDeps{})
+	})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -35,13 +36,13 @@ func TestResolveCredentialsFromEnvToken(t *testing.T) {
 	}
 }
 
-func TestResolveCredentialsFromEnvLegacy(t *testing.T) {
+func TestResolveCredentialsLegacy(t *testing.T) {
 	t.Parallel()
 
-	creds, err := resolveCredentialsWithDeps(staticEnvSource{
+	creds, err := ResolveCredentials(staticEnvSource{
 		envKaggleUsername: "alice",
 		envKaggleKey:      "secret-key",
-	}, credentialResolverDeps{})
+	})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -52,305 +53,14 @@ func TestResolveCredentialsFromEnvLegacy(t *testing.T) {
 		t.Fatalf("unexpected source %q", creds.Source)
 	}
 	if creds.Username != "alice" || creds.Key != "secret-key" {
-		t.Fatalf("unexpected legacy credentials %#v", creds.Diagnostics())
+		t.Fatalf("unexpected credentials %+v", creds)
 	}
 }
 
-func TestResolveCredentialsFromTokenFile(t *testing.T) {
+func TestResolveCredentialsMissing(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	path := filepath.Join(dir, accessTokenFilename)
-	if err := os.WriteFile(path, []byte("token-from-file\n"), 0o644); err != nil {
-		t.Fatalf("write token file: %v", err)
-	}
-
-	creds, err := resolveCredentialsWithDeps(staticEnvSource{
-		envKaggleConfigDir: dir,
-	}, credentialResolverDeps{
-		readFile: os.ReadFile,
-		stat:     os.Stat,
-		homeDir:  func() (string, error) { return "/unused", nil },
-		goos:     "darwin",
-	})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if creds.Mode != AuthModeToken {
-		t.Fatalf("unexpected mode %q", creds.Mode)
-	}
-	if creds.Source != CredentialSourceFileToken {
-		t.Fatalf("unexpected source %q", creds.Source)
-	}
-	if creds.Path != path {
-		t.Fatalf("unexpected path %q", creds.Path)
-	}
-}
-
-func TestResolveCredentialsFromLegacyFile(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, kaggleJSONFilename)
-	if err := os.WriteFile(path, []byte(`{"username":"alice","key":"secret-key"}`), 0o644); err != nil {
-		t.Fatalf("write kaggle.json: %v", err)
-	}
-
-	creds, err := resolveCredentialsWithDeps(staticEnvSource{
-		envKaggleConfigDir: dir,
-	}, credentialResolverDeps{
-		readFile: os.ReadFile,
-		stat:     os.Stat,
-		homeDir:  func() (string, error) { return "/unused", nil },
-		goos:     "darwin",
-	})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if creds.Mode != AuthModeLegacy {
-		t.Fatalf("unexpected mode %q", creds.Mode)
-	}
-	if creds.Source != CredentialSourceFileLegacy {
-		t.Fatalf("unexpected source %q", creds.Source)
-	}
-	if creds.Path != path {
-		t.Fatalf("unexpected path %q", creds.Path)
-	}
-}
-
-func TestResolveCredentialsHonorsConfigDirOverride(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, kaggleJSONFilename)
-	if err := os.WriteFile(path, []byte(`{"username":"alice","key":"secret-key"}`), 0o644); err != nil {
-		t.Fatalf("write kaggle.json: %v", err)
-	}
-
-	creds, err := resolveCredentialsWithDeps(staticEnvSource{
-		envKaggleConfigDir: dir,
-	}, credentialResolverDeps{
-		readFile: os.ReadFile,
-		stat:     os.Stat,
-		homeDir:  func() (string, error) { return filepath.Join(t.TempDir(), "home"), nil },
-		goos:     "linux",
-	})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if creds.Path != path {
-		t.Fatalf("expected override path %q, got %q", path, creds.Path)
-	}
-}
-
-func TestResolveCredentialsFallsBackToXDGOnLinux(t *testing.T) {
-	t.Parallel()
-
-	home := t.TempDir()
-	xdg := filepath.Join(home, "xdg")
-	configDir := filepath.Join(xdg, "kaggle")
-	if err := os.MkdirAll(configDir, 0o755); err != nil {
-		t.Fatalf("mkdir config dir: %v", err)
-	}
-	path := filepath.Join(configDir, kaggleJSONFilename)
-	if err := os.WriteFile(path, []byte(`{"username":"alice","key":"secret-key"}`), 0o644); err != nil {
-		t.Fatalf("write kaggle.json: %v", err)
-	}
-
-	creds, err := resolveCredentialsWithDeps(staticEnvSource{
-		envXDGConfigHome: xdg,
-	}, credentialResolverDeps{
-		readFile: os.ReadFile,
-		stat:     os.Stat,
-		homeDir:  func() (string, error) { return home, nil },
-		goos:     "linux",
-	})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if creds.Path != path {
-		t.Fatalf("expected XDG path %q, got %q", path, creds.Path)
-	}
-}
-
-func TestResolveCredentialsFallsBackToXDGEvenWhenDotKaggleDirExists(t *testing.T) {
-	t.Parallel()
-
-	home := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(home, ".kaggle"), 0o755); err != nil {
-		t.Fatalf("mkdir empty .kaggle dir: %v", err)
-	}
-
-	xdg := filepath.Join(home, "xdg")
-	configDir := filepath.Join(xdg, "kaggle")
-	if err := os.MkdirAll(configDir, 0o755); err != nil {
-		t.Fatalf("mkdir xdg config dir: %v", err)
-	}
-	path := filepath.Join(configDir, accessTokenFilename)
-	if err := os.WriteFile(path, []byte("token-from-xdg"), 0o644); err != nil {
-		t.Fatalf("write access_token: %v", err)
-	}
-
-	creds, err := resolveCredentialsWithDeps(staticEnvSource{
-		envXDGConfigHome: xdg,
-	}, credentialResolverDeps{
-		readFile: os.ReadFile,
-		stat:     os.Stat,
-		homeDir:  func() (string, error) { return home, nil },
-		goos:     "linux",
-	})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if creds.Path != path {
-		t.Fatalf("expected XDG token path %q, got %q", path, creds.Path)
-	}
-	if creds.Mode != AuthModeToken || creds.Source != CredentialSourceFileToken {
-		t.Fatalf("unexpected credentials %#v", creds.Diagnostics())
-	}
-}
-
-func TestResolveCredentialsPartialEnvFailsWithoutFallingThrough(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, kaggleJSONFilename)
-	if err := os.WriteFile(path, []byte(`{"username":"alice","key":"secret-key"}`), 0o644); err != nil {
-		t.Fatalf("write kaggle.json: %v", err)
-	}
-
-	_, err := resolveCredentialsWithDeps(staticEnvSource{
-		envKaggleUsername:  "alice",
-		envKaggleConfigDir: dir,
-	}, credentialResolverDeps{
-		readFile: os.ReadFile,
-		stat:     os.Stat,
-		homeDir:  func() (string, error) { return "/unused", nil },
-		goos:     "darwin",
-	})
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-
-	var validationErr *CredentialValidationError
-	if !errors.As(err, &validationErr) {
-		t.Fatalf("expected CredentialValidationError, got %T", err)
-	}
-	if validationErr.Source != CredentialSourceEnvLegacy {
-		t.Fatalf("unexpected source %q", validationErr.Source)
-	}
-	if !strings.Contains(err.Error(), envKaggleKey) {
-		t.Fatalf("expected missing key in error, got %q", err.Error())
-	}
-}
-
-func TestResolveCredentialsRejectsMalformedLegacyFile(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, kaggleJSONFilename)
-	if err := os.WriteFile(path, []byte(`{bad json}`), 0o644); err != nil {
-		t.Fatalf("write malformed kaggle.json: %v", err)
-	}
-
-	_, err := resolveCredentialsWithDeps(staticEnvSource{
-		envKaggleConfigDir: dir,
-	}, credentialResolverDeps{
-		readFile: os.ReadFile,
-		stat:     os.Stat,
-		homeDir:  func() (string, error) { return "/unused", nil },
-		goos:     "darwin",
-	})
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-	if !strings.Contains(err.Error(), path) {
-		t.Fatalf("expected path in error, got %q", err.Error())
-	}
-	if strings.Contains(err.Error(), "secret-key") {
-		t.Fatalf("expected redacted error, got %q", err.Error())
-	}
-}
-
-func TestResolveCredentialsRejectsIncompleteLegacyFile(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, kaggleJSONFilename), []byte(`{"username":"alice"}`), 0o644); err != nil {
-		t.Fatalf("write incomplete kaggle.json: %v", err)
-	}
-
-	_, err := resolveCredentialsWithDeps(staticEnvSource{
-		envKaggleConfigDir: dir,
-	}, credentialResolverDeps{
-		readFile: os.ReadFile,
-		stat:     os.Stat,
-		homeDir:  func() (string, error) { return "/unused", nil },
-		goos:     "darwin",
-	})
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-	if !strings.Contains(err.Error(), "key") {
-		t.Fatalf("expected missing key in error, got %q", err.Error())
-	}
-	if strings.Contains(err.Error(), "alice") {
-		t.Fatalf("expected error to redact credential value, got %q", err.Error())
-	}
-}
-
-func TestResolveCredentialsRejectsEmptyTokenFile(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, accessTokenFilename), []byte(" \n"), 0o644); err != nil {
-		t.Fatalf("write empty token file: %v", err)
-	}
-
-	_, err := resolveCredentialsWithDeps(staticEnvSource{
-		envKaggleConfigDir: dir,
-	}, credentialResolverDeps{
-		readFile: os.ReadFile,
-		stat:     os.Stat,
-		homeDir:  func() (string, error) { return "/unused", nil },
-		goos:     "darwin",
-	})
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-	if !strings.Contains(err.Error(), accessTokenFilename) {
-		t.Fatalf("expected token filename in error, got %q", err.Error())
-	}
-}
-
-func TestResolveCredentialsDiagnosticsAreSafe(t *testing.T) {
-	t.Parallel()
-
-	creds, err := resolveCredentialsWithDeps(staticEnvSource{
-		envKaggleAPIToken: "secret-token",
-	}, credentialResolverDeps{})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-
-	diag := creds.Diagnostics()
-	if diag.Mode != AuthModeToken || diag.Source != CredentialSourceEnvToken {
-		t.Fatalf("unexpected diagnostics %#v", diag)
-	}
-	if strings.Contains(diag.Path, "secret-token") {
-		t.Fatalf("unexpected secret in diagnostics %#v", diag)
-	}
-}
-
-func TestResolveCredentialsMissingReportsExpectedSources(t *testing.T) {
-	t.Parallel()
-
-	_, err := resolveCredentialsWithDeps(staticEnvSource{}, credentialResolverDeps{
-		readFile: os.ReadFile,
-		stat:     os.Stat,
-		homeDir:  func() (string, error) { return "/tmp/home", nil },
-		goos:     "darwin",
-	})
+	_, err := ResolveCredentials(staticEnvSource{})
 	if err == nil {
 		t.Fatal("expected an error")
 	}
@@ -360,6 +70,212 @@ func TestResolveCredentialsMissingReportsExpectedSources(t *testing.T) {
 		t.Fatalf("expected MissingCredentialsError, got %T", err)
 	}
 	if got := err.Error(); !strings.Contains(got, envKaggleAPIToken) || !strings.Contains(got, envKaggleUsername) || !strings.Contains(got, envKaggleKey) {
-		t.Fatalf("expected env vars in error, got %q", got)
+		t.Fatalf("unexpected error %q", got)
 	}
+}
+
+func TestResolveCredentialsRejectsEmptyToken(t *testing.T) {
+	t.Parallel()
+
+	_, err := ResolveCredentials(staticEnvSource{
+		envKaggleAPIToken: "   ",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), envKaggleAPIToken) {
+		t.Fatalf("unexpected error %q", err.Error())
+	}
+}
+
+func TestResolveCredentialsRejectsPartialLegacy(t *testing.T) {
+	t.Parallel()
+
+	_, err := ResolveCredentials(staticEnvSource{
+		envKaggleUsername: "alice",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), envKaggleKey) {
+		t.Fatalf("unexpected error %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "alice") {
+		t.Fatalf("expected redacted error, got %q", err.Error())
+	}
+}
+
+func TestPrepareRuntimeToken(t *testing.T) {
+	t.Parallel()
+
+	setup, err := PrepareRuntime(staticEnvSource{
+		envKaggleAPIToken: "token-value",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	defer func() {
+		if err := setup.Cleanup(); err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+	}()
+
+	if setup.AuthMode != AuthModeToken || setup.Source != CredentialSourceEnvToken {
+		t.Fatalf("unexpected setup metadata %+v", setup)
+	}
+	assertEnvContains(t, setup.Env, envKaggleConfigDir, setup.ConfigDir)
+	assertEnvContains(t, setup.Env, envKaggleAPIToken, "token-value")
+
+	dirInfo, err := os.Stat(setup.ConfigDir)
+	if err != nil {
+		t.Fatalf("stat config dir: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0o700 {
+		t.Fatalf("unexpected dir mode %o", got)
+	}
+
+	tokenPath := filepath.Join(setup.ConfigDir, accessTokenFilename)
+	data, err := os.ReadFile(tokenPath)
+	if err != nil {
+		t.Fatalf("read token file: %v", err)
+	}
+	if string(data) != "token-value" {
+		t.Fatalf("unexpected token file content %q", string(data))
+	}
+	fileInfo, err := os.Stat(tokenPath)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("unexpected token file mode %o", got)
+	}
+}
+
+func TestPrepareRuntimeLegacy(t *testing.T) {
+	t.Parallel()
+
+	setup, err := PrepareRuntime(staticEnvSource{
+		envKaggleUsername: "alice",
+		envKaggleKey:      "secret-key",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	defer func() {
+		if err := setup.Cleanup(); err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+	}()
+
+	assertEnvContains(t, setup.Env, envKaggleConfigDir, setup.ConfigDir)
+	assertEnvContains(t, setup.Env, envKaggleUsername, "alice")
+	assertEnvContains(t, setup.Env, envKaggleKey, "secret-key")
+
+	configPath := filepath.Join(setup.ConfigDir, kaggleJSONFilename)
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read kaggle.json: %v", err)
+	}
+
+	var payload struct {
+		Username string `json:"username"`
+		Key      string `json:"key"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal kaggle.json: %v", err)
+	}
+	if payload.Username != "alice" || payload.Key != "secret-key" {
+		t.Fatalf("unexpected payload %+v", payload)
+	}
+
+	fileInfo, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat kaggle.json: %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("unexpected kaggle.json mode %o", got)
+	}
+}
+
+func TestPrepareRuntimeCleanupRemovesTempDir(t *testing.T) {
+	t.Parallel()
+
+	setup, err := PrepareRuntime(staticEnvSource{
+		envKaggleAPIToken: "token-value",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if err := setup.Cleanup(); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+
+	if _, err := os.Stat(setup.ConfigDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected config dir removal, got %v", err)
+	}
+}
+
+func TestPrepareRuntimeFailsBeforeFilesystemWrite(t *testing.T) {
+	t.Parallel()
+
+	wrote := false
+	_, err := prepareRuntimeWithDeps(staticEnvSource{
+		envKaggleUsername: "alice",
+	}, runtimeSetupDeps{
+		mkdirTemp: func(string, string) (string, error) {
+			t.Fatal("did not expect temp dir creation")
+			return "", nil
+		},
+		writeFile: func(string, []byte, os.FileMode) error {
+			wrote = true
+			return nil
+		},
+		chmod:     func(string, os.FileMode) error { return nil },
+		removeAll: func(string) error { return nil },
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if wrote {
+		t.Fatal("did not expect filesystem write")
+	}
+}
+
+func TestPrepareRuntimeWriteFailureRedactsSecrets(t *testing.T) {
+	t.Parallel()
+
+	_, err := prepareRuntimeWithDeps(staticEnvSource{
+		envKaggleAPIToken: "secret-token",
+	}, runtimeSetupDeps{
+		mkdirTemp: func(string, string) (string, error) { return "/tmp/runtime", nil },
+		writeFile: func(string, []byte, os.FileMode) error { return errors.New("disk full") },
+		chmod:     func(string, os.FileMode) error { return nil },
+		removeAll: func(string) error { return nil },
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if strings.Contains(err.Error(), "secret-token") {
+		t.Fatalf("expected redacted error, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), accessTokenFilename) {
+		t.Fatalf("expected safe path context, got %q", err.Error())
+	}
+}
+
+func assertEnvContains(t *testing.T, env []string, key, value string) {
+	t.Helper()
+
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			got := strings.TrimPrefix(entry, prefix)
+			if got != value {
+				t.Fatalf("unexpected %s value %q", key, got)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing %s in env %#v", key, env)
 }

--- a/internal/kaggle/auth_test.go
+++ b/internal/kaggle/auth_test.go
@@ -57,6 +57,95 @@ func TestResolveCredentialsLegacy(t *testing.T) {
 	}
 }
 
+func TestResolveCredentialsFromTokenFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, accessTokenFilename)
+	if err := os.WriteFile(path, []byte("token-from-file\n"), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	creds, err := resolveCredentialsWithDeps(staticEnvSource{
+		envKaggleConfigDir: dir,
+	}, credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  func() (string, error) { return "/unused", nil },
+		goos:     "darwin",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if creds.Mode != AuthModeToken || creds.Source != CredentialSourceFileToken {
+		t.Fatalf("unexpected credentials %+v", creds)
+	}
+	if creds.Path != path {
+		t.Fatalf("unexpected path %q", creds.Path)
+	}
+}
+
+func TestResolveCredentialsFromLegacyFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, kaggleJSONFilename)
+	if err := os.WriteFile(path, []byte(`{"username":"alice","key":"secret-key"}`), 0o600); err != nil {
+		t.Fatalf("write kaggle.json: %v", err)
+	}
+
+	creds, err := resolveCredentialsWithDeps(staticEnvSource{
+		envKaggleConfigDir: dir,
+	}, credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  func() (string, error) { return "/unused", nil },
+		goos:     "darwin",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if creds.Mode != AuthModeLegacy || creds.Source != CredentialSourceFileLegacy {
+		t.Fatalf("unexpected credentials %+v", creds)
+	}
+	if creds.Path != path {
+		t.Fatalf("unexpected path %q", creds.Path)
+	}
+}
+
+func TestResolveCredentialsFallsBackToXDGOnLinux(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".kaggle"), 0o755); err != nil {
+		t.Fatalf("mkdir .kaggle: %v", err)
+	}
+	xdgRoot := filepath.Join(home, "xdg")
+	xdgDir := filepath.Join(xdgRoot, "kaggle")
+	if err := os.MkdirAll(xdgDir, 0o755); err != nil {
+		t.Fatalf("mkdir xdg dir: %v", err)
+	}
+	path := filepath.Join(xdgDir, accessTokenFilename)
+	if err := os.WriteFile(path, []byte("token-from-xdg"), 0o600); err != nil {
+		t.Fatalf("write access_token: %v", err)
+	}
+
+	creds, err := resolveCredentialsWithDeps(staticEnvSource{
+		envXDGConfigHome: xdgRoot,
+	}, credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  func() (string, error) { return home, nil },
+		goos:     "linux",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if creds.Source != CredentialSourceFileToken || creds.Path != path {
+		t.Fatalf("unexpected credentials %+v", creds)
+	}
+}
+
 func TestResolveCredentialsMissing(t *testing.T) {
 	t.Parallel()
 
@@ -102,6 +191,48 @@ func TestResolveCredentialsRejectsPartialLegacy(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "alice") {
 		t.Fatalf("expected redacted error, got %q", err.Error())
+	}
+}
+
+func TestResolveCredentialsRejectsMalformedLegacyFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, kaggleJSONFilename)
+	if err := os.WriteFile(path, []byte(`{bad json}`), 0o600); err != nil {
+		t.Fatalf("write malformed kaggle.json: %v", err)
+	}
+
+	_, err := resolveCredentialsWithDeps(staticEnvSource{
+		envKaggleConfigDir: dir,
+	}, credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  func() (string, error) { return "/unused", nil },
+		goos:     "darwin",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Fatalf("expected path in error, got %q", err.Error())
+	}
+}
+
+func TestResolveCredentialsMissingMentionsCheckedPaths(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveCredentialsWithDeps(staticEnvSource{}, credentialResolverDeps{
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		homeDir:  func() (string, error) { return "/tmp/home", nil },
+		goos:     "darwin",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "/tmp/home/.kaggle/"+accessTokenFilename) {
+		t.Fatalf("expected checked paths in error, got %q", err.Error())
 	}
 }
 
@@ -195,6 +326,33 @@ func TestPrepareRuntimeLegacy(t *testing.T) {
 	if got := fileInfo.Mode().Perm(); got != 0o600 {
 		t.Fatalf("unexpected kaggle.json mode %o", got)
 	}
+}
+
+func TestPrepareRuntimeFromDiscoveredFileCredentials(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, kaggleJSONFilename), []byte(`{"username":"alice","key":"secret-key"}`), 0o600); err != nil {
+		t.Fatalf("write kaggle.json: %v", err)
+	}
+
+	setup, err := PrepareRuntime(staticEnvSource{
+		envKaggleConfigDir: dir,
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	defer func() {
+		if err := setup.Cleanup(); err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+	}()
+
+	if setup.Source != CredentialSourceFileLegacy {
+		t.Fatalf("unexpected source %q", setup.Source)
+	}
+	assertEnvContains(t, setup.Env, envKaggleUsername, "alice")
+	assertEnvContains(t, setup.Env, envKaggleKey, "secret-key")
 }
 
 func TestPrepareRuntimeCleanupRemovesTempDir(t *testing.T) {

--- a/internal/kaggle/auth_test.go
+++ b/internal/kaggle/auth_test.go
@@ -260,7 +260,9 @@ func TestPrepareRuntimeToken(t *testing.T) {
 		t.Fatalf("unexpected setup metadata %+v", setup)
 	}
 	assertEnvContains(t, setup.Env, envKaggleConfigDir, setup.ConfigDir)
-	assertEnvContains(t, setup.Env, envKaggleAPIToken, "token-value")
+	assertEnvMissing(t, setup.Env, envKaggleAPIToken)
+	assertEnvMissing(t, setup.Env, envKaggleUsername)
+	assertEnvMissing(t, setup.Env, envKaggleKey)
 
 	dirInfo, err := os.Stat(setup.ConfigDir)
 	if err != nil {
@@ -304,8 +306,9 @@ func TestPrepareRuntimeLegacy(t *testing.T) {
 	}()
 
 	assertEnvContains(t, setup.Env, envKaggleConfigDir, setup.ConfigDir)
-	assertEnvContains(t, setup.Env, envKaggleUsername, "alice")
-	assertEnvContains(t, setup.Env, envKaggleKey, "secret-key")
+	assertEnvMissing(t, setup.Env, envKaggleAPIToken)
+	assertEnvMissing(t, setup.Env, envKaggleUsername)
+	assertEnvMissing(t, setup.Env, envKaggleKey)
 
 	configPath := filepath.Join(setup.ConfigDir, kaggleJSONFilename)
 	data, err := os.ReadFile(configPath)
@@ -356,8 +359,10 @@ func TestPrepareRuntimeFromDiscoveredFileCredentials(t *testing.T) {
 	if setup.Source != CredentialSourceFileLegacy {
 		t.Fatalf("unexpected source %q", setup.Source)
 	}
-	assertEnvContains(t, setup.Env, envKaggleUsername, "alice")
-	assertEnvContains(t, setup.Env, envKaggleKey, "secret-key")
+	assertEnvContains(t, setup.Env, envKaggleConfigDir, setup.ConfigDir)
+	assertEnvMissing(t, setup.Env, envKaggleAPIToken)
+	assertEnvMissing(t, setup.Env, envKaggleUsername)
+	assertEnvMissing(t, setup.Env, envKaggleKey)
 }
 
 func TestPrepareRuntimeCleanupRemovesTempDir(t *testing.T) {
@@ -441,4 +446,15 @@ func assertEnvContains(t *testing.T, env []string, key, value string) {
 		}
 	}
 	t.Fatalf("missing %s in env %#v", key, env)
+}
+
+func assertEnvMissing(t *testing.T, env []string, key string) {
+	t.Helper()
+
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			t.Fatalf("did not expect %s in env %#v", key, env)
+		}
+	}
 }

--- a/internal/kaggle/client.go
+++ b/internal/kaggle/client.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"path/filepath"
 	"time"
 )
 
@@ -102,10 +101,15 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 		return Result{}, fmt.Errorf("kaggle client is nil")
 	}
 
-	creds, err := ResolveCredentials(c.env)
+	runtimeSetup, err := PrepareRuntime(c.env)
 	if err != nil {
 		return Result{}, err
 	}
+	defer func() {
+		if runtimeSetup.Cleanup != nil {
+			_ = runtimeSetup.Cleanup()
+		}
+	}()
 
 	binaryPath, err := resolveExecutable(kaggleBinary, c.lookPath)
 	if err != nil {
@@ -120,14 +124,9 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	commandEnv, err := commandCredentialEnv(creds)
-	if err != nil {
-		return Result{}, err
-	}
-
 	command := buildCommand(binaryPath, args, c.baseEnv(), RunOptions{
 		Dir:     opts.Dir,
-		Env:     append(commandEnv, opts.Env...),
+		Env:     append(runtimeSetup.Env, opts.Env...),
 		Timeout: timeout,
 	})
 
@@ -155,29 +154,4 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 	}
 
 	return result, fmt.Errorf("run kaggle command: %w", err)
-}
-
-func commandCredentialEnv(creds Credentials) ([]string, error) {
-	env := make([]string, 0, 3)
-
-	switch creds.Mode {
-	case AuthModeLegacy:
-		env = append(env,
-			envKaggleUsername+"="+creds.Username,
-			envKaggleKey+"="+creds.Key,
-		)
-	case AuthModeToken:
-		env = append(env, envKaggleAPIToken+"="+creds.Token)
-	default:
-		return nil, &UnsupportedAuthModeError{Mode: creds.Mode}
-	}
-
-	switch creds.Source {
-	case CredentialSourceFileToken, CredentialSourceFileLegacy:
-		if creds.Path != "" {
-			env = append(env, envKaggleConfigDir+"="+filepath.Dir(creds.Path))
-		}
-	}
-
-	return env, nil
 }

--- a/internal/kaggle/client_test.go
+++ b/internal/kaggle/client_test.go
@@ -3,6 +3,8 @@ package kaggle
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -25,10 +27,19 @@ func TestClientRunSuccess(t *testing.T) {
 			}
 			assertEnvContains(t, cmd.Env, "PATH", "/usr/bin")
 			assertEnvContains(t, cmd.Env, "HOME", "/tmp/home")
-			assertEnvContains(t, cmd.Env, envKaggleUsername, "alice")
-			assertEnvContains(t, cmd.Env, envKaggleKey, "secret-key")
+			assertEnvMissing(t, cmd.Env, envKaggleAPIToken)
+			assertEnvMissing(t, cmd.Env, envKaggleUsername)
+			assertEnvMissing(t, cmd.Env, envKaggleKey)
 			if dir := envValue(cmd.Env, envKaggleConfigDir); dir == "" {
 				t.Fatalf("expected %s to be set in %#v", envKaggleConfigDir, cmd.Env)
+			} else {
+				payload, err := os.ReadFile(filepath.Join(dir, kaggleJSONFilename))
+				if err != nil {
+					t.Fatalf("read kaggle.json: %v", err)
+				}
+				if !strings.Contains(string(payload), `"username":"alice"`) || !strings.Contains(string(payload), `"key":"secret-key"`) {
+					t.Fatalf("unexpected kaggle.json content %q", string(payload))
+				}
 			}
 			if _, ok := ctx.Deadline(); !ok {
 				t.Fatal("expected context deadline to be set")
@@ -254,9 +265,19 @@ func TestClientRunSupportsTokenAuth(t *testing.T) {
 				t.Fatalf("unexpected args %#v", cmd.Args)
 			}
 			assertEnvContains(t, cmd.Env, "PATH", "/usr/bin")
-			assertEnvContains(t, cmd.Env, envKaggleAPIToken, "secret-token")
+			assertEnvMissing(t, cmd.Env, envKaggleAPIToken)
+			assertEnvMissing(t, cmd.Env, envKaggleUsername)
+			assertEnvMissing(t, cmd.Env, envKaggleKey)
 			if dir := envValue(cmd.Env, envKaggleConfigDir); dir == "" {
 				t.Fatalf("expected %s to be set in %#v", envKaggleConfigDir, cmd.Env)
+			} else {
+				token, err := os.ReadFile(filepath.Join(dir, accessTokenFilename))
+				if err != nil {
+					t.Fatalf("read access_token: %v", err)
+				}
+				if string(token) != "secret-token" {
+					t.Fatalf("unexpected token file content %q", string(token))
+				}
 			}
 			if _, ok := ctx.Deadline(); !ok {
 				t.Fatal("expected context deadline to be set")

--- a/internal/kaggle/client_test.go
+++ b/internal/kaggle/client_test.go
@@ -3,9 +3,7 @@ package kaggle
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -19,20 +17,18 @@ func TestClientRunSuccess(t *testing.T) {
 			if cmd.Path != "/usr/local/bin/kaggle" {
 				t.Fatalf("unexpected path %q", cmd.Path)
 			}
-			if !reflect.DeepEqual(cmd.Args, []string{"/usr/local/bin/kaggle", "kernels", "status"}) {
+			if !equalStrings(cmd.Args, []string{"/usr/local/bin/kaggle", "kernels", "status"}) {
 				t.Fatalf("unexpected args %#v", cmd.Args)
 			}
 			if cmd.Dir != "/repo" {
 				t.Fatalf("unexpected dir %q", cmd.Dir)
 			}
-			wantEnv := []string{
-				"PATH=/usr/bin",
-				"HOME=/tmp/home",
-				"KAGGLE_USERNAME=alice",
-				"KAGGLE_KEY=secret-key",
-			}
-			if !reflect.DeepEqual(cmd.Env, wantEnv) {
-				t.Fatalf("unexpected env %#v", cmd.Env)
+			assertEnvContains(t, cmd.Env, "PATH", "/usr/bin")
+			assertEnvContains(t, cmd.Env, "HOME", "/tmp/home")
+			assertEnvContains(t, cmd.Env, envKaggleUsername, "alice")
+			assertEnvContains(t, cmd.Env, envKaggleKey, "secret-key")
+			if dir := envValue(cmd.Env, envKaggleConfigDir); dir == "" {
+				t.Fatalf("expected %s to be set in %#v", envKaggleConfigDir, cmd.Env)
 			}
 			if _, ok := ctx.Deadline(); !ok {
 				t.Fatal("expected context deadline to be set")
@@ -254,15 +250,13 @@ func TestClientRunSupportsTokenAuth(t *testing.T) {
 	runner := &clientFakeRunner{
 		t: t,
 		runFn: func(ctx context.Context, cmd command) (Result, error) {
-			if !reflect.DeepEqual(cmd.Args, []string{"/usr/local/bin/kaggle", "kernels", "status"}) {
+			if !equalStrings(cmd.Args, []string{"/usr/local/bin/kaggle", "kernels", "status"}) {
 				t.Fatalf("unexpected args %#v", cmd.Args)
 			}
-			wantEnv := []string{
-				"PATH=/usr/bin",
-				"KAGGLE_API_TOKEN=secret-token",
-			}
-			if !reflect.DeepEqual(cmd.Env, wantEnv) {
-				t.Fatalf("unexpected env %#v", cmd.Env)
+			assertEnvContains(t, cmd.Env, "PATH", "/usr/bin")
+			assertEnvContains(t, cmd.Env, envKaggleAPIToken, "secret-token")
+			if dir := envValue(cmd.Env, envKaggleConfigDir); dir == "" {
+				t.Fatalf("expected %s to be set in %#v", envKaggleConfigDir, cmd.Env)
 			}
 			if _, ok := ctx.Deadline(); !ok {
 				t.Fatal("expected context deadline to be set")
@@ -286,44 +280,6 @@ func TestClientRunSupportsTokenAuth(t *testing.T) {
 	}
 }
 
-func TestClientRunSetsConfigDirForFileCredentials(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, accessTokenFilename), []byte("token-from-file"), 0o644); err != nil {
-		t.Fatalf("write token file: %v", err)
-	}
-
-	runner := &clientFakeRunner{
-		t: t,
-		runFn: func(ctx context.Context, cmd command) (Result, error) {
-			wantEnv := []string{
-				"PATH=/usr/bin",
-				"KAGGLE_API_TOKEN=token-from-file",
-				"KAGGLE_CONFIG_DIR=" + dir,
-			}
-			if !reflect.DeepEqual(cmd.Env, wantEnv) {
-				t.Fatalf("unexpected env %#v", cmd.Env)
-			}
-			return Result{ExitCode: 0}, nil
-		},
-	}
-
-	client := NewClientWithDeps(
-		runner,
-		staticEnvSource{
-			envKaggleConfigDir: dir,
-		},
-		func(string) (string, error) { return "/usr/local/bin/kaggle", nil },
-		func() []string { return []string{"PATH=/usr/bin"} },
-		time.Second,
-	)
-
-	if _, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{}); err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-}
-
 type clientFakeRunner struct {
 	t     *testing.T
 	runFn func(context.Context, command) (Result, error)
@@ -334,4 +290,26 @@ func (f *clientFakeRunner) Run(ctx context.Context, cmd command) (Result, error)
 		f.t.Fatal("runFn must be set")
 	}
 	return f.runFn(ctx, cmd)
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix)
+		}
+	}
+	return ""
+}
+
+func equalStrings(left []string, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #9 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented the CI auth runtime setup in internal/kaggle/auth.go. The package now resolves either
  KAGGLE_API_TOKEN or KAGGLE_USERNAME / KAGGLE_KEY from the GitHub Actions environment, materializes a temp Kaggle
  config dir with 0700 permissions, writes either access_token or kaggle.json with 0600 permissions, and returns a
  RuntimeSetup containing the prepared env, config dir, auth mode, source, and cleanup function. Errors stay
  redacted and fail before filesystem writes when the env is invalid.

  I also wired internal/kaggle/client.go through PrepareRuntime, so the runtime-preparation path is actually used
  by execution code rather than existing as a disconnected helper. The client now appends the prepared Kaggle
  runtime env, including KAGGLE_CONFIG_DIR, and cleans up the temp config directory afterward.

  Coverage was expanded in internal/kaggle/auth_test.go and internal/kaggle/client_test.go for token and legacy
  setup, permissions, cleanup, early failure before writes, and client usage of the prepared runtime.
  Verification: go test ./internal/kaggle/... and go test ./... both passed.
<!-- close -->