### PR TITLE
kaggle kernel push

### DIFF
--- a/internal/kaggle/adapter.go
+++ b/internal/kaggle/adapter.go
@@ -27,7 +27,7 @@ type PushKernelRequest struct {
 }
 
 type PushKernelResponse struct {
-	KernelRef string
+	Output Result
 }
 
 type KernelStatusRequest struct {
@@ -103,10 +103,11 @@ func (a *CLIAdapter) PushKernel(ctx context.Context, req PushKernelRequest) (Pus
 	if err != nil {
 		return PushKernelResponse{}, err
 	}
-	if _, err := a.run(ctx, "push kernel", args, req.Debug); err != nil {
+	result, err := a.run(ctx, "push kernel", args, req.Debug)
+	if err != nil {
 		return PushKernelResponse{}, err
 	}
-	return PushKernelResponse{}, nil
+	return PushKernelResponse{Output: result}, nil
 }
 
 func (a *CLIAdapter) KernelStatus(ctx context.Context, req KernelStatusRequest) (KernelStatusResponse, error) {

--- a/internal/kaggle/adapter_test.go
+++ b/internal/kaggle/adapter_test.go
@@ -34,7 +34,11 @@ func TestCLIAdapterPushKernel(t *testing.T) {
 				t.Fatalf("unexpected args %#v", args)
 			}
 			assertZeroRunOptions(t, opts)
-			return Result{}, nil
+			return Result{
+				Stdout:   "Kernel pushed successfully\n",
+				Stderr:   "",
+				ExitCode: 0,
+			}, nil
 		},
 	}
 
@@ -44,8 +48,11 @@ func TestCLIAdapterPushKernel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if resp.KernelRef != "" {
-		t.Fatalf("expected empty kernel ref, got %q", resp.KernelRef)
+	if resp.Output.Stdout != "Kernel pushed successfully\n" {
+		t.Fatalf("unexpected stdout %q", resp.Output.Stdout)
+	}
+	if resp.Output.ExitCode != 0 {
+		t.Fatalf("unexpected exit code %d", resp.Output.ExitCode)
 	}
 }
 
@@ -448,6 +455,47 @@ func TestCLIAdapterNormalizesMissingCredentials(t *testing.T) {
 	}
 	if adapterErr.Category != ErrorCategoryMissingCredentials {
 		t.Fatalf("unexpected category %q", adapterErr.Category)
+	}
+}
+
+func TestCLIAdapterNormalizesPushKernelCommandFailure(t *testing.T) {
+	t.Parallel()
+
+	fake := &adapterFakeClient{
+		t: t,
+		runFn: func(_ context.Context, _ []string, _ RunOptions) (Result, error) {
+			return Result{
+					Stdout:   "uploading bundle\n",
+					Stderr:   "403 Forbidden: you must accept the competition rules",
+					ExitCode: 1,
+				}, &CommandError{
+					ExitCode: 1,
+					Stdout:   "uploading bundle\n",
+					Stderr:   "403 Forbidden: you must accept the competition rules",
+					Err:      errors.New("exit status 1"),
+				}
+		},
+	}
+
+	_, err := (&CLIAdapter{client: fake}).PushKernel(context.Background(), PushKernelRequest{
+		WorkDir: "/tmp/work",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var adapterErr *AdapterError
+	if !errors.As(err, &adapterErr) {
+		t.Fatalf("expected AdapterError, got %T", err)
+	}
+	if adapterErr.Category != ErrorCategoryPermissionDenied {
+		t.Fatalf("unexpected category %q", adapterErr.Category)
+	}
+	if adapterErr.Stdout != "uploading bundle\n" {
+		t.Fatalf("unexpected stdout %q", adapterErr.Stdout)
+	}
+	if adapterErr.Stderr == "" {
+		t.Fatal("expected stderr to be preserved")
 	}
 }
 


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #17

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented on branch feat/kaggle-kernel-push.

  What changed:

  - PushKernelResponse now carries the Kaggle CLI result via Output Result in internal/
    kaggle/adapter.go:29-110.
  - PushKernel now returns the captured CLI result instead of discarding it.
  - Added/updated tests to cover:
      - successful push output propagation in internal/kaggle/adapter_test.go:27-56
      - push command failure normalization and stdout/stderr preservation in internal/
        kaggle/adapter_test.go:461-499

  Commits:

  - c8e63cd feat(kaggle): return push command output
  - 6a8fdf1 test(kaggle): cover push command output

  Verification:

  - go test ./internal/kaggle/...
  - go test ./...
<!-- close -->