### PR TITLE
adapter suite and opt-in Kaggle smoke path

### DIFF
--- a/.github/workflows/kaggle-smoke.yml
+++ b/.github/workflows/kaggle-smoke.yml
@@ -1,0 +1,51 @@
+name: Kaggle Smoke
+
+on:
+    workflow_dispatch:
+        inputs:
+            competition:
+                description: Kaggle competition slug to probe with a read-only submission listing
+                required: true
+                type: string
+
+permissions:
+    contents: read
+
+jobs:
+    smoke:
+        name: Smoke
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Set up Go
+              uses: actions/setup-go@v5
+              with:
+                  go-version-file: go.mod
+                  cache: false
+
+            - name: Install Kaggle CLI
+              shell: bash
+              run: python3 -m pip install --upgrade kaggle
+
+            - name: Run Kaggle smoke test
+              shell: bash
+              env:
+                  KGH_KAGGLE_SMOKE: "1"
+                  KGH_KAGGLE_SMOKE_COMPETITION: ${{ inputs.competition }}
+                  KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_API_TOKEN }}
+                  KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
+                  KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}
+              run: |
+                  set -euo pipefail
+                  if [[ -z "${KGH_KAGGLE_SMOKE_COMPETITION}" ]]; then
+                    echo "KGH_KAGGLE_SMOKE_COMPETITION is required" >&2
+                    exit 1
+                  fi
+                  if [[ -z "${KAGGLE_API_TOKEN}" && ( -z "${KAGGLE_USERNAME}" || -z "${KAGGLE_KEY}" ) ]]; then
+                    echo "Set either KAGGLE_API_TOKEN or both KAGGLE_USERNAME and KAGGLE_KEY" >&2
+                    exit 1
+                  fi
+                  go test -tags smoke ./internal/kaggle -run '^TestSmokeKaggleAdapterLive$' -count=1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test build fmt
+.PHONY: test build fmt smoke-kaggle
 
 test:
 	go test ./...
@@ -8,3 +8,7 @@ build:
 
 fmt:
 	gofmt -w $(shell find . -name '*.go' -not -path './vendor/*')
+
+smoke-kaggle:
+	@if [ -z "$$KGH_KAGGLE_SMOKE_COMPETITION" ]; then echo "KGH_KAGGLE_SMOKE_COMPETITION is required"; exit 1; fi
+	KGH_KAGGLE_SMOKE=1 go test -tags smoke ./internal/kaggle -run '^TestSmokeKaggleAdapterLive$$' -count=1

--- a/README.md
+++ b/README.md
@@ -25,3 +25,25 @@ go test ./...
 go build ./cmd/kgh
 ./kgh version
 ```
+
+### Kaggle smoke test
+
+Use the live smoke path only when you need to validate the adapter against real Kaggle credentials and the Kaggle CLI.
+It is intentionally opt-in and is not part of default CI.
+
+```bash
+export KGH_KAGGLE_SMOKE=1
+export KGH_KAGGLE_SMOKE_COMPETITION=<competition-slug>
+export KAGGLE_API_TOKEN=<token>
+# or:
+# export KAGGLE_USERNAME=<username>
+# export KAGGLE_KEY=<key>
+
+make smoke-kaggle
+```
+
+The smoke test runs a read-only submissions listing through the Kaggle adapter. Use a competition you have access to and have already joined. If you prefer not to use `make`, the equivalent command is:
+
+```bash
+KGH_KAGGLE_SMOKE=1 KGH_KAGGLE_SMOKE_COMPETITION=<competition-slug> go test -tags smoke ./internal/kaggle -run '^TestSmokeKaggleAdapterLive$' -count=1
+```

--- a/internal/kaggle/adapter_test.go
+++ b/internal/kaggle/adapter_test.go
@@ -159,6 +159,244 @@ func TestCLIAdapterListCompetitionSubmissions(t *testing.T) {
 	}
 }
 
+func TestCLIAdapterForwardsDebugFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func(*CLIAdapter) error
+		want []string
+	}{
+		{
+			name: "push kernel",
+			run: func(adapter *CLIAdapter) error {
+				_, err := adapter.PushKernel(context.Background(), PushKernelRequest{
+					WorkDir: "/tmp/work tree",
+					Debug:   true,
+				})
+				return err
+			},
+			want: []string{"kernels", "push", "-p", "/tmp/work tree"},
+		},
+		{
+			name: "kernel status",
+			run: func(adapter *CLIAdapter) error {
+				_, err := adapter.KernelStatus(context.Background(), KernelStatusRequest{
+					KernelRef: "alice/exp142",
+					Debug:     true,
+				})
+				return err
+			},
+			want: []string{"kernels", "status", "-p", "alice/exp142"},
+		},
+		{
+			name: "download kernel output",
+			run: func(adapter *CLIAdapter) error {
+				_, err := adapter.DownloadKernelOutput(context.Background(), DownloadKernelOutputRequest{
+					KernelRef: "alice/exp142",
+					OutputDir: "/tmp/output dir",
+					Debug:     true,
+				})
+				return err
+			},
+			want: []string{"kernels", "output", "alice/exp142", "-p", "/tmp/output dir"},
+		},
+		{
+			name: "submit competition",
+			run: func(adapter *CLIAdapter) error {
+				_, err := adapter.SubmitCompetition(context.Background(), CompetitionSubmitRequest{
+					Competition: "playground-series-s6e2",
+					FilePath:    "/tmp/submission csv",
+					Message:     "submit from PR #12",
+					Debug:       true,
+				})
+				return err
+			},
+			want: []string{"competitions", "submit", "-c", "playground-series-s6e2", "-f", "/tmp/submission csv", "-m", "submit from PR #12"},
+		},
+		{
+			name: "list competition submissions",
+			run: func(adapter *CLIAdapter) error {
+				_, err := adapter.ListCompetitionSubmissions(context.Background(), CompetitionSubmissionsRequest{
+					Competition: "playground-series-s6e2",
+					Debug:       true,
+				})
+				return err
+			},
+			want: []string{"competitions", "submissions", "-c", "playground-series-s6e2"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := &adapterFakeClient{
+				t: t,
+				runFn: func(_ context.Context, args []string, opts RunOptions) (Result, error) {
+					if !equalStrings(args, tt.want) {
+						t.Fatalf("unexpected args %#v", args)
+					}
+					assertDebugRunOptions(t, opts)
+					switch tt.name {
+					case "kernel status":
+						return Result{Stdout: "status: complete\nmessage: finished\n"}, nil
+					case "list competition submissions":
+						return Result{Stdout: "file,description,date,status,publicScore\nsubmission.csv,submit from PR #12,2026-04-14T10:00:00Z,complete,0.12345\n"}, nil
+					default:
+						return Result{}, nil
+					}
+				},
+			}
+
+			if err := tt.run(&CLIAdapter{client: fake}); err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestCLIAdapterNormalizesOperationFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		run         func(*CLIAdapter) error
+		runErr      error
+		wantCategory ErrorCategory
+	}{
+		{
+			name: "push kernel missing credentials",
+			run: func(adapter *CLIAdapter) error {
+				_, err := adapter.PushKernel(context.Background(), PushKernelRequest{WorkDir: "/tmp/work"})
+				return err
+			},
+			runErr: &MissingCredentialsError{Missing: []string{envKaggleUsername}},
+			wantCategory: ErrorCategoryMissingCredentials,
+		},
+		{
+			name: "kernel status invalid credentials",
+			run: func(adapter *CLIAdapter) error {
+				_, err := adapter.KernelStatus(context.Background(), KernelStatusRequest{KernelRef: "alice/exp142"})
+				return err
+			},
+			runErr: &CommandError{
+				ExitCode: 1,
+				Stderr:   "401 Unauthorized: invalid credentials",
+				Err:      errors.New("exit status 1"),
+			},
+			wantCategory: ErrorCategoryInvalidCredentials,
+		},
+		{
+			name: "download kernel output command failure",
+			run: func(adapter *CLIAdapter) error {
+				_, err := adapter.DownloadKernelOutput(context.Background(), DownloadKernelOutputRequest{
+					KernelRef: "alice/exp142",
+					OutputDir: "/tmp/output",
+				})
+				return err
+			},
+			runErr: &CommandError{
+				ExitCode: 1,
+				Stderr:   "something unexpected happened",
+				Err:      errors.New("exit status 1"),
+			},
+			wantCategory: ErrorCategoryCommandFailed,
+		},
+		{
+			name: "submit competition permission denied",
+			run: func(adapter *CLIAdapter) error {
+				_, err := adapter.SubmitCompetition(context.Background(), CompetitionSubmitRequest{
+					Competition: "playground-series-s6e2",
+					FilePath:    "/tmp/submission.csv",
+					Message:     "submit",
+				})
+				return err
+			},
+			runErr: &CommandError{
+				ExitCode: 1,
+				Stderr:   "403 Forbidden: you must accept the rules",
+				Err:      errors.New("exit status 1"),
+			},
+			wantCategory: ErrorCategoryPermissionDenied,
+		},
+		{
+			name: "list competition submissions invalid reference",
+			run: func(adapter *CLIAdapter) error {
+				_, err := adapter.ListCompetitionSubmissions(context.Background(), CompetitionSubmissionsRequest{
+					Competition: "missing-comp",
+				})
+				return err
+			},
+			runErr: &CommandError{
+				ExitCode: 1,
+				Stderr:   "404 Not Found: invalid competition slug",
+				Err:      errors.New("exit status 1"),
+			},
+			wantCategory: ErrorCategoryInvalidReference,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := &adapterFakeClient{
+				t: t,
+				runFn: func(_ context.Context, _ []string, opts RunOptions) (Result, error) {
+					if opts.Debug {
+						t.Fatal("did not expect debug mode")
+					}
+					return Result{}, tt.runErr
+				},
+			}
+
+			err := tt.run(&CLIAdapter{client: fake})
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+
+			var adapterErr *AdapterError
+			if !errors.As(err, &adapterErr) {
+				t.Fatalf("expected AdapterError, got %T", err)
+			}
+			if adapterErr.Category != tt.wantCategory {
+				t.Fatalf("unexpected category %q", adapterErr.Category)
+			}
+		})
+	}
+}
+
+func TestCLIAdapterReportsMalformedSubmissionDate(t *testing.T) {
+	t.Parallel()
+
+	fake := &adapterFakeClient{
+		t: t,
+		runFn: func(_ context.Context, _ []string, _ RunOptions) (Result, error) {
+			return Result{
+				Stdout: "file,description,date,status,publicScore\nsubmission.csv,submit,not-a-date,complete,0.12345\n",
+			}, nil
+		},
+	}
+
+	_, err := (&CLIAdapter{client: fake}).ListCompetitionSubmissions(context.Background(), CompetitionSubmissionsRequest{
+		Competition: "playground-series-s6e2",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var adapterErr *AdapterError
+	if !errors.As(err, &adapterErr) {
+		t.Fatalf("expected AdapterError, got %T", err)
+	}
+	if adapterErr.Category != ErrorCategoryUnexpectedOutput {
+		t.Fatalf("unexpected category %q", adapterErr.Category)
+	}
+}
+
 func TestCLIAdapterPropagatesClientErrors(t *testing.T) {
 	t.Parallel()
 
@@ -609,5 +847,22 @@ func assertZeroRunOptions(t *testing.T, opts RunOptions) {
 	}
 	if opts.Debug {
 		t.Fatal("unexpected debug flag")
+	}
+}
+
+func assertDebugRunOptions(t *testing.T, opts RunOptions) {
+	t.Helper()
+
+	if opts.Dir != "" {
+		t.Fatalf("unexpected dir %q", opts.Dir)
+	}
+	if len(opts.Env) != 0 {
+		t.Fatalf("unexpected env %#v", opts.Env)
+	}
+	if opts.Timeout != 0 {
+		t.Fatalf("unexpected timeout %s", opts.Timeout)
+	}
+	if !opts.Debug {
+		t.Fatal("expected debug flag")
 	}
 }

--- a/internal/kaggle/adapter_test.go
+++ b/internal/kaggle/adapter_test.go
@@ -261,9 +261,9 @@ func TestCLIAdapterNormalizesOperationFailures(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		run         func(*CLIAdapter) error
-		runErr      error
+		name         string
+		run          func(*CLIAdapter) error
+		runErr       error
 		wantCategory ErrorCategory
 	}{
 		{
@@ -272,7 +272,7 @@ func TestCLIAdapterNormalizesOperationFailures(t *testing.T) {
 				_, err := adapter.PushKernel(context.Background(), PushKernelRequest{WorkDir: "/tmp/work"})
 				return err
 			},
-			runErr: &MissingCredentialsError{Missing: []string{envKaggleUsername}},
+			runErr:       &MissingCredentialsError{Missing: []string{envKaggleUsername}},
 			wantCategory: ErrorCategoryMissingCredentials,
 		},
 		{

--- a/internal/kaggle/smoke_test.go
+++ b/internal/kaggle/smoke_test.go
@@ -1,0 +1,62 @@
+//go:build smoke && unix
+
+package kaggle
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"os/exec"
+)
+
+func TestSmokeKaggleAdapterLive(t *testing.T) {
+	competition := strings.TrimSpace(os.Getenv("KGH_KAGGLE_SMOKE_COMPETITION"))
+	if competition == "" {
+		t.Fatal("KGH_KAGGLE_SMOKE_COMPETITION is required")
+	}
+	if os.Getenv("KGH_KAGGLE_SMOKE") != "1" {
+		t.Fatal("set KGH_KAGGLE_SMOKE=1 to run the Kaggle smoke test")
+	}
+	requireExplicitSmokeCredentials(t)
+
+	client := NewClientWithDeps(
+		nil,
+		osEnvSource{},
+		exec.LookPath,
+		currentEnv,
+		2*time.Minute,
+		nil,
+	)
+	adapter := NewAdapter(client)
+
+	resp, err := adapter.ListCompetitionSubmissions(context.Background(), CompetitionSubmissionsRequest{
+		Competition: competition,
+	})
+	if err != nil {
+		t.Fatalf("smoke test failed: %v", err)
+	}
+
+	t.Logf("retrieved %d submission rows for %s", len(resp.Submissions), competition)
+}
+
+func requireExplicitSmokeCredentials(t *testing.T) {
+	t.Helper()
+
+	token := strings.TrimSpace(os.Getenv(envKaggleAPIToken))
+	username := strings.TrimSpace(os.Getenv(envKaggleUsername))
+	key := strings.TrimSpace(os.Getenv(envKaggleKey))
+
+	switch {
+	case token != "":
+		return
+	case username != "" && key != "":
+		return
+	case username != "" || key != "":
+		t.Fatal("set both KAGGLE_USERNAME and KAGGLE_KEY, or set KAGGLE_API_TOKEN")
+	default:
+		t.Fatal("set KAGGLE_API_TOKEN, or set KAGGLE_USERNAME and KAGGLE_KEY")
+	}
+}


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #14 
- [x] Github issue: Closes: #15 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Updated internal/kaggle/adapter_test.go to make the adapter suite match the plan more
  closely.

  The test coverage now explicitly checks Debug propagation through the fake runner,
  exercises normalized failures across all v1 adapter operations, and adds a malformed
  competition-submissions date case. Existing client/auth tests already cover credential
  discovery and env handling, so I left those layers unchanged.

Implemented the opt-in Kaggle smoke path.

  - Added a tagged live smoke test at internal/kaggle/smoke_test.go:1 that requires
    KGH_KAGGLE_SMOKE=1, explicit Kaggle credentials, and KGH_KAGGLE_SMOKE_COMPETITION,
    then exercises the adapter end to end with ListCompetitionSubmissions.
  - Added a manual-only GitHub Actions workflow at .github/workflows/kaggle-smoke.yml:1
    using workflow_dispatch only, so it stays out of default CI.
  - Added a convenience Makefile:1 target and documented when to use it in README.md:1.
<!-- close -->