### PR TITLE
Local Kaggle Bundle Staging

### DIFF
--- a/internal/kaggle/bundle.go
+++ b/internal/kaggle/bundle.go
@@ -1,0 +1,221 @@
+package kaggle
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/shotomorisk/kgh/internal/spec"
+)
+
+const bundleTempPrefix = "kgh-kaggle-bundle-*"
+
+// StagedBundle describes a prepared Kaggle push directory.
+type StagedBundle struct {
+	WorkDir      string
+	NotebookPath string
+	MetadataPath string
+	Execution    spec.ExecutionSpec
+	Cleanup      func() error
+}
+
+// StagingError reports a failure while preparing a local Kaggle bundle.
+type StagingError struct {
+	Op   string
+	Path string
+	Err  error
+}
+
+func (e *StagingError) Error() string {
+	if e == nil {
+		return "prepare kaggle bundle"
+	}
+	if e.Path != "" {
+		return fmt.Sprintf("prepare kaggle bundle: %s %s: %v", e.Op, e.Path, e.Err)
+	}
+	return fmt.Sprintf("prepare kaggle bundle: %s: %v", e.Op, e.Err)
+}
+
+func (e *StagingError) Unwrap() error { return e.Err }
+
+// StageKernelBundle creates a temporary Kaggle bundle directory for the resolved execution spec.
+func StageKernelBundle(exec spec.ExecutionSpec) (StagedBundle, error) {
+	if err := validateNotebookSource(exec.Notebook); err != nil {
+		return StagedBundle{}, err
+	}
+
+	workDir, cleanup, err := createBundleDir()
+	if err != nil {
+		return StagedBundle{}, err
+	}
+
+	bundle := StagedBundle{
+		WorkDir:   workDir,
+		Execution: exec,
+		Cleanup:   cleanup,
+	}
+
+	notebookPath, err := copyNotebookToBundle(exec.Notebook, workDir)
+	if err != nil {
+		_ = cleanup()
+		return StagedBundle{}, err
+	}
+	bundle.NotebookPath = notebookPath
+
+	metadataPath, err := WriteKernelMetadata(workDir, exec)
+	if err != nil {
+		_ = cleanup()
+		return StagedBundle{}, &StagingError{
+			Op:   "write metadata",
+			Path: filepath.Join(workDir, metadataFilename),
+			Err:  err,
+		}
+	}
+	bundle.MetadataPath = metadataPath
+
+	if err := verifyBundleFiles(bundle.NotebookPath, bundle.MetadataPath); err != nil {
+		_ = cleanup()
+		return StagedBundle{}, err
+	}
+
+	return bundle, nil
+}
+
+func validateNotebookSource(path string) error {
+	if strings.TrimSpace(path) == "" {
+		return &StagingError{
+			Op:  "validate notebook",
+			Err: fmt.Errorf("notebook path is required"),
+		}
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &StagingError{
+				Op:   "check notebook",
+				Path: path,
+				Err:  fmt.Errorf("notebook file is missing"),
+			}
+		}
+		return &StagingError{
+			Op:   "check notebook",
+			Path: path,
+			Err:  err,
+		}
+	}
+	if info.IsDir() {
+		return &StagingError{
+			Op:   "check notebook",
+			Path: path,
+			Err:  fmt.Errorf("notebook path must be a file"),
+		}
+	}
+
+	return nil
+}
+
+func createBundleDir() (string, func() error, error) {
+	workDir, err := os.MkdirTemp("", bundleTempPrefix)
+	if err != nil {
+		return "", nil, &StagingError{
+			Op:  "create temp dir",
+			Err: err,
+		}
+	}
+
+	if err := os.Chmod(workDir, 0o700); err != nil {
+		_ = os.RemoveAll(workDir)
+		return "", nil, &StagingError{
+			Op:   "chmod temp dir",
+			Path: workDir,
+			Err:  err,
+		}
+	}
+
+	cleanup := func() error {
+		if err := os.RemoveAll(workDir); err != nil {
+			return &StagingError{
+				Op:   "cleanup",
+				Path: workDir,
+				Err:  err,
+			}
+		}
+		return nil
+	}
+
+	return workDir, cleanup, nil
+}
+
+func copyNotebookToBundle(src, workDir string) (string, error) {
+	dst := filepath.Join(workDir, filepath.Base(src))
+	if err := copyFile(src, dst); err != nil {
+		return "", &StagingError{
+			Op:   "copy notebook",
+			Path: src,
+			Err:  err,
+		}
+	}
+	return dst, nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+func verifyBundleFiles(paths ...string) error {
+	for _, path := range paths {
+		if err := verifyFile(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func verifyFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &StagingError{
+				Op:   "verify file",
+				Path: path,
+				Err:  fmt.Errorf("required file is missing"),
+			}
+		}
+		return &StagingError{
+			Op:   "verify file",
+			Path: path,
+			Err:  err,
+		}
+	}
+	if info.IsDir() {
+		return &StagingError{
+			Op:   "verify file",
+			Path: path,
+			Err:  fmt.Errorf("expected a file, found a directory"),
+		}
+	}
+	return nil
+}

--- a/internal/kaggle/bundle_test.go
+++ b/internal/kaggle/bundle_test.go
@@ -1,0 +1,113 @@
+package kaggle
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shotomorisk/kgh/internal/config"
+	"github.com/shotomorisk/kgh/internal/spec"
+)
+
+func TestStageKernelBundle(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+	sourceNotebook := filepath.Join(sourceDir, "notebooks", "exp142.ipynb")
+	if err := os.MkdirAll(filepath.Dir(sourceNotebook), 0o755); err != nil {
+		t.Fatalf("create notebook dir: %v", err)
+	}
+	const notebookBody = "{ \"cells\": [] }"
+	if err := os.WriteFile(sourceNotebook, []byte(notebookBody), 0o644); err != nil {
+		t.Fatalf("write notebook: %v", err)
+	}
+
+	exec := spec.ExecutionSpec{
+		Notebook:  sourceNotebook,
+		KernelID:  "yourname/exp142",
+		Resources: config.Resources{GPU: true, Internet: true, Private: false},
+		Sources: config.Sources{
+			CompetitionSources: []string{"playground-series-s6e2"},
+			DatasetSources:     []string{"yourname/feature-pack-v3"},
+		},
+	}
+
+	bundle, err := StageKernelBundle(exec)
+	if err != nil {
+		t.Fatalf("stage bundle: %v", err)
+	}
+	defer func() {
+		if err := bundle.Cleanup(); err != nil {
+			t.Fatalf("cleanup bundle: %v", err)
+		}
+	}()
+
+	if bundle.WorkDir == "" {
+		t.Fatal("expected work dir to be set")
+	}
+	if got, err := os.Stat(bundle.WorkDir); err != nil || !got.IsDir() {
+		t.Fatalf("expected work dir to exist, got info=%v err=%v", got, err)
+	}
+
+	wantNotebook := filepath.Join(bundle.WorkDir, "exp142.ipynb")
+	if bundle.NotebookPath != wantNotebook {
+		t.Fatalf("unexpected notebook path %q", bundle.NotebookPath)
+	}
+	if bundle.MetadataPath != filepath.Join(bundle.WorkDir, metadataFilename) {
+		t.Fatalf("unexpected metadata path %q", bundle.MetadataPath)
+	}
+	if bundle.Execution.Notebook != exec.Notebook || bundle.Execution.KernelID != exec.KernelID {
+		t.Fatalf("unexpected execution spec %+v", bundle.Execution)
+	}
+
+	gotNotebook, err := os.ReadFile(bundle.NotebookPath)
+	if err != nil {
+		t.Fatalf("read staged notebook: %v", err)
+	}
+	if string(gotNotebook) != notebookBody {
+		t.Fatalf("unexpected staged notebook body %q", string(gotNotebook))
+	}
+
+	gotMetadata, err := os.ReadFile(bundle.MetadataPath)
+	if err != nil {
+		t.Fatalf("read staged metadata: %v", err)
+	}
+	wantMetadata := `{"title":"exp142","id":"yourname/exp142","code_file":"exp142.ipynb","language":"python","kernel_type":"notebook","enable_gpu":true,"enable_internet":true,"competition_sources":["playground-series-s6e2"],"dataset_sources":["yourname/feature-pack-v3"],"kernel_sources":[],"model_sources":[],"is_private":false}`
+	if string(gotMetadata) != wantMetadata {
+		t.Fatalf("unexpected metadata file:\nwant %s\ngot  %s", wantMetadata, string(gotMetadata))
+	}
+
+	if err := bundle.Cleanup(); err != nil {
+		t.Fatalf("cleanup bundle: %v", err)
+	}
+	if _, err := os.Stat(bundle.WorkDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected work dir to be removed, got err=%v", err)
+	}
+}
+
+func TestStageKernelBundleMissingNotebook(t *testing.T) {
+	t.Parallel()
+
+	missing := filepath.Join(t.TempDir(), "missing.ipynb")
+
+	_, err := StageKernelBundle(spec.ExecutionSpec{Notebook: missing})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var stagingErr *StagingError
+	if !errors.As(err, &stagingErr) {
+		t.Fatalf("expected StagingError, got %T", err)
+	}
+	if stagingErr.Op != "check notebook" {
+		t.Fatalf("unexpected operation %q", stagingErr.Op)
+	}
+	if stagingErr.Path != missing {
+		t.Fatalf("unexpected path %q", stagingErr.Path)
+	}
+	if !strings.Contains(err.Error(), "notebook file is missing") {
+		t.Fatalf("unexpected error %q", err)
+	}
+}

--- a/internal/kaggle/doc.go
+++ b/internal/kaggle/doc.go
@@ -4,6 +4,7 @@
 // Client is a lower-level Kaggle CLI executor that concrete adapters can build on.
 //
 // The package remains intentionally thin. It resolves Kaggle credentials,
-// delegates external command execution to internal/execx, and returns typed
-// errors that higher layers can surface cleanly.
+// stages local kernel bundles, delegates external command execution to
+// internal/execx, and returns typed errors that higher layers can surface
+// cleanly.
 package kaggle


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #16 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented in two commits.

  - Staging API added in internal/kaggle/bundle.go:15: StageKernelBundle now creates a
    per-run temp directory, copies the notebook to the bundle root as the basename,
    writes kernel-metadata.json, verifies both files exist, and returns a structured
    StagedBundle with cleanup.
  - Error handling is explicit in internal/kaggle/bundle.go:24: source-notebook
    validation, temp-dir creation, copy, metadata write, and verification all return
    actionable StagingErrors.
  - Package docs updated in internal/kaggle/doc.go:1 to reflect bundle staging.
  - Coverage added in internal/kaggle/bundle_test.go:14: success path, flatten-to-root
    layout, metadata contents, cleanup, and missing-notebook failure.
<!-- close -->