### PR TITLE
Kaggle adapter normalization and safe diagnostics path

### DIFF
--- a/internal/kaggle/adapter.go
+++ b/internal/kaggle/adapter.go
@@ -1,9 +1,13 @@
 package kaggle
 
 import (
+	"bufio"
 	"context"
+	"encoding/csv"
 	"errors"
 	"fmt"
+	"io"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -19,6 +23,7 @@ type Adapter interface {
 
 type PushKernelRequest struct {
 	WorkDir string
+	Debug   bool
 }
 
 type PushKernelResponse struct {
@@ -27,6 +32,7 @@ type PushKernelResponse struct {
 
 type KernelStatusRequest struct {
 	KernelRef string
+	Debug     bool
 }
 
 type KernelStatusResponse struct {
@@ -38,6 +44,7 @@ type KernelStatusResponse struct {
 type DownloadKernelOutputRequest struct {
 	KernelRef string
 	OutputDir string
+	Debug     bool
 }
 
 type DownloadKernelOutputResponse struct {
@@ -48,6 +55,7 @@ type CompetitionSubmitRequest struct {
 	Competition string
 	FilePath    string
 	Message     string
+	Debug       bool
 }
 
 type CompetitionSubmitResponse struct {
@@ -58,6 +66,7 @@ type CompetitionSubmitResponse struct {
 type CompetitionSubmissionsRequest struct {
 	Competition string
 	Limit       int
+	Debug       bool
 }
 
 type CompetitionSubmissionsResponse struct {
@@ -94,7 +103,7 @@ func (a *CLIAdapter) PushKernel(ctx context.Context, req PushKernelRequest) (Pus
 	if err != nil {
 		return PushKernelResponse{}, err
 	}
-	if _, err := a.run(ctx, args); err != nil {
+	if _, err := a.run(ctx, "push kernel", args, req.Debug); err != nil {
 		return PushKernelResponse{}, err
 	}
 	return PushKernelResponse{}, nil
@@ -105,10 +114,15 @@ func (a *CLIAdapter) KernelStatus(ctx context.Context, req KernelStatusRequest) 
 	if err != nil {
 		return KernelStatusResponse{}, err
 	}
-	if _, err := a.run(ctx, args); err != nil {
+	result, err := a.run(ctx, "kernel status", args, req.Debug)
+	if err != nil {
 		return KernelStatusResponse{}, err
 	}
-	return KernelStatusResponse{KernelRef: req.KernelRef}, nil
+	resp, err := parseKernelStatusResult(req.KernelRef, result)
+	if err != nil {
+		return KernelStatusResponse{}, err
+	}
+	return resp, nil
 }
 
 func (a *CLIAdapter) DownloadKernelOutput(ctx context.Context, req DownloadKernelOutputRequest) (DownloadKernelOutputResponse, error) {
@@ -116,7 +130,7 @@ func (a *CLIAdapter) DownloadKernelOutput(ctx context.Context, req DownloadKerne
 	if err != nil {
 		return DownloadKernelOutputResponse{}, err
 	}
-	if _, err := a.run(ctx, args); err != nil {
+	if _, err := a.run(ctx, "download kernel output", args, req.Debug); err != nil {
 		return DownloadKernelOutputResponse{}, err
 	}
 	return DownloadKernelOutputResponse{OutputDir: req.OutputDir}, nil
@@ -127,7 +141,7 @@ func (a *CLIAdapter) SubmitCompetition(ctx context.Context, req CompetitionSubmi
 	if err != nil {
 		return CompetitionSubmitResponse{}, err
 	}
-	if _, err := a.run(ctx, args); err != nil {
+	if _, err := a.run(ctx, "submit competition", args, req.Debug); err != nil {
 		return CompetitionSubmitResponse{}, err
 	}
 	return CompetitionSubmitResponse{
@@ -141,17 +155,26 @@ func (a *CLIAdapter) ListCompetitionSubmissions(ctx context.Context, req Competi
 	if err != nil {
 		return CompetitionSubmissionsResponse{}, err
 	}
-	if _, err := a.run(ctx, args); err != nil {
+	result, err := a.run(ctx, "list competition submissions", args, req.Debug)
+	if err != nil {
 		return CompetitionSubmissionsResponse{}, err
 	}
-	return CompetitionSubmissionsResponse{}, nil
+	resp, err := parseCompetitionSubmissionsResult(result)
+	if err != nil {
+		return CompetitionSubmissionsResponse{}, err
+	}
+	return resp, nil
 }
 
-func (a *CLIAdapter) run(ctx context.Context, args []string) (Result, error) {
+func (a *CLIAdapter) run(ctx context.Context, operation string, args []string, debug bool) (Result, error) {
 	if a == nil || a.client == nil {
 		return Result{}, fmt.Errorf("kaggle adapter client is nil")
 	}
-	return a.client.Run(ctx, args, RunOptions{})
+	result, err := a.client.Run(ctx, args, RunOptions{Debug: debug})
+	if err != nil {
+		return result, normalizeAdapterError(operation, err)
+	}
+	return result, nil
 }
 
 // StubAdapter is a compile-ready placeholder implementation for tests and wiring.
@@ -246,4 +269,199 @@ func requiredValue(field string, value string) (string, error) {
 
 func unsupportedRequest(detail string) error {
 	return fmt.Errorf("%w: %s", ErrUnsupportedRequest, detail)
+}
+
+func parseKernelStatusResult(kernelRef string, result Result) (KernelStatusResponse, error) {
+	fields := parseKeyValueOutput(result.Stdout)
+	status := firstNonEmpty(fields["status"], inferStatus(result.Stdout))
+	message := firstNonEmpty(fields["message"], fields["error"])
+	if strings.TrimSpace(status) == "" {
+		return KernelStatusResponse{}, unexpectedOutputError("kernel status", result, "missing status field")
+	}
+	return KernelStatusResponse{
+		KernelRef: kernelRef,
+		Status:    strings.TrimSpace(status),
+		Message:   strings.TrimSpace(message),
+	}, nil
+}
+
+func parseCompetitionSubmissionsResult(result Result) (CompetitionSubmissionsResponse, error) {
+	output := strings.TrimSpace(result.Stdout)
+	if output == "" {
+		return CompetitionSubmissionsResponse{}, nil
+	}
+	rows, err := readDelimitedRows(output)
+	if err != nil {
+		return CompetitionSubmissionsResponse{}, unexpectedOutputError("list competition submissions", result, err.Error())
+	}
+	if len(rows) == 0 {
+		return CompetitionSubmissionsResponse{}, nil
+	}
+	header := normalizeHeader(rows[0])
+	required := []string{"file", "description", "date", "status", "publicscore"}
+	for _, name := range required {
+		if _, ok := header[name]; !ok {
+			return CompetitionSubmissionsResponse{}, unexpectedOutputError("list competition submissions", result, "missing submissions header")
+		}
+	}
+
+	submissions := make([]CompetitionSubmission, 0, len(rows)-1)
+	for _, row := range rows[1:] {
+		if len(row) == 0 {
+			continue
+		}
+		submission := CompetitionSubmission{
+			FileName:    valueAt(row, header, "file"),
+			Description: valueAt(row, header, "description"),
+			Status:      valueAt(row, header, "status"),
+			PublicScore: valueAt(row, header, "publicscore"),
+		}
+		date := valueAt(row, header, "date")
+		if strings.TrimSpace(date) != "" {
+			parsed, err := parseSubmissionTime(date)
+			if err != nil {
+				return CompetitionSubmissionsResponse{}, unexpectedOutputError("list competition submissions", result, "invalid submission date")
+			}
+			submission.SubmittedAt = parsed
+		}
+		submissions = append(submissions, submission)
+	}
+	return CompetitionSubmissionsResponse{Submissions: submissions}, nil
+}
+
+func parseKeyValueOutput(output string) map[string]string {
+	values := make(map[string]string)
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		key = strings.ToLower(strings.ReplaceAll(strings.TrimSpace(key), " ", ""))
+		values[key] = strings.TrimSpace(value)
+	}
+	return values
+}
+
+func inferStatus(output string) string {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		lower := strings.ToLower(line)
+		index := strings.Index(lower, "status")
+		if index == -1 {
+			continue
+		}
+		value := strings.TrimSpace(line[index+len("status"):])
+		value = strings.TrimLeft(value, " :=-\"'")
+		value = strings.TrimRight(value, "\"'")
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func readDelimitedRows(output string) ([][]string, error) {
+	delimiter := detectDelimiter(output)
+	reader := csv.NewReader(strings.NewReader(output))
+	reader.TrimLeadingSpace = true
+	reader.FieldsPerRecord = -1
+	reader.LazyQuotes = true
+	reader.Comma = delimiter
+
+	rows := make([][]string, 0)
+	for {
+		record, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			return rows, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		trimmed := trimRow(record)
+		if len(trimmed) == 0 {
+			continue
+		}
+		rows = append(rows, trimmed)
+	}
+}
+
+func detectDelimiter(output string) rune {
+	firstLine := output
+	if index := strings.IndexByte(output, '\n'); index >= 0 {
+		firstLine = output[:index]
+	}
+	switch {
+	case strings.Contains(firstLine, "\t"):
+		return '\t'
+	case strings.Contains(firstLine, "|"):
+		return '|'
+	default:
+		return ','
+	}
+}
+
+func trimRow(row []string) []string {
+	trimmed := make([]string, 0, len(row))
+	for _, value := range row {
+		value = strings.TrimSpace(strings.Trim(value, `"`))
+		trimmed = append(trimmed, value)
+	}
+	if len(trimmed) == 1 && trimmed[0] == "" {
+		return nil
+	}
+	return trimmed
+}
+
+func normalizeHeader(row []string) map[string]int {
+	header := make(map[string]int, len(row))
+	for i, value := range row {
+		key := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), " ", ""))
+		header[key] = i
+	}
+	return header
+}
+
+func valueAt(row []string, header map[string]int, key string) string {
+	index, ok := header[key]
+	if !ok || index >= len(row) {
+		return ""
+	}
+	return row[index]
+}
+
+func parseSubmissionTime(value string) (time.Time, error) {
+	layouts := []string{
+		time.RFC3339,
+		"2006-01-02 15:04:05",
+		"2006-01-02 15:04",
+		"2006-01-02",
+	}
+	for _, layout := range layouts {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsed, nil
+		}
+	}
+	if unix, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return time.Unix(unix, 0).UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("parse submission time")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/internal/kaggle/adapter_test.go
+++ b/internal/kaggle/adapter_test.go
@@ -59,7 +59,7 @@ func TestCLIAdapterKernelStatus(t *testing.T) {
 				t.Fatalf("unexpected args %#v", args)
 			}
 			assertZeroRunOptions(t, opts)
-			return Result{}, nil
+			return Result{Stdout: "status: complete\nmessage: finished\n"}, nil
 		},
 	}
 
@@ -72,8 +72,8 @@ func TestCLIAdapterKernelStatus(t *testing.T) {
 	if resp.KernelRef != "alice/exp142" {
 		t.Fatalf("unexpected kernel ref %q", resp.KernelRef)
 	}
-	if resp.Status != "" || resp.Message != "" {
-		t.Fatalf("expected zero-value status response, got %+v", resp)
+	if resp.Status != "complete" || resp.Message != "finished" {
+		t.Fatalf("unexpected status response %+v", resp)
 	}
 }
 
@@ -141,7 +141,7 @@ func TestCLIAdapterListCompetitionSubmissions(t *testing.T) {
 				t.Fatalf("unexpected args %#v", args)
 			}
 			assertZeroRunOptions(t, opts)
-			return Result{}, nil
+			return Result{Stdout: "file,description,date,status,publicScore\nsubmission.csv,submit from PR #12,2026-04-14T10:00:00Z,complete,0.12345\n"}, nil
 		},
 	}
 
@@ -151,8 +151,11 @@ func TestCLIAdapterListCompetitionSubmissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if len(resp.Submissions) != 0 {
-		t.Fatalf("expected empty submissions, got %+v", resp.Submissions)
+	if len(resp.Submissions) != 1 {
+		t.Fatalf("expected one submission, got %+v", resp.Submissions)
+	}
+	if resp.Submissions[0].FileName != "submission.csv" || resp.Submissions[0].PublicScore != "0.12345" {
+		t.Fatalf("unexpected submission %+v", resp.Submissions[0])
 	}
 }
 
@@ -175,7 +178,155 @@ func TestCLIAdapterPropagatesClientErrors(t *testing.T) {
 		KernelRef: "alice/exp142",
 	})
 	if !errors.Is(err, wantErr) {
-		t.Fatalf("expected %v, got %v", wantErr, err)
+		t.Fatalf("expected wrapped %v, got %v", wantErr, err)
+	}
+	var adapterErr *AdapterError
+	if !errors.As(err, &adapterErr) {
+		t.Fatalf("expected AdapterError, got %T", err)
+	}
+	if adapterErr.Category != ErrorCategoryCommandFailed {
+		t.Fatalf("unexpected category %q", adapterErr.Category)
+	}
+}
+
+func TestCLIAdapterNormalizesMissingCredentials(t *testing.T) {
+	t.Parallel()
+
+	fake := &adapterFakeClient{
+		t: t,
+		runFn: func(_ context.Context, _ []string, _ RunOptions) (Result, error) {
+			return Result{}, &MissingCredentialsError{Missing: []string{envKaggleUsername}}
+		},
+	}
+
+	_, err := (&CLIAdapter{client: fake}).PushKernel(context.Background(), PushKernelRequest{WorkDir: "/tmp/work"})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var adapterErr *AdapterError
+	if !errors.As(err, &adapterErr) {
+		t.Fatalf("expected AdapterError, got %T", err)
+	}
+	if adapterErr.Category != ErrorCategoryMissingCredentials {
+		t.Fatalf("unexpected category %q", adapterErr.Category)
+	}
+}
+
+func TestCLIAdapterNormalizesPermissionDenied(t *testing.T) {
+	t.Parallel()
+
+	fake := &adapterFakeClient{
+		t: t,
+		runFn: func(_ context.Context, _ []string, _ RunOptions) (Result, error) {
+			return Result{}, &CommandError{
+				ExitCode: 1,
+				Stderr:   "403 Forbidden: you must accept the competition rules",
+				Err:      errors.New("exit status 1"),
+			}
+		},
+	}
+
+	_, err := (&CLIAdapter{client: fake}).SubmitCompetition(context.Background(), CompetitionSubmitRequest{
+		Competition: "playground-series-s6e2",
+		FilePath:    "/tmp/submission.csv",
+		Message:     "submit",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var adapterErr *AdapterError
+	if !errors.As(err, &adapterErr) {
+		t.Fatalf("expected AdapterError, got %T", err)
+	}
+	if adapterErr.Category != ErrorCategoryPermissionDenied {
+		t.Fatalf("unexpected category %q", adapterErr.Category)
+	}
+	if adapterErr.Stderr == "" {
+		t.Fatal("expected stderr to be preserved")
+	}
+}
+
+func TestCLIAdapterNormalizesInvalidReference(t *testing.T) {
+	t.Parallel()
+
+	fake := &adapterFakeClient{
+		t: t,
+		runFn: func(_ context.Context, _ []string, _ RunOptions) (Result, error) {
+			return Result{}, &CommandError{
+				ExitCode: 1,
+				Stderr:   "404 Not Found: invalid competition slug",
+				Err:      errors.New("exit status 1"),
+			}
+		},
+	}
+
+	_, err := (&CLIAdapter{client: fake}).ListCompetitionSubmissions(context.Background(), CompetitionSubmissionsRequest{
+		Competition: "missing-comp",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var adapterErr *AdapterError
+	if !errors.As(err, &adapterErr) {
+		t.Fatalf("expected AdapterError, got %T", err)
+	}
+	if adapterErr.Category != ErrorCategoryInvalidReference {
+		t.Fatalf("unexpected category %q", adapterErr.Category)
+	}
+}
+
+func TestCLIAdapterReportsUnexpectedKernelStatusOutput(t *testing.T) {
+	t.Parallel()
+
+	fake := &adapterFakeClient{
+		t: t,
+		runFn: func(_ context.Context, _ []string, _ RunOptions) (Result, error) {
+			return Result{Stdout: "kernel is doing something\n"}, nil
+		},
+	}
+
+	_, err := (&CLIAdapter{client: fake}).KernelStatus(context.Background(), KernelStatusRequest{
+		KernelRef: "alice/exp142",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var adapterErr *AdapterError
+	if !errors.As(err, &adapterErr) {
+		t.Fatalf("expected AdapterError, got %T", err)
+	}
+	if adapterErr.Category != ErrorCategoryUnexpectedOutput {
+		t.Fatalf("unexpected category %q", adapterErr.Category)
+	}
+}
+
+func TestCLIAdapterReportsUnexpectedSubmissionsOutput(t *testing.T) {
+	t.Parallel()
+
+	fake := &adapterFakeClient{
+		t: t,
+		runFn: func(_ context.Context, _ []string, _ RunOptions) (Result, error) {
+			return Result{Stdout: "submission.csv only\n"}, nil
+		},
+	}
+
+	_, err := (&CLIAdapter{client: fake}).ListCompetitionSubmissions(context.Background(), CompetitionSubmissionsRequest{
+		Competition: "playground-series-s6e2",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var adapterErr *AdapterError
+	if !errors.As(err, &adapterErr) {
+		t.Fatalf("expected AdapterError, got %T", err)
+	}
+	if adapterErr.Category != ErrorCategoryUnexpectedOutput {
+		t.Fatalf("unexpected category %q", adapterErr.Category)
 	}
 }
 
@@ -455,5 +606,8 @@ func assertZeroRunOptions(t *testing.T, opts RunOptions) {
 	}
 	if opts.Timeout != 0 {
 		t.Fatalf("unexpected timeout %s", opts.Timeout)
+	}
+	if opts.Debug {
+		t.Fatal("unexpected debug flag")
 	}
 }

--- a/internal/kaggle/client.go
+++ b/internal/kaggle/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/shotomorisk/kgh/internal/execx"
@@ -19,6 +20,7 @@ type Client struct {
 	lookPath       LookPathFunc
 	baseEnv        func() []string
 	defaultTimeout time.Duration
+	logger         operationLogger
 }
 
 type osEnvSource struct{}
@@ -67,11 +69,11 @@ func (e *TimeoutError) Unwrap() error { return e.Err }
 
 // NewClient constructs a Kaggle CLI adapter with production dependencies.
 func NewClient() *Client {
-	return NewClientWithDeps(nil, osEnvSource{}, exec.LookPath, currentEnv, defaultTimeout)
+	return NewClientWithDeps(nil, osEnvSource{}, exec.LookPath, currentEnv, defaultTimeout, nil)
 }
 
 // NewClientWithDeps constructs a Kaggle CLI adapter with injected dependencies for tests.
-func NewClientWithDeps(runner Runner, env EnvSource, lookPath LookPathFunc, baseEnv func() []string, timeout time.Duration) *Client {
+func NewClientWithDeps(runner Runner, env EnvSource, lookPath LookPathFunc, baseEnv func() []string, timeout time.Duration, logger operationLogger) *Client {
 	if baseEnv == nil {
 		baseEnv = currentEnv
 	}
@@ -87,6 +89,9 @@ func NewClientWithDeps(runner Runner, env EnvSource, lookPath LookPathFunc, base
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
+	if logger == nil {
+		logger = newNoopLogger()
+	}
 
 	return &Client{
 		runner:         runner,
@@ -94,6 +99,7 @@ func NewClientWithDeps(runner Runner, env EnvSource, lookPath LookPathFunc, base
 		lookPath:       lookPath,
 		baseEnv:        baseEnv,
 		defaultTimeout: timeout,
+		logger:         logger,
 	}
 }
 
@@ -102,9 +108,15 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 	if c == nil {
 		return Result{}, fmt.Errorf("kaggle client is nil")
 	}
+	operation := operationName(args)
 
 	runtimeSetup, err := PrepareRuntime(c.env)
 	if err != nil {
+		c.logger.ErrorContext(ctx, "kaggle operation failed",
+			"operation", operation,
+			"args", sanitizeArgs(args),
+			"error", err,
+		)
 		return Result{}, err
 	}
 	defer func() {
@@ -122,6 +134,7 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 	if timeout <= 0 {
 		timeout = c.defaultTimeout
 	}
+	env := execx.MergeEnv(c.baseEnv(), append(runtimeSetup.Env, opts.Env...))
 
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -131,17 +144,42 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 		Args: append([]string(nil), args...),
 	}
 
-	result, err := c.runner.Run(runCtx, command, RunOptions{
+	logAttrs := []any{
+		"operation", operation,
+		"args", sanitizeArgs(args),
+	}
+	if opts.Debug {
+		logAttrs = append(logAttrs,
+			"dir", opts.Dir,
+			"timeout", timeout.String(),
+			"auth_mode", runtimeSetup.AuthMode,
+			"auth_source", runtimeSetup.Source,
+			"env", sanitizeEnv(env),
+		)
+	}
+	c.logger.InfoContext(ctx, "kaggle operation start", logAttrs...)
+
+	result, err := c.runner.Run(runCtx, command, execx.Options{
 		Dir:     opts.Dir,
-		Env:     execx.MergeEnv(c.baseEnv(), append(runtimeSetup.Env, opts.Env...)),
+		Env:     env,
 		Timeout: timeout,
 	})
 	if err == nil {
+		c.logger.InfoContext(ctx, "kaggle operation complete",
+			"operation", operation,
+			"exit_code", result.ExitCode,
+		)
 		return result, nil
 	}
 
 	var timeoutErr *execx.TimeoutError
 	if errors.As(err, &timeoutErr) {
+		c.logger.ErrorContext(ctx, "kaggle operation timed out",
+			"operation", operation,
+			"args", sanitizeArgs(args),
+			"timeout", timeout.String(),
+			"error", err,
+		)
 		return result, &TimeoutError{
 			Args:    append([]string(nil), args...),
 			Timeout: timeout,
@@ -150,6 +188,12 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 	}
 
 	if errors.Is(runCtx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
+		c.logger.ErrorContext(ctx, "kaggle operation timed out",
+			"operation", operation,
+			"args", sanitizeArgs(args),
+			"timeout", timeout.String(),
+			"error", err,
+		)
 		return result, &TimeoutError{
 			Args:    append([]string(nil), args...),
 			Timeout: timeout,
@@ -159,6 +203,13 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 
 	var exitErr *execx.ExitError
 	if errors.As(err, &exitErr) {
+		c.logger.ErrorContext(ctx, "kaggle operation failed",
+			"operation", operation,
+			"args", sanitizeArgs(args),
+			"exit_code", result.ExitCode,
+			"stderr", strings.TrimSpace(result.Stderr),
+			"error", err,
+		)
 		return result, &CommandError{
 			Args:     append([]string(nil), args...),
 			ExitCode: result.ExitCode,
@@ -168,5 +219,10 @@ func (c *Client) Run(ctx context.Context, args []string, opts RunOptions) (Resul
 		}
 	}
 
+	c.logger.ErrorContext(ctx, "kaggle operation failed",
+		"operation", operation,
+		"args", sanitizeArgs(args),
+		"error", err,
+	)
 	return result, fmt.Errorf("run kaggle command: %w", err)
 }

--- a/internal/kaggle/client_test.go
+++ b/internal/kaggle/client_test.go
@@ -3,6 +3,7 @@ package kaggle
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,7 +18,7 @@ func TestClientRunSuccess(t *testing.T) {
 
 	runner := &clientFakeRunner{
 		t: t,
-		runFn: func(ctx context.Context, cmd command, opts RunOptions) (Result, error) {
+		runFn: func(ctx context.Context, cmd command, opts execx.Options) (Result, error) {
 			if cmd.Path != "/usr/local/bin/kaggle" {
 				t.Fatalf("unexpected path %q", cmd.Path)
 			}
@@ -71,6 +72,7 @@ func TestClientRunSuccess(t *testing.T) {
 		},
 		func() []string { return []string{"PATH=/usr/bin", "HOME=/base/home"} },
 		30*time.Second,
+		nil,
 	)
 
 	result, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{
@@ -91,7 +93,7 @@ func TestClientRunUsesDefaultTimeout(t *testing.T) {
 	client := NewClientWithDeps(
 		&clientFakeRunner{
 			t: t,
-			runFn: func(ctx context.Context, _ command, opts RunOptions) (Result, error) {
+			runFn: func(ctx context.Context, _ command, opts execx.Options) (Result, error) {
 				if _, ok := ctx.Deadline(); !ok {
 					t.Fatal("expected deadline to be set")
 				}
@@ -108,6 +110,7 @@ func TestClientRunUsesDefaultTimeout(t *testing.T) {
 		func(string) (string, error) { return "/usr/local/bin/kaggle", nil },
 		func() []string { return nil },
 		2*time.Second,
+		nil,
 	)
 
 	if _, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{}); err != nil {
@@ -121,7 +124,7 @@ func TestClientRunAppliesBaseEnvForCustomRunner(t *testing.T) {
 	client := NewClientWithDeps(
 		&clientFakeRunner{
 			t: t,
-			runFn: func(ctx context.Context, _ command, opts RunOptions) (Result, error) {
+			runFn: func(ctx context.Context, _ command, opts execx.Options) (Result, error) {
 				if _, ok := ctx.Deadline(); !ok {
 					t.Fatal("expected deadline to be set")
 				}
@@ -137,6 +140,7 @@ func TestClientRunAppliesBaseEnvForCustomRunner(t *testing.T) {
 		func(string) (string, error) { return "/usr/local/bin/kaggle", nil },
 		func() []string { return []string{"PATH=/usr/bin", "HOME=/base/home"} },
 		time.Second,
+		nil,
 	)
 
 	if _, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{
@@ -152,7 +156,7 @@ func TestClientRunUsesExplicitTimeoutOverride(t *testing.T) {
 	client := NewClientWithDeps(
 		&clientFakeRunner{
 			t: t,
-			runFn: func(ctx context.Context, _ command, opts RunOptions) (Result, error) {
+			runFn: func(ctx context.Context, _ command, opts execx.Options) (Result, error) {
 				if _, ok := ctx.Deadline(); !ok {
 					t.Fatal("expected deadline to be set")
 				}
@@ -169,6 +173,7 @@ func TestClientRunUsesExplicitTimeoutOverride(t *testing.T) {
 		func(string) (string, error) { return "/usr/local/bin/kaggle", nil },
 		func() []string { return nil },
 		10*time.Second,
+		nil,
 	)
 
 	if _, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{
@@ -184,7 +189,7 @@ func TestClientRunClassifiesTimeout(t *testing.T) {
 	client := NewClientWithDeps(
 		&clientFakeRunner{
 			t: t,
-			runFn: func(ctx context.Context, _ command, _ RunOptions) (Result, error) {
+			runFn: func(ctx context.Context, _ command, _ execx.Options) (Result, error) {
 				<-ctx.Done()
 				return Result{}, ctx.Err()
 			},
@@ -196,6 +201,7 @@ func TestClientRunClassifiesTimeout(t *testing.T) {
 		func(string) (string, error) { return "/usr/local/bin/kaggle", nil },
 		func() []string { return nil },
 		10*time.Millisecond,
+		nil,
 	)
 
 	_, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{})
@@ -218,7 +224,7 @@ func TestClientRunClassifiesCommandFailure(t *testing.T) {
 	client := NewClientWithDeps(
 		&clientFakeRunner{
 			t: t,
-			runFn: func(context.Context, command, RunOptions) (Result, error) {
+			runFn: func(context.Context, command, execx.Options) (Result, error) {
 				result := Result{
 					Stdout:   "partial output",
 					Stderr:   "bad things happened",
@@ -237,6 +243,7 @@ func TestClientRunClassifiesCommandFailure(t *testing.T) {
 		func(string) (string, error) { return "/usr/local/bin/kaggle", nil },
 		func() []string { return nil },
 		time.Second,
+		nil,
 	)
 
 	result, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{})
@@ -273,6 +280,7 @@ func TestClientRunReturnsExecutableLookupError(t *testing.T) {
 		},
 		func() []string { return nil },
 		time.Second,
+		nil,
 	)
 
 	_, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{})
@@ -291,7 +299,7 @@ func TestClientRunSupportsTokenAuth(t *testing.T) {
 
 	runner := &clientFakeRunner{
 		t: t,
-		runFn: func(_ context.Context, cmd command, opts RunOptions) (Result, error) {
+		runFn: func(_ context.Context, cmd command, opts execx.Options) (Result, error) {
 			if !equalStrings(cmd.Args, []string{"kernels", "status"}) {
 				t.Fatalf("unexpected args %#v", cmd.Args)
 			}
@@ -324,6 +332,7 @@ func TestClientRunSupportsTokenAuth(t *testing.T) {
 		func(string) (string, error) { return "/usr/local/bin/kaggle", nil },
 		func() []string { return []string{"PATH=/usr/bin"} },
 		time.Second,
+		nil,
 	)
 
 	if _, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{}); err != nil {
@@ -331,12 +340,96 @@ func TestClientRunSupportsTokenAuth(t *testing.T) {
 	}
 }
 
-type clientFakeRunner struct {
-	t     *testing.T
-	runFn func(context.Context, command, RunOptions) (Result, error)
+func TestClientRunLogsDebugContextWithRedaction(t *testing.T) {
+	t.Parallel()
+
+	logger := &fakeOperationLogger{}
+	client := NewClientWithDeps(
+		&clientFakeRunner{
+			t: t,
+			runFn: func(_ context.Context, _ command, _ execx.Options) (Result, error) {
+				return Result{ExitCode: 0}, nil
+			},
+		},
+		staticEnvSource{
+			envKaggleUsername: "alice",
+			envKaggleKey:      "secret-key",
+		},
+		func(string) (string, error) { return "/usr/local/bin/kaggle", nil },
+		func() []string { return []string{"PATH=/usr/bin", envKaggleAPIToken + "=base-secret"} },
+		time.Second,
+		logger,
+	)
+
+	if _, err := client.Run(context.Background(), []string{"kernels", "status"}, RunOptions{
+		Debug: true,
+		Env: []string{
+			envKaggleUsername + "=alice",
+			"HOME=/tmp/home",
+		},
+	}); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(logger.infoLogs) < 2 {
+		t.Fatalf("expected info logs, got %+v", logger.infoLogs)
+	}
+	start := strings.Join(logger.infoLogs[0].attrs, " ")
+	if !strings.Contains(start, "operation kernels status") {
+		t.Fatalf("unexpected log attrs %q", start)
+	}
+	if !strings.Contains(start, envKaggleUsername+"=[REDACTED]") {
+		t.Fatalf("expected redacted username in %q", start)
+	}
+	if !strings.Contains(start, envKaggleAPIToken+"=[REDACTED]") {
+		t.Fatalf("expected redacted token in %q", start)
+	}
+	if strings.Contains(start, "secret-key") || strings.Contains(start, "base-secret") {
+		t.Fatalf("unexpected secret leakage in %q", start)
+	}
 }
 
-func (f *clientFakeRunner) Run(ctx context.Context, cmd command, opts RunOptions) (Result, error) {
+func TestClientRunLogsActionableFailure(t *testing.T) {
+	t.Parallel()
+
+	logger := &fakeOperationLogger{}
+	client := NewClientWithDeps(
+		&clientFakeRunner{
+			t: t,
+			runFn: func(_ context.Context, _ command, _ execx.Options) (Result, error) {
+				result := Result{ExitCode: 2, Stderr: "permission denied"}
+				return result, &execx.ExitError{Result: result, Err: errors.New("exit status 2")}
+			},
+		},
+		staticEnvSource{
+			envKaggleUsername: "alice",
+			envKaggleKey:      "secret-key",
+		},
+		func(string) (string, error) { return "/usr/local/bin/kaggle", nil },
+		func() []string { return nil },
+		time.Second,
+		logger,
+	)
+
+	if _, err := client.Run(context.Background(), []string{"competitions", "submit"}, RunOptions{}); err == nil {
+		t.Fatal("expected an error")
+	}
+
+	if len(logger.errorLogs) == 0 {
+		t.Fatal("expected error logs")
+	}
+	entry := strings.Join(logger.errorLogs[0].attrs, " ")
+	if !strings.Contains(entry, "exit_code 2") || !strings.Contains(entry, "permission denied") {
+		t.Fatalf("unexpected error log attrs %q", entry)
+	}
+}
+
+type clientFakeRunner struct {
+	t     *testing.T
+	runFn func(context.Context, command, execx.Options) (Result, error)
+}
+
+func (f *clientFakeRunner) Run(ctx context.Context, cmd command, opts execx.Options) (Result, error) {
 	if f.runFn == nil {
 		f.t.Fatal("runFn must be set")
 	}
@@ -363,4 +456,34 @@ func equalStrings(left []string, right []string) bool {
 		}
 	}
 	return true
+}
+
+type fakeOperationLogger struct {
+	infoLogs  []fakeLogEntry
+	errorLogs []fakeLogEntry
+}
+
+type fakeLogEntry struct {
+	msg   string
+	attrs []string
+}
+
+func (l *fakeOperationLogger) InfoContext(_ context.Context, msg string, args ...any) {
+	l.infoLogs = append(l.infoLogs, fakeLogEntry{msg: msg, attrs: stringifyAttrs(args)})
+}
+
+func (l *fakeOperationLogger) ErrorContext(_ context.Context, msg string, args ...any) {
+	l.errorLogs = append(l.errorLogs, fakeLogEntry{msg: msg, attrs: stringifyAttrs(args)})
+}
+
+func stringifyAttrs(args []any) []string {
+	values := make([]string, 0, len(args))
+	for i := 0; i < len(args); i += 2 {
+		if i+1 >= len(args) {
+			values = append(values, fmt.Sprint(args[i]))
+			continue
+		}
+		values = append(values, fmt.Sprintf("%v %v", args[i], args[i+1]))
+	}
+	return values
 }

--- a/internal/kaggle/errors.go
+++ b/internal/kaggle/errors.go
@@ -1,0 +1,161 @@
+package kaggle
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type ErrorCategory string
+
+const (
+	ErrorCategoryMissingCredentials ErrorCategory = "missing_credentials"
+	ErrorCategoryInvalidCredentials ErrorCategory = "invalid_credentials"
+	ErrorCategoryPermissionDenied   ErrorCategory = "permission_denied"
+	ErrorCategoryInvalidReference   ErrorCategory = "invalid_reference"
+	ErrorCategoryCommandFailed      ErrorCategory = "command_failed"
+	ErrorCategoryUnexpectedOutput   ErrorCategory = "unexpected_output"
+	ErrorCategoryTimeout            ErrorCategory = "timeout"
+)
+
+// AdapterError reports a normalized Kaggle adapter failure for higher layers.
+type AdapterError struct {
+	Operation string
+	Category  ErrorCategory
+	Message   string
+	Stdout    string
+	Stderr    string
+	Err       error
+}
+
+func (e *AdapterError) Error() string {
+	if e == nil {
+		return "kaggle adapter error"
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Operation != "" && e.Category != "" {
+		return fmt.Sprintf("kaggle %s failed: %s", e.Operation, e.Category)
+	}
+	if e.Category != "" {
+		return fmt.Sprintf("kaggle adapter error: %s", e.Category)
+	}
+	return "kaggle adapter error"
+}
+
+func (e *AdapterError) Unwrap() error { return e.Err }
+
+func normalizeAdapterError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var adapterErr *AdapterError
+	if errors.As(err, &adapterErr) {
+		if adapterErr.Operation == "" {
+			adapterErr.Operation = operation
+		}
+		return adapterErr
+	}
+
+	var missingErr *MissingCredentialsError
+	if errors.As(err, &missingErr) {
+		return &AdapterError{
+			Operation: operation,
+			Category:  ErrorCategoryMissingCredentials,
+			Message:   fmt.Sprintf("kaggle %s failed: Kaggle credentials are missing", operation),
+			Err:       err,
+		}
+	}
+
+	var validationErr *CredentialValidationError
+	if errors.As(err, &validationErr) {
+		return &AdapterError{
+			Operation: operation,
+			Category:  ErrorCategoryInvalidCredentials,
+			Message:   fmt.Sprintf("kaggle %s failed: Kaggle credentials are invalid", operation),
+			Err:       err,
+		}
+	}
+
+	var timeoutErr *TimeoutError
+	if errors.As(err, &timeoutErr) {
+		return &AdapterError{
+			Operation: operation,
+			Category:  ErrorCategoryTimeout,
+			Message:   fmt.Sprintf("kaggle %s timed out", operation),
+			Err:       err,
+		}
+	}
+
+	var execErr *ExecutableNotFoundError
+	if errors.As(err, &execErr) {
+		return &AdapterError{
+			Operation: operation,
+			Category:  ErrorCategoryCommandFailed,
+			Message:   fmt.Sprintf("kaggle %s failed: Kaggle CLI is not available", operation),
+			Err:       err,
+		}
+	}
+
+	var commandErr *CommandError
+	if errors.As(err, &commandErr) {
+		category, message := classifyCommandFailure(operation, commandErr)
+		return &AdapterError{
+			Operation: operation,
+			Category:  category,
+			Message:   message,
+			Stdout:    commandErr.Stdout,
+			Stderr:    commandErr.Stderr,
+			Err:       err,
+		}
+	}
+
+	return &AdapterError{
+		Operation: operation,
+		Category:  ErrorCategoryCommandFailed,
+		Message:   fmt.Sprintf("kaggle %s failed", operation),
+		Err:       err,
+	}
+}
+
+func unexpectedOutputError(operation string, result Result, problem string) error {
+	message := fmt.Sprintf("kaggle %s failed: unexpected CLI output", operation)
+	if strings.TrimSpace(problem) != "" {
+		message += ": " + strings.TrimSpace(problem)
+	}
+	return &AdapterError{
+		Operation: operation,
+		Category:  ErrorCategoryUnexpectedOutput,
+		Message:   message,
+		Stdout:    result.Stdout,
+		Stderr:    result.Stderr,
+	}
+}
+
+func classifyCommandFailure(operation string, err *CommandError) (ErrorCategory, string) {
+	stderr := strings.ToLower(strings.TrimSpace(err.Stderr))
+	stdout := strings.ToLower(strings.TrimSpace(err.Stdout))
+	combined := strings.TrimSpace(stderr + "\n" + stdout)
+
+	switch {
+	case containsAny(combined, "401", "unauthorized", "api credentials", "invalid credentials", "could not find kaggle.json", "credentials not found", "forbidden: you must provide a key"):
+		return ErrorCategoryInvalidCredentials, fmt.Sprintf("kaggle %s failed: Kaggle credentials were rejected", operation)
+	case containsAny(combined, "403", "forbidden", "permission", "not allowed", "must accept", "rules", "join the competition", "not have permission"):
+		return ErrorCategoryPermissionDenied, fmt.Sprintf("kaggle %s failed: Kaggle denied permission for this operation", operation)
+	case containsAny(combined, "404", "not found", "was not found", "invalid competition", "invalid kernel", "no such competition", "no such kernel"):
+		return ErrorCategoryInvalidReference, fmt.Sprintf("kaggle %s failed: Kaggle reference is invalid or does not exist", operation)
+	default:
+		return ErrorCategoryCommandFailed, fmt.Sprintf("kaggle %s failed: Kaggle CLI command exited with an error", operation)
+	}
+}
+
+func containsAny(value string, patterns ...string) bool {
+	for _, pattern := range patterns {
+		if strings.Contains(value, pattern) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/kaggle/logging.go
+++ b/internal/kaggle/logging.go
@@ -1,0 +1,65 @@
+package kaggle
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+)
+
+type operationLogger interface {
+	InfoContext(context.Context, string, ...any)
+	ErrorContext(context.Context, string, ...any)
+}
+
+func newNoopLogger() operationLogger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func operationName(args []string) string {
+	if len(args) == 0 {
+		return "command"
+	}
+	if len(args) == 1 {
+		return args[0]
+	}
+	return args[0] + " " + args[1]
+}
+
+func sanitizeArgs(args []string) []string {
+	if len(args) == 0 {
+		return nil
+	}
+	safe := make([]string, len(args))
+	copy(safe, args)
+	return safe
+}
+
+func sanitizeEnv(env []string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+	safe := make([]string, 0, len(env))
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			safe = append(safe, entry)
+			continue
+		}
+		if isSensitiveEnvKey(key) {
+			safe = append(safe, key+"=[REDACTED]")
+			continue
+		}
+		safe = append(safe, key+"="+value)
+	}
+	return safe
+}
+
+func isSensitiveEnvKey(key string) bool {
+	switch key {
+	case envKaggleUsername, envKaggleKey, envKaggleAPIToken:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/kaggle/runner.go
+++ b/internal/kaggle/runner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/shotomorisk/kgh/internal/execx"
 )
@@ -12,7 +13,12 @@ import (
 const kaggleBinary = "kaggle"
 
 // RunOptions configures a Kaggle CLI process execution.
-type RunOptions = execx.Options
+type RunOptions struct {
+	Dir     string
+	Env     []string
+	Timeout time.Duration
+	Debug   bool
+}
 
 // Result captures the observable output from a Kaggle CLI process.
 type Result = execx.Result


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #12 
- [ ] Github issue: Closes: #13 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented the Kaggle adapter normalization and safe diagnostics path.

  internal/kaggle/errors.go adds a small stable taxonomy plus AdapterError, and internal/
  kaggle/adapter.go now converts raw client/CLI failures into categorized errors such as
  missing_credentials, permission_denied, invalid_reference, command_failed, timeout, and
  unexpected_output. It also preserves raw stderr/stdout for debugging and stops
  returning silent zero-value success when kernels status or competitions submissions
  output is unparseable.

  internal/kaggle/client.go, internal/kaggle/runner.go, and internal/kaggle/logging.go
  now support safe operation logging with an opt-in Debug flag on RunOptions. Logs
  include operation intent and sanitized command context, redact Kaggle secrets by env
  key, and keep failure logs actionable without leaking credentials. The adapter request
  types now carry Debug through to the client.

  I also expanded internal/kaggle/adapter_test.go and internal/kaggle/client_test.go to
  cover category mapping, stderr preservation, unexpected output handling, and log
  redaction.
<!-- close -->