### PR TITLE
Canonical Kaggle kernel identity

### DIFF
--- a/internal/kaggle/adapter.go
+++ b/internal/kaggle/adapter.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/shotomorisk/kgh/internal/kernelref"
 )
 
 // Adapter defines workflow-level Kaggle operations without exposing shell details.
@@ -27,7 +29,8 @@ type PushKernelRequest struct {
 }
 
 type PushKernelResponse struct {
-	Output Result
+	KernelRef string
+	Output    Result
 }
 
 type KernelStatusRequest struct {
@@ -107,7 +110,11 @@ func (a *CLIAdapter) PushKernel(ctx context.Context, req PushKernelRequest) (Pus
 	if err != nil {
 		return PushKernelResponse{}, err
 	}
-	return PushKernelResponse{Output: result}, nil
+	kernelRef, err := extractKernelRefFromPushResult(result)
+	if err != nil {
+		return PushKernelResponse{}, err
+	}
+	return PushKernelResponse{KernelRef: kernelRef, Output: result}, nil
 }
 
 func (a *CLIAdapter) KernelStatus(ctx context.Context, req KernelStatusRequest) (KernelStatusResponse, error) {
@@ -465,4 +472,13 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func extractKernelRefFromPushResult(result Result) (string, error) {
+	output := strings.TrimSpace(strings.Join([]string{result.Stdout, result.Stderr}, "\n"))
+	kernelRef, err := kernelref.ExtractFromText(output)
+	if err != nil {
+		return "", unexpectedOutputError("push kernel", result, err.Error())
+	}
+	return kernelRef, nil
 }

--- a/internal/kaggle/adapter_test.go
+++ b/internal/kaggle/adapter_test.go
@@ -3,6 +3,7 @@ package kaggle
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -35,7 +36,7 @@ func TestCLIAdapterPushKernel(t *testing.T) {
 			}
 			assertZeroRunOptions(t, opts)
 			return Result{
-				Stdout:   "Kernel pushed successfully\n",
+				Stdout:   "Kernel URL: https://www.kaggle.com/code/alice/exp142\nKernel pushed successfully\n",
 				Stderr:   "",
 				ExitCode: 0,
 			}, nil
@@ -48,11 +49,39 @@ func TestCLIAdapterPushKernel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if resp.Output.Stdout != "Kernel pushed successfully\n" {
+	if resp.KernelRef != "alice/exp142" {
+		t.Fatalf("unexpected kernel ref %q", resp.KernelRef)
+	}
+	if resp.Output.Stdout != "Kernel URL: https://www.kaggle.com/code/alice/exp142\nKernel pushed successfully\n" {
 		t.Fatalf("unexpected stdout %q", resp.Output.Stdout)
 	}
 	if resp.Output.ExitCode != 0 {
 		t.Fatalf("unexpected exit code %d", resp.Output.ExitCode)
+	}
+}
+
+func TestCLIAdapterPushKernelMissingIdentity(t *testing.T) {
+	t.Parallel()
+
+	fake := &adapterFakeClient{
+		t: t,
+		runFn: func(_ context.Context, args []string, opts RunOptions) (Result, error) {
+			if !equalStrings(args, []string{"kernels", "push", "-p", "/tmp/work tree"}) {
+				t.Fatalf("unexpected args %#v", args)
+			}
+			assertZeroRunOptions(t, opts)
+			return Result{Stdout: "Kernel pushed successfully\n"}, nil
+		},
+	}
+
+	_, err := (&CLIAdapter{client: fake}).PushKernel(context.Background(), PushKernelRequest{
+		WorkDir: "/tmp/work tree",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); !strings.Contains(got, "unexpected CLI output") {
+		t.Fatalf("expected unexpected output error, got %q", got)
 	}
 }
 
@@ -249,6 +278,8 @@ func TestCLIAdapterForwardsDebugFlag(t *testing.T) {
 					switch tt.name {
 					case "kernel status":
 						return Result{Stdout: "status: complete\nmessage: finished\n"}, nil
+					case "push kernel":
+						return Result{Stdout: "Kernel URL: https://www.kaggle.com/code/alice/exp142\nKernel pushed successfully\n"}, nil
 					case "list competition submissions":
 						return Result{Stdout: "file,description,date,status,publicScore\nsubmission.csv,submit from PR #12,2026-04-14T10:00:00Z,complete,0.12345\n"}, nil
 					default:

--- a/internal/kaggle/bundle_test.go
+++ b/internal/kaggle/bundle_test.go
@@ -27,6 +27,7 @@ func TestStageKernelBundle(t *testing.T) {
 	exec := spec.ExecutionSpec{
 		Notebook:  sourceNotebook,
 		KernelID:  "yourname/exp142",
+		KernelRef: "yourname/exp142",
 		Resources: config.Resources{GPU: true, Internet: true, Private: false},
 		Sources: config.Sources{
 			CompetitionSources: []string{"playground-series-s6e2"},
@@ -58,7 +59,7 @@ func TestStageKernelBundle(t *testing.T) {
 	if bundle.MetadataPath != filepath.Join(bundle.WorkDir, metadataFilename) {
 		t.Fatalf("unexpected metadata path %q", bundle.MetadataPath)
 	}
-	if bundle.Execution.Notebook != exec.Notebook || bundle.Execution.KernelID != exec.KernelID {
+	if bundle.Execution.Notebook != exec.Notebook || bundle.Execution.KernelRef != exec.KernelRef {
 		t.Fatalf("unexpected execution spec %+v", bundle.Execution)
 	}
 

--- a/internal/kaggle/metadata.go
+++ b/internal/kaggle/metadata.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/shotomorisk/kgh/internal/kernelref"
 	"github.com/shotomorisk/kgh/internal/spec"
 )
 
@@ -30,9 +31,18 @@ type Metadata struct {
 
 // BuildMetadata converts a resolved execution spec into a deterministic Kaggle metadata payload.
 func BuildMetadata(exec spec.ExecutionSpec) Metadata {
+	kernelID := exec.KernelRef
+	if kernelID == "" {
+		if normalized, err := kernelref.Normalize(exec.KernelID); err == nil {
+			kernelID = normalized
+		} else {
+			kernelID = strings.TrimSpace(exec.KernelID)
+		}
+	}
+
 	return Metadata{
 		Title:              notebookTitle(exec.Notebook),
-		ID:                 exec.KernelID,
+		ID:                 kernelID,
 		CodeFile:           filepath.Base(exec.Notebook),
 		Language:           defaultLanguage,
 		KernelType:         defaultKernelType,

--- a/internal/kaggle/metadata_test.go
+++ b/internal/kaggle/metadata_test.go
@@ -14,6 +14,7 @@ func TestBuildMetadata(t *testing.T) {
 	exec := spec.ExecutionSpec{
 		Notebook:  "notebooks/exp142.ipynb",
 		KernelID:  "yourname/exp142",
+		KernelRef: "yourname/exp142",
 		Resources: config.Resources{GPU: true, Internet: false, Private: true},
 		Sources:   config.Sources{CompetitionSources: []string{"playground-series-s6e2"}, DatasetSources: []string{"yourname/feature-pack-v3"}},
 	}
@@ -60,8 +61,9 @@ func TestBuildMetadataDeterministic(t *testing.T) {
 	t.Parallel()
 
 	exec := spec.ExecutionSpec{
-		Notebook: "notebooks/exp142.ipynb",
-		KernelID: "yourname/exp142",
+		Notebook:  "notebooks/exp142.ipynb",
+		KernelID:  "yourname/exp142",
+		KernelRef: "yourname/exp142",
 		Sources: config.Sources{
 			CompetitionSources: []string{"b", "a"},
 			DatasetSources:     []string{"x", "y"},

--- a/internal/kaggle/writer_test.go
+++ b/internal/kaggle/writer_test.go
@@ -16,6 +16,7 @@ func TestWriteKernelMetadata(t *testing.T) {
 	exec := spec.ExecutionSpec{
 		Notebook:  "notebooks/exp142.ipynb",
 		KernelID:  "yourname/exp142",
+		KernelRef: "yourname/exp142",
 		Resources: config.Resources{GPU: true, Internet: true, Private: false},
 		Sources:   config.Sources{CompetitionSources: []string{"playground-series-s6e2"}, DatasetSources: []string{"yourname/feature-pack-v3"}},
 	}

--- a/internal/kernelref/kernelref.go
+++ b/internal/kernelref/kernelref.go
@@ -1,0 +1,96 @@
+package kernelref
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	urlRefPattern = regexp.MustCompile(`(?i)\bhttps?://(?:www\.)?kaggle\.com/(?:code|kernels)/([A-Za-z0-9][A-Za-z0-9._-]*)/([A-Za-z0-9][A-Za-z0-9._-]*)(?:[/?#].*)?\b`)
+	rawRefPattern = regexp.MustCompile(`(?i)\b([A-Za-z0-9][A-Za-z0-9._-]*)/([A-Za-z0-9][A-Za-z0-9._-]*)\b`)
+)
+
+// Normalize converts a kernel reference or Kaggle URL into the canonical owner/kernel-slug form.
+func Normalize(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", fmt.Errorf("kernel identity is required")
+	}
+
+	if ref, ok := extractURLRef(trimmed); ok {
+		return ref, nil
+	}
+	if ref, ok := extractRawRef(trimmed); ok {
+		return ref, nil
+	}
+
+	return "", fmt.Errorf("kernel identity %q is not a canonical Kaggle kernel reference", trimmed)
+}
+
+// ExtractFromText finds a canonical kernel reference in free-form CLI output.
+func ExtractFromText(output string) (string, error) {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return "", fmt.Errorf("kernel identity not found in push output")
+	}
+
+	matches := make(map[string]struct{})
+	for _, line := range strings.Split(trimmed, "\n") {
+		if ref, ok := extractURLRef(line); ok {
+			matches[ref] = struct{}{}
+			continue
+		}
+		for _, ref := range extractRawRefs(line) {
+			matches[ref] = struct{}{}
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("kernel identity not found in push output")
+	case 1:
+		for ref := range matches {
+			return ref, nil
+		}
+	default:
+		candidates := make([]string, 0, len(matches))
+		for ref := range matches {
+			candidates = append(candidates, ref)
+		}
+		return "", fmt.Errorf("kernel identity is ambiguous: %s", strings.Join(candidates, ", "))
+	}
+
+	return "", fmt.Errorf("kernel identity not found in push output")
+}
+
+func extractURLRef(value string) (string, bool) {
+	matches := urlRefPattern.FindStringSubmatch(strings.TrimSpace(value))
+	if len(matches) != 3 {
+		return "", false
+	}
+	return matches[1] + "/" + matches[2], true
+}
+
+func extractRawRef(value string) (string, bool) {
+	matches := rawRefPattern.FindStringSubmatch(strings.TrimSpace(value))
+	if len(matches) != 3 {
+		return "", false
+	}
+	return matches[1] + "/" + matches[2], true
+}
+
+func extractRawRefs(value string) []string {
+	matches := rawRefPattern.FindAllStringSubmatch(strings.TrimSpace(value), -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if len(match) != 3 {
+			continue
+		}
+		out = append(out, match[1]+"/"+match[2])
+	}
+	return out
+}

--- a/internal/kernelref/kernelref_test.go
+++ b/internal/kernelref/kernelref_test.go
@@ -1,0 +1,109 @@
+package kernelref
+
+import "testing"
+
+func TestNormalize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "raw ref",
+			input: "alice/exp142",
+			want:  "alice/exp142",
+		},
+		{
+			name:  "url ref",
+			input: "https://www.kaggle.com/code/alice/exp142",
+			want:  "alice/exp142",
+		},
+		{
+			name:    "empty",
+			input:   " ",
+			wantErr: true,
+		},
+		{
+			name:    "invalid",
+			input:   "exp142",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := Normalize(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestExtractFromText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "url",
+			input: "Kernel URL: https://www.kaggle.com/code/alice/exp142",
+			want:  "alice/exp142",
+		},
+		{
+			name:  "raw ref",
+			input: "kernel identity: alice/exp142",
+			want:  "alice/exp142",
+		},
+		{
+			name:    "missing",
+			input:   "Kernel pushed successfully",
+			wantErr: true,
+		},
+		{
+			name:    "ambiguous",
+			input:   "first alice/exp142\nsecond bob/exp143",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ExtractFromText(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -15,8 +15,13 @@ func Resolve(cfg config.Config, trigger parser.Trigger) (spec.ExecutionSpec, err
 		return spec.ExecutionSpec{}, fmt.Errorf("unknown target %q", trigger.Target)
 	}
 
-	return spec.NewExecutionSpec(trigger.Target, target, spec.RuntimeOverrides{
+	exec, err := spec.NewExecutionSpec(trigger.Target, target, spec.RuntimeOverrides{
 		GPU:      trigger.GPU,
 		Internet: trigger.Internet,
-	}), nil
+	})
+	if err != nil {
+		return spec.ExecutionSpec{}, fmt.Errorf("resolve target %q: %w", trigger.Target, err)
+	}
+
+	return exec, nil
 }

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -118,3 +118,25 @@ func TestResolveUnknownTarget(t *testing.T) {
 		t.Fatalf("expected unknown target error, got %q", got)
 	}
 }
+
+func TestResolveInvalidKernelIdentity(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Targets: map[string]config.Target{
+			"exp142": {
+				Notebook:    "notebooks/exp142.ipynb",
+				KernelID:    "exp142",
+				Competition: "playground-series-s6e2",
+			},
+		},
+	}
+
+	_, err := Resolve(cfg, parser.Trigger{Target: "exp142"})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); !strings.Contains(got, "kernel identity") {
+		t.Fatalf("expected kernel identity error, got %q", got)
+	}
+}

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -49,6 +49,9 @@ func TestResolveUsesTargetDefaults(t *testing.T) {
 	if got.KernelID != "yourname/exp142" {
 		t.Fatalf("unexpected kernel id %q", got.KernelID)
 	}
+	if got.KernelRef != "yourname/exp142" {
+		t.Fatalf("unexpected kernel ref %q", got.KernelRef)
+	}
 	if got.Resources.GPU != true || got.Resources.Internet != false || got.Resources.Private != true {
 		t.Fatalf("unexpected resources: %+v", got.Resources)
 	}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1,6 +1,9 @@
 package spec
 
-import "github.com/shotomorisk/kgh/internal/config"
+import (
+	"github.com/shotomorisk/kgh/internal/config"
+	"github.com/shotomorisk/kgh/internal/kernelref"
+)
 
 // RuntimeOverrides contains the subset of trigger-level fields that can override a target.
 type RuntimeOverrides struct {
@@ -13,6 +16,7 @@ type ExecutionSpec struct {
 	TargetName  string           `json:"target_name" yaml:"target_name"`
 	Notebook    string           `json:"notebook" yaml:"notebook"`
 	KernelID    string           `json:"kernel_id" yaml:"kernel_id"`
+	KernelRef   string           `json:"kernel_ref" yaml:"kernel_ref"`
 	Competition string           `json:"competition" yaml:"competition"`
 	Submit      bool             `json:"submit" yaml:"submit"`
 	Resources   config.Resources `json:"resources" yaml:"resources"`
@@ -22,7 +26,7 @@ type ExecutionSpec struct {
 }
 
 // NewExecutionSpec merges a target definition with supported runtime overrides.
-func NewExecutionSpec(name string, target config.Target, overrides RuntimeOverrides) ExecutionSpec {
+func NewExecutionSpec(name string, target config.Target, overrides RuntimeOverrides) (ExecutionSpec, error) {
 	resources := target.Resources
 	if overrides.GPU != nil {
 		resources.GPU = *overrides.GPU
@@ -31,15 +35,21 @@ func NewExecutionSpec(name string, target config.Target, overrides RuntimeOverri
 		resources.Internet = *overrides.Internet
 	}
 
+	kernelRef, err := kernelref.Normalize(target.KernelID)
+	if err != nil {
+		return ExecutionSpec{}, err
+	}
+
 	return ExecutionSpec{
 		TargetName:  name,
 		Notebook:    target.Notebook,
 		KernelID:    target.KernelID,
+		KernelRef:   kernelRef,
 		Competition: target.Competition,
 		Submit:      target.Submit,
 		Resources:   resources,
 		Sources:     target.Sources,
 		Outputs:     target.Outputs,
 		Overrides:   overrides,
-	}
+	}, nil
 }


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #18 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented on feat/normalize-kernel-identity with three stage commits:

  - d68fa87 Normalize kernel identity in resolved specs
  - 437f096 Surface kernel refs from push output
  - 23dc383 Cover invalid kernel identities

  What changed:

  - Added a reusable kernel identity helper in internal/kernelref/kernelref.go with
    normalization and CLI-output extraction.
  - Extended internal/spec/spec.go so resolved execution specs carry a normalized
    KernelRef alongside the configured KernelID.
  - Updated internal/planner/planner.go to fail cleanly on invalid kernel identities.
  - Made internal/kaggle/adapter.go return a canonical KernelRef from push output and
    treat missing identity as unexpected output.
  - Updated metadata generation in internal/kaggle/metadata.go to prefer the normalized
    ref.
  - Adjusted tests across planner and Kaggle packages to cover normalization, push-output
    parsing, and invalid identity failures.

  Validation:

  - go test ./... passes.
<!-- close -->