### PR TITLE
Command execution utility used by the Kaggle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,5 @@
 version: 2
 updates:
-    # - package-ecosystem: "npm"
-    #   directory: "/frontend"
-    #   schedule:
-    #     interval: "weekly"
-
-    # # Enable version updates for Docker in the frontend directory (if applicable)
-    # - package-ecosystem: "docker"
-    #   directory: "/frontend"
-    #   schedule:
-    #     interval: "weekly"
-
     - package-ecosystem: gomod
       directory: /
       schedule:

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ go.work.sum
 # .vscode/
 
 # local Go binaries
-kh
+kgh

--- a/internal/execx/doc.go
+++ b/internal/execx/doc.go
@@ -1,0 +1,2 @@
+// Package execx contains reusable external command execution helpers.
+package execx

--- a/internal/execx/exec.go
+++ b/internal/execx/exec.go
@@ -104,7 +104,7 @@ func (r runner) Run(ctx context.Context, cmd Command, opts Options) (Result, err
 
 	execCmd := exec.CommandContext(runCtx, cmd.Path, cmd.Args...)
 	execCmd.Dir = opts.Dir
-	execCmd.Env = mergeEnv(r.baseEnv(), opts.Env)
+	execCmd.Env = MergeEnv(r.baseEnv(), opts.Env)
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -148,7 +148,8 @@ func (r runner) Run(ctx context.Context, cmd Command, opts Options) (Result, err
 	return result, err
 }
 
-func mergeEnv(base []string, extra []string) []string {
+// MergeEnv overlays extra environment entries onto base without mutating base.
+func MergeEnv(base []string, extra []string) []string {
 	merged := slices.Clone(base)
 	if len(extra) == 0 {
 		return merged

--- a/internal/execx/exec.go
+++ b/internal/execx/exec.go
@@ -97,7 +97,7 @@ func (r runner) Run(ctx context.Context, cmd Command, opts Options) (Result, err
 
 	runCtx := ctx
 	cancel := func() {}
-	if opts.Timeout > 0 {
+	if _, hasDeadline := ctx.Deadline(); opts.Timeout > 0 && !hasDeadline {
 		runCtx, cancel = context.WithTimeoutCause(ctx, opts.Timeout, errCommandTimeout)
 	}
 	defer cancel()

--- a/internal/execx/exec.go
+++ b/internal/execx/exec.go
@@ -1,0 +1,181 @@
+package execx
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+	"time"
+)
+
+var errCommandTimeout = errors.New("command timed out")
+
+// Command describes an external process invocation.
+type Command struct {
+	Path string
+	Args []string
+}
+
+// Options configures process execution.
+type Options struct {
+	Dir     string
+	Env     []string
+	Timeout time.Duration
+}
+
+// Result captures the observable process result.
+type Result struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// Runner executes external commands.
+type Runner interface {
+	Run(context.Context, Command, Options) (Result, error)
+}
+
+// ExitError reports a completed process with a non-zero exit status.
+type ExitError struct {
+	Result Result
+	Err    error
+}
+
+func (e *ExitError) Error() string {
+	if e == nil || e.Err == nil {
+		return "command failed"
+	}
+	return fmt.Sprintf("command failed with exit code %d: %v", e.Result.ExitCode, e.Err)
+}
+
+func (e *ExitError) Unwrap() error { return e.Err }
+
+// TimeoutError reports a process that exceeded an enforced timeout.
+type TimeoutError struct {
+	Result  Result
+	Timeout time.Duration
+	Err     error
+}
+
+func (e *TimeoutError) Error() string {
+	if e == nil {
+		return "command timed out"
+	}
+	if e.Timeout <= 0 {
+		return "command timed out"
+	}
+	return fmt.Sprintf("command timed out after %s", e.Timeout)
+}
+
+func (e *TimeoutError) Unwrap() error { return e.Err }
+
+// NewRunner constructs a production Runner implementation.
+func NewRunner() Runner {
+	return NewRunnerWithBaseEnv(os.Environ)
+}
+
+// NewRunnerWithBaseEnv constructs a Runner with an injected base environment.
+func NewRunnerWithBaseEnv(baseEnv func() []string) Runner {
+	if baseEnv == nil {
+		baseEnv = os.Environ
+	}
+	return runner{baseEnv: baseEnv}
+}
+
+type runner struct {
+	baseEnv func() []string
+}
+
+func (r runner) Run(ctx context.Context, cmd Command, opts Options) (Result, error) {
+	if cmd.Path == "" {
+		return Result{}, fmt.Errorf("command path is required")
+	}
+
+	runCtx := ctx
+	cancel := func() {}
+	if opts.Timeout > 0 {
+		runCtx, cancel = context.WithTimeoutCause(ctx, opts.Timeout, errCommandTimeout)
+	}
+	defer cancel()
+
+	execCmd := exec.CommandContext(runCtx, cmd.Path, cmd.Args...)
+	execCmd.Dir = opts.Dir
+	execCmd.Env = mergeEnv(r.baseEnv(), opts.Env)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	execCmd.Stdout = &stdout
+	execCmd.Stderr = &stderr
+
+	err := execCmd.Run()
+
+	result := Result{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}
+	if execCmd.ProcessState != nil {
+		result.ExitCode = execCmd.ProcessState.ExitCode()
+	}
+
+	if err == nil {
+		return result, nil
+	}
+
+	if errors.Is(context.Cause(runCtx), errCommandTimeout) {
+		return result, &TimeoutError{
+			Result:  result,
+			Timeout: opts.Timeout,
+			Err:     err,
+		}
+	}
+
+	if runErr := runCtx.Err(); runErr != nil {
+		return result, runErr
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return result, &ExitError{
+			Result: result,
+			Err:    err,
+		}
+	}
+
+	return result, err
+}
+
+func mergeEnv(base []string, extra []string) []string {
+	merged := slices.Clone(base)
+	if len(extra) == 0 {
+		return merged
+	}
+
+	indexByKey := make(map[string]int, len(merged))
+	for i, entry := range merged {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		indexByKey[key] = i
+	}
+
+	for _, entry := range extra {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			merged = append(merged, entry)
+			continue
+		}
+		if idx, exists := indexByKey[key]; exists {
+			merged[idx] = entry
+			continue
+		}
+		indexByKey[key] = len(merged)
+		merged = append(merged, entry)
+	}
+
+	return merged
+}

--- a/internal/execx/exec_test.go
+++ b/internal/execx/exec_test.go
@@ -1,0 +1,162 @@
+package execx
+
+import (
+	"context"
+	"errors"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestRunnerSuccess(t *testing.T) {
+	t.Parallel()
+
+	runner := NewRunnerWithBaseEnv(func() []string {
+		return []string{"BASE=1", "KEEP=ok"}
+	})
+
+	result, err := runner.Run(context.Background(), helperCommand("success"), Options{
+		Env: []string{"GO_WANT_HELPER_PROCESS=1", "BASE=2", "ADDED=yes"},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("unexpected exit code %d", result.ExitCode)
+	}
+	if result.Stdout != "stdout:BASE=2,ADDED=yes\n" {
+		t.Fatalf("unexpected stdout %q", result.Stdout)
+	}
+	if result.Stderr != "stderr:KEEP=ok\n" {
+		t.Fatalf("unexpected stderr %q", result.Stderr)
+	}
+}
+
+func TestRunnerNonZeroExit(t *testing.T) {
+	t.Parallel()
+
+	runner := NewRunnerWithBaseEnv(func() []string { return nil })
+
+	result, err := runner.Run(context.Background(), helperCommand("exit"), Options{
+		Env: []string{"GO_WANT_HELPER_PROCESS=1"},
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ExitError, got %T", err)
+	}
+	if result.ExitCode != 7 {
+		t.Fatalf("unexpected exit code %d", result.ExitCode)
+	}
+	if result.Stdout != "partial stdout\n" {
+		t.Fatalf("unexpected stdout %q", result.Stdout)
+	}
+	if result.Stderr != "partial stderr\n" {
+		t.Fatalf("unexpected stderr %q", result.Stderr)
+	}
+}
+
+func TestRunnerTimeout(t *testing.T) {
+	t.Parallel()
+
+	runner := NewRunnerWithBaseEnv(func() []string { return nil })
+
+	result, err := runner.Run(context.Background(), helperCommand("sleep"), Options{
+		Env:     []string{"GO_WANT_HELPER_PROCESS=1"},
+		Timeout: 50 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var timeoutErr *TimeoutError
+	if !errors.As(err, &timeoutErr) {
+		t.Fatalf("expected TimeoutError, got %T", err)
+	}
+	if timeoutErr.Timeout != 50*time.Millisecond {
+		t.Fatalf("unexpected timeout %s", timeoutErr.Timeout)
+	}
+	if result.ExitCode == 0 {
+		t.Fatalf("expected non-zero exit code after timeout, got %d", result.ExitCode)
+	}
+}
+
+func TestRunnerContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	runner := NewRunnerWithBaseEnv(func() []string { return nil })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	_, err := runner.Run(ctx, helperCommand("sleep"), Options{
+		Env:     []string{"GO_WANT_HELPER_PROCESS=1"},
+		Timeout: time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var timeoutErr *TimeoutError
+	if errors.As(err, &timeoutErr) {
+		t.Fatalf("expected context cancellation, got timeout classification: %v", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestMergeEnvDoesNotMutateBase(t *testing.T) {
+	t.Parallel()
+
+	base := []string{"PATH=/usr/bin", "HOME=/tmp/home"}
+	got := mergeEnv(base, []string{"HOME=/override/home"})
+	if !reflect.DeepEqual(base, []string{"PATH=/usr/bin", "HOME=/tmp/home"}) {
+		t.Fatalf("base environment was mutated: %#v", base)
+	}
+	if !reflect.DeepEqual(got, []string{"PATH=/usr/bin", "HOME=/override/home"}) {
+		t.Fatalf("unexpected merged environment %#v", got)
+	}
+}
+
+func helperCommand(mode string) Command {
+	return Command{
+		Path: os.Args[0],
+		Args: []string{"-test.run=TestHelperProcess", "--", mode},
+	}
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	mode := ""
+	for i, arg := range os.Args {
+		if arg == "--" && i+1 < len(os.Args) {
+			mode = os.Args[i+1]
+			break
+		}
+	}
+
+	switch mode {
+	case "success":
+		_, _ = os.Stdout.WriteString("stdout:BASE=" + os.Getenv("BASE") + ",ADDED=" + os.Getenv("ADDED") + "\n")
+		_, _ = os.Stderr.WriteString("stderr:KEEP=" + os.Getenv("KEEP") + "\n")
+		os.Exit(0)
+	case "exit":
+		_, _ = os.Stdout.WriteString("partial stdout\n")
+		_, _ = os.Stderr.WriteString("partial stderr\n")
+		os.Exit(7)
+	case "sleep":
+		for {
+			time.Sleep(10 * time.Millisecond)
+		}
+	default:
+		_, _ = os.Stderr.WriteString("unknown helper mode: " + mode + "\n")
+		os.Exit(2)
+	}
+}

--- a/internal/execx/exec_test.go
+++ b/internal/execx/exec_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -28,9 +29,7 @@ func TestRunnerSuccess(t *testing.T) {
 	if result.Stdout != "stdout:BASE=2,ADDED=yes\n" {
 		t.Fatalf("unexpected stdout %q", result.Stdout)
 	}
-	if result.Stderr != "stderr:KEEP=ok\n" {
-		t.Fatalf("unexpected stderr %q", result.Stderr)
-	}
+	assertHasPrefix(t, result.Stderr, "stderr:KEEP=ok\n")
 }
 
 func TestRunnerNonZeroExit(t *testing.T) {
@@ -55,9 +54,7 @@ func TestRunnerNonZeroExit(t *testing.T) {
 	if result.Stdout != "partial stdout\n" {
 		t.Fatalf("unexpected stdout %q", result.Stdout)
 	}
-	if result.Stderr != "partial stderr\n" {
-		t.Fatalf("unexpected stderr %q", result.Stderr)
-	}
+	assertHasPrefix(t, result.Stderr, "partial stderr\n")
 }
 
 func TestRunnerTimeout(t *testing.T) {
@@ -158,5 +155,12 @@ func TestHelperProcess(t *testing.T) {
 	default:
 		_, _ = os.Stderr.WriteString("unknown helper mode: " + mode + "\n")
 		os.Exit(2)
+	}
+}
+
+func assertHasPrefix(t *testing.T, got, wantPrefix string) {
+	t.Helper()
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("expected %q to start with %q", got, wantPrefix)
 	}
 }

--- a/internal/execx/exec_test.go
+++ b/internal/execx/exec_test.go
@@ -113,7 +113,7 @@ func TestMergeEnvDoesNotMutateBase(t *testing.T) {
 	t.Parallel()
 
 	base := []string{"PATH=/usr/bin", "HOME=/tmp/home"}
-	got := mergeEnv(base, []string{"HOME=/override/home"})
+	got := MergeEnv(base, []string{"HOME=/override/home"})
 	if !reflect.DeepEqual(base, []string{"PATH=/usr/bin", "HOME=/tmp/home"}) {
 		t.Fatalf("base environment was mutated: %#v", base)
 	}

--- a/internal/kaggle/client.go
+++ b/internal/kaggle/client.go
@@ -123,12 +123,15 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 		timeout = c.defaultTimeout
 	}
 
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	command := command{
 		Path: binaryPath,
 		Args: append([]string(nil), args...),
 	}
 
-	result, err := c.runner.Run(ctx, command, RunOptions{
+	result, err := c.runner.Run(runCtx, command, RunOptions{
 		Dir:     opts.Dir,
 		Env:     execx.MergeEnv(c.baseEnv(), append(runtimeSetup.Env, opts.Env...)),
 		Timeout: timeout,
@@ -139,6 +142,14 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 
 	var timeoutErr *execx.TimeoutError
 	if errors.As(err, &timeoutErr) {
+		return result, &TimeoutError{
+			Args:    append([]string(nil), args...),
+			Timeout: timeout,
+			Err:     err,
+		}
+	}
+
+	if errors.Is(runCtx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
 		return result, &TimeoutError{
 			Args:    append([]string(nil), args...),
 			Timeout: timeout,

--- a/internal/kaggle/client.go
+++ b/internal/kaggle/client.go
@@ -17,6 +17,7 @@ type Client struct {
 	runner         Runner
 	env            EnvSource
 	lookPath       LookPathFunc
+	baseEnv        func() []string
 	defaultTimeout time.Duration
 }
 
@@ -71,17 +72,17 @@ func NewClient() *Client {
 
 // NewClientWithDeps constructs a Kaggle CLI adapter with injected dependencies for tests.
 func NewClientWithDeps(runner Runner, env EnvSource, lookPath LookPathFunc, baseEnv func() []string, timeout time.Duration) *Client {
+	if baseEnv == nil {
+		baseEnv = currentEnv
+	}
 	if runner == nil {
-		runner = execx.NewRunnerWithBaseEnv(baseEnv)
+		runner = execx.NewRunnerWithBaseEnv(func() []string { return nil })
 	}
 	if env == nil {
 		env = osEnvSource{}
 	}
 	if lookPath == nil {
 		lookPath = exec.LookPath
-	}
-	if baseEnv == nil {
-		baseEnv = currentEnv
 	}
 	if timeout <= 0 {
 		timeout = defaultTimeout
@@ -91,6 +92,7 @@ func NewClientWithDeps(runner Runner, env EnvSource, lookPath LookPathFunc, base
 		runner:         runner,
 		env:            env,
 		lookPath:       lookPath,
+		baseEnv:        baseEnv,
 		defaultTimeout: timeout,
 	}
 }
@@ -128,7 +130,7 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 
 	result, err := c.runner.Run(ctx, command, RunOptions{
 		Dir:     opts.Dir,
-		Env:     append(runtimeSetup.Env, opts.Env...),
+		Env:     execx.MergeEnv(c.baseEnv(), append(runtimeSetup.Env, opts.Env...)),
 		Timeout: timeout,
 	})
 	if err == nil {

--- a/internal/kaggle/client.go
+++ b/internal/kaggle/client.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os/exec"
 	"time"
+
+	"github.com/shotomorisk/kgh/internal/execx"
 )
 
 const defaultTimeout = 30 * time.Second
@@ -15,7 +17,6 @@ type Client struct {
 	runner         Runner
 	env            EnvSource
 	lookPath       LookPathFunc
-	baseEnv        func() []string
 	defaultTimeout time.Duration
 }
 
@@ -65,13 +66,13 @@ func (e *TimeoutError) Unwrap() error { return e.Err }
 
 // NewClient constructs a Kaggle CLI adapter with production dependencies.
 func NewClient() *Client {
-	return NewClientWithDeps(execRunner{}, osEnvSource{}, exec.LookPath, currentEnv, defaultTimeout)
+	return NewClientWithDeps(nil, osEnvSource{}, exec.LookPath, currentEnv, defaultTimeout)
 }
 
 // NewClientWithDeps constructs a Kaggle CLI adapter with injected dependencies for tests.
 func NewClientWithDeps(runner Runner, env EnvSource, lookPath LookPathFunc, baseEnv func() []string, timeout time.Duration) *Client {
 	if runner == nil {
-		runner = execRunner{}
+		runner = execx.NewRunnerWithBaseEnv(baseEnv)
 	}
 	if env == nil {
 		env = osEnvSource{}
@@ -90,7 +91,6 @@ func NewClientWithDeps(runner Runner, env EnvSource, lookPath LookPathFunc, base
 		runner:         runner,
 		env:            env,
 		lookPath:       lookPath,
-		baseEnv:        baseEnv,
 		defaultTimeout: timeout,
 	}
 }
@@ -121,21 +121,22 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 		timeout = c.defaultTimeout
 	}
 
-	runCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+	command := command{
+		Path: binaryPath,
+		Args: append([]string(nil), args...),
+	}
 
-	command := buildCommand(binaryPath, args, c.baseEnv(), RunOptions{
+	result, err := c.runner.Run(ctx, command, RunOptions{
 		Dir:     opts.Dir,
 		Env:     append(runtimeSetup.Env, opts.Env...),
 		Timeout: timeout,
 	})
-
-	result, err := c.runner.Run(runCtx, command)
 	if err == nil {
 		return result, nil
 	}
 
-	if errors.Is(runCtx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
+	var timeoutErr *execx.TimeoutError
+	if errors.As(err, &timeoutErr) {
 		return result, &TimeoutError{
 			Args:    append([]string(nil), args...),
 			Timeout: timeout,
@@ -143,7 +144,8 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 		}
 	}
 
-	if result.ExitCode != 0 {
+	var exitErr *execx.ExitError
+	if errors.As(err, &exitErr) {
 		return result, &CommandError{
 			Args:     append([]string(nil), args...),
 			ExitCode: result.ExitCode,

--- a/internal/kaggle/client_test.go
+++ b/internal/kaggle/client_test.go
@@ -30,6 +30,7 @@ func TestClientRunSuccess(t *testing.T) {
 			if opts.Timeout != 30*time.Second {
 				t.Fatalf("unexpected timeout %s", opts.Timeout)
 			}
+			assertEnvContains(t, opts.Env, "PATH", "/usr/bin")
 			assertEnvContains(t, opts.Env, "HOME", "/tmp/home")
 			assertEnvMissing(t, opts.Env, envKaggleAPIToken)
 			assertEnvMissing(t, opts.Env, envKaggleUsername)
@@ -104,6 +105,34 @@ func TestClientRunUsesDefaultTimeout(t *testing.T) {
 	)
 
 	if _, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{}); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestClientRunAppliesBaseEnvForCustomRunner(t *testing.T) {
+	t.Parallel()
+
+	client := NewClientWithDeps(
+		&clientFakeRunner{
+			t: t,
+			runFn: func(_ context.Context, _ command, opts RunOptions) (Result, error) {
+				assertEnvContains(t, opts.Env, "PATH", "/usr/bin")
+				assertEnvContains(t, opts.Env, "HOME", "/override/home")
+				return Result{}, nil
+			},
+		},
+		staticEnvSource{
+			envKaggleUsername: "alice",
+			envKaggleKey:      "secret-key",
+		},
+		func(string) (string, error) { return "/usr/local/bin/kaggle", nil },
+		func() []string { return []string{"PATH=/usr/bin", "HOME=/base/home"} },
+		time.Second,
+	)
+
+	if _, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{
+		Env: []string{"HOME=/override/home"},
+	}); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 }

--- a/internal/kaggle/client_test.go
+++ b/internal/kaggle/client_test.go
@@ -17,7 +17,7 @@ func TestClientRunSuccess(t *testing.T) {
 
 	runner := &clientFakeRunner{
 		t: t,
-		runFn: func(_ context.Context, cmd command, opts RunOptions) (Result, error) {
+		runFn: func(ctx context.Context, cmd command, opts RunOptions) (Result, error) {
 			if cmd.Path != "/usr/local/bin/kaggle" {
 				t.Fatalf("unexpected path %q", cmd.Path)
 			}
@@ -45,6 +45,9 @@ func TestClientRunSuccess(t *testing.T) {
 				if !strings.Contains(string(payload), `"username":"alice"`) || !strings.Contains(string(payload), `"key":"secret-key"`) {
 					t.Fatalf("unexpected kaggle.json content %q", string(payload))
 				}
+			}
+			if _, ok := ctx.Deadline(); !ok {
+				t.Fatal("expected deadline to be set")
 			}
 			return Result{
 				Stdout:   "ok",
@@ -88,7 +91,10 @@ func TestClientRunUsesDefaultTimeout(t *testing.T) {
 	client := NewClientWithDeps(
 		&clientFakeRunner{
 			t: t,
-			runFn: func(_ context.Context, _ command, opts RunOptions) (Result, error) {
+			runFn: func(ctx context.Context, _ command, opts RunOptions) (Result, error) {
+				if _, ok := ctx.Deadline(); !ok {
+					t.Fatal("expected deadline to be set")
+				}
 				if opts.Timeout != 2*time.Second {
 					t.Fatalf("unexpected timeout %s", opts.Timeout)
 				}
@@ -115,7 +121,10 @@ func TestClientRunAppliesBaseEnvForCustomRunner(t *testing.T) {
 	client := NewClientWithDeps(
 		&clientFakeRunner{
 			t: t,
-			runFn: func(_ context.Context, _ command, opts RunOptions) (Result, error) {
+			runFn: func(ctx context.Context, _ command, opts RunOptions) (Result, error) {
+				if _, ok := ctx.Deadline(); !ok {
+					t.Fatal("expected deadline to be set")
+				}
 				assertEnvContains(t, opts.Env, "PATH", "/usr/bin")
 				assertEnvContains(t, opts.Env, "HOME", "/override/home")
 				return Result{}, nil
@@ -143,7 +152,10 @@ func TestClientRunUsesExplicitTimeoutOverride(t *testing.T) {
 	client := NewClientWithDeps(
 		&clientFakeRunner{
 			t: t,
-			runFn: func(_ context.Context, _ command, opts RunOptions) (Result, error) {
+			runFn: func(ctx context.Context, _ command, opts RunOptions) (Result, error) {
+				if _, ok := ctx.Deadline(); !ok {
+					t.Fatal("expected deadline to be set")
+				}
 				if opts.Timeout != time.Second {
 					t.Fatalf("unexpected timeout %s", opts.Timeout)
 				}
@@ -172,11 +184,9 @@ func TestClientRunClassifiesTimeout(t *testing.T) {
 	client := NewClientWithDeps(
 		&clientFakeRunner{
 			t: t,
-			runFn: func(context.Context, command, RunOptions) (Result, error) {
-				return Result{}, &execx.TimeoutError{
-					Timeout: 10 * time.Millisecond,
-					Err:     context.DeadlineExceeded,
-				}
+			runFn: func(ctx context.Context, _ command, _ RunOptions) (Result, error) {
+				<-ctx.Done()
+				return Result{}, ctx.Err()
 			},
 		},
 		staticEnvSource{

--- a/internal/kaggle/client_test.go
+++ b/internal/kaggle/client_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/shotomorisk/kgh/internal/execx"
 )
 
 func TestClientRunSuccess(t *testing.T) {
@@ -15,23 +17,25 @@ func TestClientRunSuccess(t *testing.T) {
 
 	runner := &clientFakeRunner{
 		t: t,
-		runFn: func(ctx context.Context, cmd command) (Result, error) {
+		runFn: func(_ context.Context, cmd command, opts RunOptions) (Result, error) {
 			if cmd.Path != "/usr/local/bin/kaggle" {
 				t.Fatalf("unexpected path %q", cmd.Path)
 			}
-			if !equalStrings(cmd.Args, []string{"/usr/local/bin/kaggle", "kernels", "status"}) {
+			if !equalStrings(cmd.Args, []string{"kernels", "status"}) {
 				t.Fatalf("unexpected args %#v", cmd.Args)
 			}
-			if cmd.Dir != "/repo" {
-				t.Fatalf("unexpected dir %q", cmd.Dir)
+			if opts.Dir != "/repo" {
+				t.Fatalf("unexpected dir %q", opts.Dir)
 			}
-			assertEnvContains(t, cmd.Env, "PATH", "/usr/bin")
-			assertEnvContains(t, cmd.Env, "HOME", "/tmp/home")
-			assertEnvMissing(t, cmd.Env, envKaggleAPIToken)
-			assertEnvMissing(t, cmd.Env, envKaggleUsername)
-			assertEnvMissing(t, cmd.Env, envKaggleKey)
-			if dir := envValue(cmd.Env, envKaggleConfigDir); dir == "" {
-				t.Fatalf("expected %s to be set in %#v", envKaggleConfigDir, cmd.Env)
+			if opts.Timeout != 30*time.Second {
+				t.Fatalf("unexpected timeout %s", opts.Timeout)
+			}
+			assertEnvContains(t, opts.Env, "HOME", "/tmp/home")
+			assertEnvMissing(t, opts.Env, envKaggleAPIToken)
+			assertEnvMissing(t, opts.Env, envKaggleUsername)
+			assertEnvMissing(t, opts.Env, envKaggleKey)
+			if dir := envValue(opts.Env, envKaggleConfigDir); dir == "" {
+				t.Fatalf("expected %s to be set in %#v", envKaggleConfigDir, opts.Env)
 			} else {
 				payload, err := os.ReadFile(filepath.Join(dir, kaggleJSONFilename))
 				if err != nil {
@@ -40,9 +44,6 @@ func TestClientRunSuccess(t *testing.T) {
 				if !strings.Contains(string(payload), `"username":"alice"`) || !strings.Contains(string(payload), `"key":"secret-key"`) {
 					t.Fatalf("unexpected kaggle.json content %q", string(payload))
 				}
-			}
-			if _, ok := ctx.Deadline(); !ok {
-				t.Fatal("expected context deadline to be set")
 			}
 			return Result{
 				Stdout:   "ok",
@@ -64,12 +65,7 @@ func TestClientRunSuccess(t *testing.T) {
 			}
 			return "/usr/local/bin/kaggle", nil
 		},
-		func() []string {
-			return []string{
-				"PATH=/usr/bin",
-				"HOME=/base/home",
-			}
-		},
+		func() []string { return []string{"PATH=/usr/bin", "HOME=/base/home"} },
 		30*time.Second,
 	)
 
@@ -91,14 +87,9 @@ func TestClientRunUsesDefaultTimeout(t *testing.T) {
 	client := NewClientWithDeps(
 		&clientFakeRunner{
 			t: t,
-			runFn: func(ctx context.Context, cmd command) (Result, error) {
-				deadline, ok := ctx.Deadline()
-				if !ok {
-					t.Fatal("expected deadline to be set")
-				}
-				remaining := time.Until(deadline)
-				if remaining <= 0 || remaining > 5*time.Second {
-					t.Fatalf("unexpected deadline window %s", remaining)
+			runFn: func(_ context.Context, _ command, opts RunOptions) (Result, error) {
+				if opts.Timeout != 2*time.Second {
+					t.Fatalf("unexpected timeout %s", opts.Timeout)
 				}
 				return Result{}, nil
 			},
@@ -123,14 +114,9 @@ func TestClientRunUsesExplicitTimeoutOverride(t *testing.T) {
 	client := NewClientWithDeps(
 		&clientFakeRunner{
 			t: t,
-			runFn: func(ctx context.Context, cmd command) (Result, error) {
-				deadline, ok := ctx.Deadline()
-				if !ok {
-					t.Fatal("expected deadline to be set")
-				}
-				remaining := time.Until(deadline)
-				if remaining <= 0 || remaining > 1500*time.Millisecond {
-					t.Fatalf("unexpected deadline window %s", remaining)
+			runFn: func(_ context.Context, _ command, opts RunOptions) (Result, error) {
+				if opts.Timeout != time.Second {
+					t.Fatalf("unexpected timeout %s", opts.Timeout)
 				}
 				return Result{}, nil
 			},
@@ -157,9 +143,11 @@ func TestClientRunClassifiesTimeout(t *testing.T) {
 	client := NewClientWithDeps(
 		&clientFakeRunner{
 			t: t,
-			runFn: func(ctx context.Context, cmd command) (Result, error) {
-				<-ctx.Done()
-				return Result{}, ctx.Err()
+			runFn: func(context.Context, command, RunOptions) (Result, error) {
+				return Result{}, &execx.TimeoutError{
+					Timeout: 10 * time.Millisecond,
+					Err:     context.DeadlineExceeded,
+				}
 			},
 		},
 		staticEnvSource{
@@ -191,12 +179,16 @@ func TestClientRunClassifiesCommandFailure(t *testing.T) {
 	client := NewClientWithDeps(
 		&clientFakeRunner{
 			t: t,
-			runFn: func(context.Context, command) (Result, error) {
-				return Result{
+			runFn: func(context.Context, command, RunOptions) (Result, error) {
+				result := Result{
 					Stdout:   "partial output",
 					Stderr:   "bad things happened",
 					ExitCode: 2,
-				}, errors.New("exit status 2")
+				}
+				return result, &execx.ExitError{
+					Result: result,
+					Err:    errors.New("exit status 2"),
+				}
 			},
 		},
 		staticEnvSource{
@@ -260,16 +252,18 @@ func TestClientRunSupportsTokenAuth(t *testing.T) {
 
 	runner := &clientFakeRunner{
 		t: t,
-		runFn: func(ctx context.Context, cmd command) (Result, error) {
-			if !equalStrings(cmd.Args, []string{"/usr/local/bin/kaggle", "kernels", "status"}) {
+		runFn: func(_ context.Context, cmd command, opts RunOptions) (Result, error) {
+			if !equalStrings(cmd.Args, []string{"kernels", "status"}) {
 				t.Fatalf("unexpected args %#v", cmd.Args)
 			}
-			assertEnvContains(t, cmd.Env, "PATH", "/usr/bin")
-			assertEnvMissing(t, cmd.Env, envKaggleAPIToken)
-			assertEnvMissing(t, cmd.Env, envKaggleUsername)
-			assertEnvMissing(t, cmd.Env, envKaggleKey)
-			if dir := envValue(cmd.Env, envKaggleConfigDir); dir == "" {
-				t.Fatalf("expected %s to be set in %#v", envKaggleConfigDir, cmd.Env)
+			if opts.Timeout != time.Second {
+				t.Fatalf("unexpected timeout %s", opts.Timeout)
+			}
+			assertEnvMissing(t, opts.Env, envKaggleAPIToken)
+			assertEnvMissing(t, opts.Env, envKaggleUsername)
+			assertEnvMissing(t, opts.Env, envKaggleKey)
+			if dir := envValue(opts.Env, envKaggleConfigDir); dir == "" {
+				t.Fatalf("expected %s to be set in %#v", envKaggleConfigDir, opts.Env)
 			} else {
 				token, err := os.ReadFile(filepath.Join(dir, accessTokenFilename))
 				if err != nil {
@@ -278,9 +272,6 @@ func TestClientRunSupportsTokenAuth(t *testing.T) {
 				if string(token) != "secret-token" {
 					t.Fatalf("unexpected token file content %q", string(token))
 				}
-			}
-			if _, ok := ctx.Deadline(); !ok {
-				t.Fatal("expected context deadline to be set")
 			}
 			return Result{ExitCode: 0}, nil
 		},
@@ -303,14 +294,14 @@ func TestClientRunSupportsTokenAuth(t *testing.T) {
 
 type clientFakeRunner struct {
 	t     *testing.T
-	runFn func(context.Context, command) (Result, error)
+	runFn func(context.Context, command, RunOptions) (Result, error)
 }
 
-func (f *clientFakeRunner) Run(ctx context.Context, cmd command) (Result, error) {
+func (f *clientFakeRunner) Run(ctx context.Context, cmd command, opts RunOptions) (Result, error) {
 	if f.runFn == nil {
 		f.t.Fatal("runFn must be set")
 	}
-	return f.runFn(ctx, cmd)
+	return f.runFn(ctx, cmd, opts)
 }
 
 func envValue(env []string, key string) string {

--- a/internal/kaggle/doc.go
+++ b/internal/kaggle/doc.go
@@ -4,6 +4,6 @@
 // Client is a lower-level Kaggle CLI executor that concrete adapters can build on.
 //
 // The package remains intentionally thin. It resolves Kaggle credentials,
-// invokes the official kaggle binary with timeouts, captures process output, and
-// returns typed errors that higher layers can surface cleanly.
+// delegates external command execution to internal/execx, and returns typed
+// errors that higher layers can surface cleanly.
 package kaggle

--- a/internal/kaggle/runner.go
+++ b/internal/kaggle/runner.go
@@ -1,45 +1,26 @@
 package kaggle
 
 import (
-	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
-	"slices"
-	"strings"
-	"syscall"
-	"time"
+
+	"github.com/shotomorisk/kgh/internal/execx"
 )
 
 const kaggleBinary = "kaggle"
 
 // RunOptions configures a Kaggle CLI process execution.
-type RunOptions struct {
-	Timeout time.Duration
-	Dir     string
-	Env     []string
-}
+type RunOptions = execx.Options
 
 // Result captures the observable output from a Kaggle CLI process.
-type Result struct {
-	Stdout   string
-	Stderr   string
-	ExitCode int
-}
+type Result = execx.Result
 
-type command struct {
-	Path string
-	Args []string
-	Dir  string
-	Env  []string
-}
+type command = execx.Command
 
 // Runner executes a prepared process invocation.
-type Runner interface {
-	Run(context.Context, command) (Result, error)
-}
+type Runner = execx.Runner
 
 // LookPathFunc resolves an executable from PATH.
 type LookPathFunc func(string) (string, error)
@@ -69,83 +50,6 @@ func resolveExecutable(name string, lookPath LookPathFunc) (string, error) {
 		return "", &ExecutableNotFoundError{Name: name}
 	}
 	return "", fmt.Errorf("resolve executable %q: %w", name, err)
-}
-
-func buildCommand(path string, args []string, baseEnv []string, opts RunOptions) command {
-	return command{
-		Path: path,
-		Args: append([]string{path}, args...),
-		Dir:  opts.Dir,
-		Env:  mergeEnv(baseEnv, opts.Env),
-	}
-}
-
-func mergeEnv(base []string, extra []string) []string {
-	merged := slices.Clone(base)
-	if len(extra) == 0 {
-		return merged
-	}
-
-	indexByKey := make(map[string]int, len(merged))
-	for i, entry := range merged {
-		key, _, ok := strings.Cut(entry, "=")
-		if !ok {
-			continue
-		}
-		indexByKey[key] = i
-	}
-
-	for _, entry := range extra {
-		key, _, ok := strings.Cut(entry, "=")
-		if !ok {
-			merged = append(merged, entry)
-			continue
-		}
-		if idx, exists := indexByKey[key]; exists {
-			merged[idx] = entry
-			continue
-		}
-		indexByKey[key] = len(merged)
-		merged = append(merged, entry)
-	}
-
-	return merged
-}
-
-type execRunner struct{}
-
-func (execRunner) Run(ctx context.Context, cmd command) (Result, error) {
-	execCmd := exec.CommandContext(ctx, cmd.Path, cmd.Args[1:]...)
-	execCmd.Dir = cmd.Dir
-	execCmd.Env = cmd.Env
-
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	execCmd.Stdout = &stdout
-	execCmd.Stderr = &stderr
-
-	err := execCmd.Run()
-
-	result := Result{
-		Stdout: stdout.String(),
-		Stderr: stderr.String(),
-	}
-
-	if execCmd.ProcessState != nil {
-		result.ExitCode = execCmd.ProcessState.ExitCode()
-	}
-
-	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
-				result.ExitCode = status.ExitStatus()
-			}
-		}
-		return result, err
-	}
-
-	return result, nil
 }
 
 func currentEnv() []string {

--- a/internal/kaggle/runner_test.go
+++ b/internal/kaggle/runner_test.go
@@ -1,12 +1,9 @@
 package kaggle
 
 import (
-	"context"
 	"errors"
 	"os/exec"
-	"reflect"
 	"testing"
-	"time"
 )
 
 func TestResolveExecutable(t *testing.T) {
@@ -40,66 +37,4 @@ func TestResolveExecutableMissing(t *testing.T) {
 	if !errors.As(err, &notFoundErr) {
 		t.Fatalf("expected ExecutableNotFoundError, got %T", err)
 	}
-}
-
-func TestBuildCommandMergesEnvironment(t *testing.T) {
-	t.Parallel()
-
-	cmd := buildCommand("/usr/local/bin/kaggle", []string{"kernels", "status"}, []string{
-		"PATH=/usr/bin",
-		"HOME=/tmp/home",
-	}, RunOptions{
-		Dir: "/work",
-		Env: []string{
-			"HOME=/override/home",
-			"KAGGLE_USERNAME=alice",
-		},
-		Timeout: 5 * time.Second,
-	})
-
-	if cmd.Path != "/usr/local/bin/kaggle" {
-		t.Fatalf("unexpected path %q", cmd.Path)
-	}
-	if !reflect.DeepEqual(cmd.Args, []string{"/usr/local/bin/kaggle", "kernels", "status"}) {
-		t.Fatalf("unexpected args %#v", cmd.Args)
-	}
-	if cmd.Dir != "/work" {
-		t.Fatalf("unexpected dir %q", cmd.Dir)
-	}
-	wantEnv := []string{
-		"PATH=/usr/bin",
-		"HOME=/override/home",
-		"KAGGLE_USERNAME=alice",
-	}
-	if !reflect.DeepEqual(cmd.Env, wantEnv) {
-		t.Fatalf("unexpected env %#v", cmd.Env)
-	}
-}
-
-func TestMergeEnvDoesNotMutateBase(t *testing.T) {
-	t.Parallel()
-
-	base := []string{"PATH=/usr/bin", "HOME=/tmp/home"}
-	got := mergeEnv(base, []string{"HOME=/override/home"})
-	if !reflect.DeepEqual(base, []string{"PATH=/usr/bin", "HOME=/tmp/home"}) {
-		t.Fatalf("base environment was mutated: %#v", base)
-	}
-	if !reflect.DeepEqual(got, []string{"PATH=/usr/bin", "HOME=/override/home"}) {
-		t.Fatalf("unexpected merged environment %#v", got)
-	}
-}
-
-type fakeRunner struct {
-	t      *testing.T
-	result Result
-	err    error
-	seen   command
-}
-
-func (f *fakeRunner) Run(_ context.Context, cmd command) (Result, error) {
-	if f.t == nil {
-		panic("fakeRunner.t must be set")
-	}
-	f.seen = cmd
-	return f.result, f.err
 }


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #10 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented the shared command runner in internal/execx/exec.go and moved Kaggle onto it via internal/kaggle/
  client.go and internal/kaggle/runner.go. The new utility executes external commands, captures stdout/stderr
  separately, returns structured results with exit status, treats non-zero exits as typed errors, supports parent
  context cancellation, and enforces timeouts.

  Tests were added/updated in internal/execx/exec_test.go and internal/kaggle/client_test.go. I ran go test ./
  internal/kaggle ./... successfully.
<!-- close -->