### PR TITLE
Implement kaggle kernels status adapter

### DIFF
--- a/internal/kaggle/adapter.go
+++ b/internal/kaggle/adapter.go
@@ -42,6 +42,16 @@ type KernelStatusResponse struct {
 	KernelRef string
 	Status    string
 	Message   string
+	Raw       KernelStatusRawStatus
+}
+
+// KernelStatusRawStatus preserves the parsed CLI output alongside the normalized
+// convenience fields exposed by KernelStatusResponse.
+type KernelStatusRawStatus struct {
+	Fields   map[string]string
+	Stdout   string
+	Stderr   string
+	ExitCode int
 }
 
 type DownloadKernelOutputRequest struct {
@@ -290,6 +300,12 @@ func parseKernelStatusResult(kernelRef string, result Result) (KernelStatusRespo
 		KernelRef: kernelRef,
 		Status:    strings.TrimSpace(status),
 		Message:   strings.TrimSpace(message),
+		Raw: KernelStatusRawStatus{
+			Fields:   cloneStringMap(fields),
+			Stdout:   result.Stdout,
+			Stderr:   result.Stderr,
+			ExitCode: result.ExitCode,
+		},
 	}, nil
 }
 
@@ -472,6 +488,18 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return map[string]string{}
+	}
+
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
 }
 
 func extractKernelRefFromPushResult(result Result) (string, error) {

--- a/internal/kaggle/adapter_test.go
+++ b/internal/kaggle/adapter_test.go
@@ -122,6 +122,52 @@ func TestCLIAdapterKernelStatus(t *testing.T) {
 	}
 }
 
+func TestParseKernelStatusResultPreservesRawFields(t *testing.T) {
+	t.Parallel()
+
+	result := Result{
+		Stdout:   "Kernel status: running\nmessage: queued for execution\nattempt: 2\n",
+		Stderr:   "warning: slow queue\n",
+		ExitCode: 0,
+	}
+
+	resp, err := parseKernelStatusResult("alice/exp142", result)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Status != "running" {
+		t.Fatalf("unexpected status %q", resp.Status)
+	}
+	if resp.Message != "queued for execution" {
+		t.Fatalf("unexpected message %q", resp.Message)
+	}
+	if resp.Raw.Fields["kernelstatus"] != "running" {
+		t.Fatalf("unexpected raw fields %+v", resp.Raw.Fields)
+	}
+	if resp.Raw.Fields["attempt"] != "2" {
+		t.Fatalf("unexpected raw fields %+v", resp.Raw.Fields)
+	}
+	if resp.Raw.Stderr != "warning: slow queue\n" {
+		t.Fatalf("unexpected raw stderr %q", resp.Raw.Stderr)
+	}
+}
+
+func TestCloneStringMapReturnsIndependentCopy(t *testing.T) {
+	t.Parallel()
+
+	source := map[string]string{"status": "running"}
+	got := cloneStringMap(source)
+
+	got["status"] = "complete"
+
+	if source["status"] != "running" {
+		t.Fatalf("expected source map to remain unchanged, got %+v", source)
+	}
+	if got["status"] != "complete" {
+		t.Fatalf("unexpected cloned map %+v", got)
+	}
+}
+
 func TestCLIAdapterDownloadKernelOutput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/kaggle/adapter_test.go
+++ b/internal/kaggle/adapter_test.go
@@ -95,7 +95,7 @@ func TestCLIAdapterKernelStatus(t *testing.T) {
 				t.Fatalf("unexpected args %#v", args)
 			}
 			assertZeroRunOptions(t, opts)
-			return Result{Stdout: "status: complete\nmessage: finished\n"}, nil
+			return Result{Stdout: "status: complete\nmessage: finished\nqueued: false\n"}, nil
 		},
 	}
 
@@ -110,6 +110,15 @@ func TestCLIAdapterKernelStatus(t *testing.T) {
 	}
 	if resp.Status != "complete" || resp.Message != "finished" {
 		t.Fatalf("unexpected status response %+v", resp)
+	}
+	if resp.Raw.ExitCode != 0 {
+		t.Fatalf("unexpected raw exit code %d", resp.Raw.ExitCode)
+	}
+	if resp.Raw.Fields["status"] != "complete" || resp.Raw.Fields["queued"] != "false" {
+		t.Fatalf("unexpected raw fields %+v", resp.Raw.Fields)
+	}
+	if resp.Raw.Stdout != "status: complete\nmessage: finished\nqueued: false\n" {
+		t.Fatalf("unexpected raw stdout %q", resp.Raw.Stdout)
 	}
 }
 


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #19 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented and committed in two stages on feat/kaggle-kernels-status-adapter.

  What changed:

  - internal/kaggle/adapter.go
      - KernelStatusResponse now carries a Raw payload.
      - Added KernelStatusRawStatus with parsed fields plus raw stdout, stderr, and exit
        code.
      - parseKernelStatusResult now preserves the full parsed key/value map and the raw
        command output.
      - Added cloneStringMap to keep the raw map isolated.
  - internal/kaggle/adapter_test.go
      - Extended the adapter test to assert raw fields are preserved.
      - Added parser coverage for fallback status inference and raw-field preservation.
      - Added a clone isolation test for the raw map helper.

  Commits:

  - 34ca331 feat(kaggle): expose raw kernel status output
  - 9f2169a test(kaggle): cover raw kernel status parsing

  Verification:

  - go test ./... passed cleanly.
<!-- close -->