### PR TITLE
Polling loop timeout backoff

### DIFF
--- a/internal/kaggle/adapter.go
+++ b/internal/kaggle/adapter.go
@@ -18,6 +18,7 @@ import (
 type Adapter interface {
 	PushKernel(context.Context, PushKernelRequest) (PushKernelResponse, error)
 	KernelStatus(context.Context, KernelStatusRequest) (KernelStatusResponse, error)
+	PollKernelStatus(context.Context, KernelPollRequest) (KernelPollResult, error)
 	DownloadKernelOutput(context.Context, DownloadKernelOutputRequest) (DownloadKernelOutputResponse, error)
 	SubmitCompetition(context.Context, CompetitionSubmitRequest) (CompetitionSubmitResponse, error)
 	ListCompetitionSubmissions(context.Context, CompetitionSubmissionsRequest) (CompetitionSubmissionsResponse, error)
@@ -103,7 +104,8 @@ type clientRunner interface {
 
 // CLIAdapter maps typed adapter operations to Kaggle CLI invocations.
 type CLIAdapter struct {
-	client clientRunner
+	client    clientRunner
+	newPoller func(KernelStatusQuerier) *KernelPoller
 }
 
 // NewAdapter constructs a workflow-level adapter backed by the Kaggle CLI client.
@@ -141,6 +143,11 @@ func (a *CLIAdapter) KernelStatus(ctx context.Context, req KernelStatusRequest) 
 		return KernelStatusResponse{}, err
 	}
 	return resp, nil
+}
+
+func (a *CLIAdapter) PollKernelStatus(ctx context.Context, req KernelPollRequest) (KernelPollResult, error) {
+	poller := a.kernelPoller()
+	return poller.Poll(ctx, req)
 }
 
 func (a *CLIAdapter) DownloadKernelOutput(ctx context.Context, req DownloadKernelOutputRequest) (DownloadKernelOutputResponse, error) {
@@ -195,6 +202,13 @@ func (a *CLIAdapter) run(ctx context.Context, operation string, args []string, d
 	return result, nil
 }
 
+func (a *CLIAdapter) kernelPoller() *KernelPoller {
+	if a != nil && a.newPoller != nil {
+		return a.newPoller(a)
+	}
+	return NewKernelPoller(a)
+}
+
 // StubAdapter is a compile-ready placeholder implementation for tests and wiring.
 type StubAdapter struct{}
 
@@ -204,6 +218,10 @@ func (StubAdapter) PushKernel(context.Context, PushKernelRequest) (PushKernelRes
 
 func (StubAdapter) KernelStatus(context.Context, KernelStatusRequest) (KernelStatusResponse, error) {
 	return KernelStatusResponse{}, notImplemented("kernel status")
+}
+
+func (StubAdapter) PollKernelStatus(context.Context, KernelPollRequest) (KernelPollResult, error) {
+	return KernelPollResult{}, notImplemented("poll kernel status")
 }
 
 func (StubAdapter) DownloadKernelOutput(context.Context, DownloadKernelOutputRequest) (DownloadKernelOutputResponse, error) {

--- a/internal/kaggle/adapter_test.go
+++ b/internal/kaggle/adapter_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestStubAdapterImplementsAdapter(t *testing.T) {
@@ -119,6 +120,42 @@ func TestCLIAdapterKernelStatus(t *testing.T) {
 	}
 	if resp.Raw.Stdout != "status: complete\nmessage: finished\nqueued: false\n" {
 		t.Fatalf("unexpected raw stdout %q", resp.Raw.Stdout)
+	}
+}
+
+func TestCLIAdapterPollKernelStatus(t *testing.T) {
+	t.Parallel()
+
+	clock := &pollerClock{now: time.Unix(0, 0)}
+	fake := &pollerFakeStatusClient{
+		t: t,
+		responses: []KernelStatusResponse{
+			{KernelRef: "alice/exp142", Status: "running", Message: "queued"},
+			{KernelRef: "alice/exp142", Status: "complete", Message: "finished"},
+		},
+	}
+	adapter := &CLIAdapter{
+		client: &adapterFakeClient{t: t, runFn: func(context.Context, []string, RunOptions) (Result, error) {
+			t.Fatal("PollKernelStatus should not invoke Run directly")
+			return Result{}, nil
+		}},
+		newPoller: func(KernelStatusQuerier) *KernelPoller {
+			return NewKernelPollerWithDeps(fake, clock.Now, clock.Sleep)
+		},
+	}
+
+	result, err := adapter.PollKernelStatus(context.Background(), KernelPollRequest{
+		KernelRef: "alice/exp142",
+		Interval:  time.Second,
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Status != "complete" || result.Message != "finished" {
+		t.Fatalf("unexpected poll result %+v", result)
+	}
+	if result.Attempts != 2 {
+		t.Fatalf("unexpected attempts %d", result.Attempts)
 	}
 }
 
@@ -281,6 +318,17 @@ func TestCLIAdapterForwardsDebugFlag(t *testing.T) {
 			want: []string{"kernels", "status", "-p", "alice/exp142"},
 		},
 		{
+			name: "poll kernel status",
+			run: func(adapter *CLIAdapter) error {
+				_, err := adapter.PollKernelStatus(context.Background(), KernelPollRequest{
+					KernelRef: "alice/exp142",
+					Debug:     true,
+				})
+				return err
+			},
+			want: []string{"kernels", "status", "-p", "alice/exp142"},
+		},
+		{
 			name: "download kernel output",
 			run: func(adapter *CLIAdapter) error {
 				_, err := adapter.DownloadKernelOutput(context.Background(), DownloadKernelOutputRequest{
@@ -333,6 +381,8 @@ func TestCLIAdapterForwardsDebugFlag(t *testing.T) {
 					switch tt.name {
 					case "kernel status":
 						return Result{Stdout: "status: complete\nmessage: finished\n"}, nil
+					case "poll kernel status":
+						return Result{Stdout: "status: complete\nmessage: finished\n"}, nil
 					case "push kernel":
 						return Result{Stdout: "Kernel URL: https://www.kaggle.com/code/alice/exp142\nKernel pushed successfully\n"}, nil
 					case "list competition submissions":
@@ -372,6 +422,19 @@ func TestCLIAdapterNormalizesOperationFailures(t *testing.T) {
 			name: "kernel status invalid credentials",
 			run: func(adapter *CLIAdapter) error {
 				_, err := adapter.KernelStatus(context.Background(), KernelStatusRequest{KernelRef: "alice/exp142"})
+				return err
+			},
+			runErr: &CommandError{
+				ExitCode: 1,
+				Stderr:   "401 Unauthorized: invalid credentials",
+				Err:      errors.New("exit status 1"),
+			},
+			wantCategory: ErrorCategoryInvalidCredentials,
+		},
+		{
+			name: "poll kernel status invalid credentials",
+			run: func(adapter *CLIAdapter) error {
+				_, err := adapter.PollKernelStatus(context.Background(), KernelPollRequest{KernelRef: "alice/exp142"})
 				return err
 			},
 			runErr: &CommandError{
@@ -920,6 +983,13 @@ func TestStubAdapterReturnsNotImplemented(t *testing.T) {
 			},
 		},
 		{
+			name: "poll kernel status",
+			run: func() error {
+				_, err := adapter.PollKernelStatus(ctx, KernelPollRequest{})
+				return err
+			},
+		},
+		{
 			name: "download output",
 			run: func() error {
 				_, err := adapter.DownloadKernelOutput(ctx, DownloadKernelOutputRequest{})
@@ -999,4 +1069,19 @@ func assertDebugRunOptions(t *testing.T, opts RunOptions) {
 	if !opts.Debug {
 		t.Fatal("expected debug flag")
 	}
+}
+
+type pollerFakeStatusClient struct {
+	t         *testing.T
+	responses []KernelStatusResponse
+	calls     int
+}
+
+func (f *pollerFakeStatusClient) KernelStatus(context.Context, KernelStatusRequest) (KernelStatusResponse, error) {
+	if f.calls >= len(f.responses) {
+		f.t.Fatalf("unexpected KernelStatus call %d", f.calls+1)
+	}
+	resp := f.responses[f.calls]
+	f.calls++
+	return resp, nil
 }

--- a/internal/kaggle/doc.go
+++ b/internal/kaggle/doc.go
@@ -5,6 +5,6 @@
 //
 // The package remains intentionally thin. It resolves Kaggle credentials,
 // stages local kernel bundles, delegates external command execution to
-// internal/execx, and returns typed errors that higher layers can surface
-// cleanly.
+// internal/execx, polls kernel status until a terminal state is reached, and
+// returns typed errors that higher layers can surface cleanly.
 package kaggle

--- a/internal/kaggle/poller.go
+++ b/internal/kaggle/poller.go
@@ -1,0 +1,210 @@
+package kaggle
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const defaultKernelPollInterval = 5 * time.Second
+
+// KernelStatusQuerier describes the status lookup needed by the poller.
+type KernelStatusQuerier interface {
+	KernelStatus(context.Context, KernelStatusRequest) (KernelStatusResponse, error)
+}
+
+// PollBackoffFunc returns the next sleep duration after the given attempt.
+// Attempt numbers are 1-based and count successful status checks.
+type PollBackoffFunc func(attempt int, previous time.Duration) time.Duration
+
+// KernelPoller repeatedly queries kernel status until a terminal state is observed.
+type KernelPoller struct {
+	client KernelStatusQuerier
+	now    func() time.Time
+	sleep  func(context.Context, time.Duration) error
+}
+
+// KernelPollRequest configures a polling run.
+type KernelPollRequest struct {
+	KernelRef string
+	Debug     bool
+	Interval  time.Duration
+	Timeout   time.Duration
+	Backoff   PollBackoffFunc
+}
+
+// KernelPollResult captures the last observed kernel status and timing metadata.
+type KernelPollResult struct {
+	KernelStatusResponse
+	Attempts   int
+	StartedAt  time.Time
+	FinishedAt time.Time
+	Elapsed    time.Duration
+}
+
+// KernelPollTimeoutError reports that polling stopped because the timeout expired.
+type KernelPollTimeoutError struct {
+	KernelRef   string
+	Timeout     time.Duration
+	Attempts    int
+	LastStatus  string
+	LastMessage string
+	Err         error
+}
+
+func (e *KernelPollTimeoutError) Error() string {
+	if e == nil {
+		return "kaggle kernel polling timed out"
+	}
+	if e.KernelRef == "" {
+		return fmt.Sprintf("kaggle kernel polling timed out after %s", e.Timeout)
+	}
+	if e.LastStatus == "" {
+		return fmt.Sprintf("kaggle kernel %s polling timed out after %s", e.KernelRef, e.Timeout)
+	}
+	return fmt.Sprintf("kaggle kernel %s polling timed out after %s (last status: %s)", e.KernelRef, e.Timeout, e.LastStatus)
+}
+
+func (e *KernelPollTimeoutError) Unwrap() error { return e.Err }
+
+// NewKernelPoller constructs a poller using production timing primitives.
+func NewKernelPoller(client KernelStatusQuerier) *KernelPoller {
+	return NewKernelPollerWithDeps(client, time.Now, sleepContext)
+}
+
+// NewKernelPollerWithDeps constructs a poller with injected timing functions.
+func NewKernelPollerWithDeps(client KernelStatusQuerier, now func() time.Time, sleep func(context.Context, time.Duration) error) *KernelPoller {
+	if now == nil {
+		now = time.Now
+	}
+	if sleep == nil {
+		sleep = sleepContext
+	}
+	return &KernelPoller{
+		client: client,
+		now:    now,
+		sleep:  sleep,
+	}
+}
+
+// Poll queries kernel status until a terminal state is reached or the timeout expires.
+func (p *KernelPoller) Poll(ctx context.Context, req KernelPollRequest) (KernelPollResult, error) {
+	if p == nil || p.client == nil {
+		return KernelPollResult{}, fmt.Errorf("kaggle kernel poller client is nil")
+	}
+
+	kernelRef, err := requiredValue("kernel ref", req.KernelRef)
+	if err != nil {
+		return KernelPollResult{}, err
+	}
+
+	interval := req.Interval
+	if interval <= 0 {
+		interval = defaultKernelPollInterval
+	}
+
+	startedAt := p.now()
+	deadline := time.Time{}
+	if req.Timeout > 0 {
+		deadline = startedAt.Add(req.Timeout)
+	}
+
+	result := KernelPollResult{
+		StartedAt: startedAt,
+	}
+
+	attempts := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			result.FinishedAt = p.now()
+			result.Elapsed = result.FinishedAt.Sub(startedAt)
+			return result, err
+		}
+		if !deadline.IsZero() && !p.now().Before(deadline) {
+			result.FinishedAt = p.now()
+			result.Elapsed = result.FinishedAt.Sub(startedAt)
+			return result, &KernelPollTimeoutError{
+				KernelRef:   kernelRef,
+				Timeout:     req.Timeout,
+				Attempts:    attempts,
+				LastStatus:  result.Status,
+				LastMessage: result.Message,
+			}
+		}
+
+		status, err := p.client.KernelStatus(ctx, KernelStatusRequest{
+			KernelRef: kernelRef,
+			Debug:     req.Debug,
+		})
+		attempts++
+		if err != nil {
+			result.FinishedAt = p.now()
+			result.Elapsed = result.FinishedAt.Sub(startedAt)
+			return result, err
+		}
+
+		result.KernelStatusResponse = status
+		result.Attempts = attempts
+		if isTerminalKernelStatus(status.Status) {
+			result.FinishedAt = p.now()
+			result.Elapsed = result.FinishedAt.Sub(startedAt)
+			return result, nil
+		}
+
+		delay := interval
+		if req.Backoff != nil {
+			delay = req.Backoff(attempts, delay)
+		}
+		if delay < 0 {
+			delay = 0
+		}
+		if !deadline.IsZero() {
+			remaining := deadline.Sub(p.now())
+			if remaining < delay {
+				delay = remaining
+			}
+			if delay <= 0 {
+				result.FinishedAt = p.now()
+				result.Elapsed = result.FinishedAt.Sub(startedAt)
+				return result, &KernelPollTimeoutError{
+					KernelRef:   kernelRef,
+					Timeout:     req.Timeout,
+					Attempts:    attempts,
+					LastStatus:  result.Status,
+					LastMessage: result.Message,
+				}
+			}
+		}
+
+		if err := p.sleep(ctx, delay); err != nil {
+			result.FinishedAt = p.now()
+			result.Elapsed = result.FinishedAt.Sub(startedAt)
+			return result, err
+		}
+	}
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func isTerminalKernelStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "complete", "completed", "failed", "failure", "error", "cancelled", "canceled", "aborted", "terminated":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/kaggle/poller_test.go
+++ b/internal/kaggle/poller_test.go
@@ -1,0 +1,238 @@
+package kaggle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestKernelPollerStopsOnTerminalStatus(t *testing.T) {
+	t.Parallel()
+
+	clock := &pollerClock{now: time.Unix(0, 0)}
+	client := &pollerFakeClient{
+		t: t,
+		responses: []KernelStatusResponse{
+			{KernelRef: "alice/exp142", Status: "running", Message: "queued"},
+			{KernelRef: "alice/exp142", Status: "complete", Message: "finished"},
+		},
+	}
+	poller := NewKernelPollerWithDeps(client, clock.Now, clock.Sleep)
+
+	result, err := poller.Poll(context.Background(), KernelPollRequest{
+		KernelRef: "alice/exp142",
+		Interval:  2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Attempts != 2 {
+		t.Fatalf("expected two attempts, got %d", result.Attempts)
+	}
+	if result.Status != "complete" || result.Message != "finished" {
+		t.Fatalf("unexpected result %+v", result)
+	}
+	if result.StartedAt != time.Unix(0, 0) {
+		t.Fatalf("unexpected start time %s", result.StartedAt)
+	}
+	if result.FinishedAt != time.Unix(0, 0).Add(2*time.Second) {
+		t.Fatalf("unexpected finish time %s", result.FinishedAt)
+	}
+	if result.Elapsed != 2*time.Second {
+		t.Fatalf("unexpected elapsed %s", result.Elapsed)
+	}
+	if !equalDurations(clock.sleeps, []time.Duration{2 * time.Second}) {
+		t.Fatalf("unexpected sleep schedule %#v", clock.sleeps)
+	}
+}
+
+func TestKernelPollerAppliesBackoffStrategy(t *testing.T) {
+	t.Parallel()
+
+	clock := &pollerClock{now: time.Unix(0, 0)}
+	client := &pollerFakeClient{
+		t: t,
+		responses: []KernelStatusResponse{
+			{KernelRef: "alice/exp142", Status: "running"},
+			{KernelRef: "alice/exp142", Status: "running"},
+			{KernelRef: "alice/exp142", Status: "complete"},
+		},
+	}
+	poller := NewKernelPollerWithDeps(client, clock.Now, clock.Sleep)
+
+	_, err := poller.Poll(context.Background(), KernelPollRequest{
+		KernelRef: "alice/exp142",
+		Interval:  time.Second,
+		Backoff: func(attempt int, previous time.Duration) time.Duration {
+			return time.Duration(attempt) * previous
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !equalDurations(clock.sleeps, []time.Duration{1 * time.Second, 2 * time.Second}) {
+		t.Fatalf("unexpected sleep schedule %#v", clock.sleeps)
+	}
+}
+
+func TestKernelPollerReturnsTimeoutError(t *testing.T) {
+	t.Parallel()
+
+	clock := &pollerClock{now: time.Unix(0, 0)}
+	client := &pollerFakeClient{
+		t: t,
+		responses: []KernelStatusResponse{
+			{KernelRef: "alice/exp142", Status: "running", Message: "queued"},
+			{KernelRef: "alice/exp142", Status: "running", Message: "still queued"},
+			{KernelRef: "alice/exp142", Status: "running", Message: "still queued"},
+		},
+	}
+	poller := NewKernelPollerWithDeps(client, clock.Now, clock.Sleep)
+
+	result, err := poller.Poll(context.Background(), KernelPollRequest{
+		KernelRef: "alice/exp142",
+		Interval:  2 * time.Second,
+		Timeout:   5 * time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var timeoutErr *KernelPollTimeoutError
+	if !errors.As(err, &timeoutErr) {
+		t.Fatalf("expected KernelPollTimeoutError, got %T", err)
+	}
+	if timeoutErr.KernelRef != "alice/exp142" {
+		t.Fatalf("unexpected kernel ref %q", timeoutErr.KernelRef)
+	}
+	if timeoutErr.Timeout != 5*time.Second {
+		t.Fatalf("unexpected timeout %s", timeoutErr.Timeout)
+	}
+	if timeoutErr.Attempts != 3 {
+		t.Fatalf("unexpected attempts %d", timeoutErr.Attempts)
+	}
+	if timeoutErr.LastStatus != "running" {
+		t.Fatalf("unexpected last status %q", timeoutErr.LastStatus)
+	}
+	if result.Attempts != 3 {
+		t.Fatalf("unexpected result attempts %d", result.Attempts)
+	}
+	if result.Status != "running" || result.Message != "still queued" {
+		t.Fatalf("unexpected partial result %+v", result)
+	}
+	if result.Elapsed != 5*time.Second {
+		t.Fatalf("unexpected elapsed %s", result.Elapsed)
+	}
+	if !equalDurations(clock.sleeps, []time.Duration{2 * time.Second, 2 * time.Second, 1 * time.Second}) {
+		t.Fatalf("unexpected sleep schedule %#v", clock.sleeps)
+	}
+}
+
+func TestKernelPollerHonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clock := &pollerClock{now: time.Unix(0, 0)}
+	client := &pollerFakeClient{
+		t: t,
+		responses: []KernelStatusResponse{
+			{KernelRef: "alice/exp142", Status: "running"},
+		},
+	}
+	poller := NewKernelPollerWithDeps(client, clock.Now, func(context.Context, time.Duration) error {
+		cancel()
+		return context.Canceled
+	})
+
+	_, err := poller.Poll(ctx, KernelPollRequest{
+		KernelRef: "alice/exp142",
+		Interval:  time.Second,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+}
+
+func TestIsTerminalKernelStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status string
+		want   bool
+	}{
+		{status: "complete", want: true},
+		{status: "completed", want: true},
+		{status: "failed", want: true},
+		{status: "error", want: true},
+		{status: "cancelled", want: true},
+		{status: "running", want: false},
+		{status: "queued", want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.status, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isTerminalKernelStatus(tt.status); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+type pollerFakeClient struct {
+	t         *testing.T
+	responses []KernelStatusResponse
+	errors    []error
+	calls     int
+}
+
+func (f *pollerFakeClient) KernelStatus(context.Context, KernelStatusRequest) (KernelStatusResponse, error) {
+	if f.t == nil {
+		panic("pollerFakeClient requires a test handle")
+	}
+	if f.calls >= len(f.responses) {
+		f.t.Fatalf("unexpected KernelStatus call %d", f.calls+1)
+	}
+	resp := f.responses[f.calls]
+	var err error
+	if f.calls < len(f.errors) {
+		err = f.errors[f.calls]
+	}
+	f.calls++
+	return resp, err
+}
+
+type pollerClock struct {
+	now    time.Time
+	sleeps []time.Duration
+}
+
+func (c *pollerClock) Now() time.Time {
+	return c.now
+}
+
+func (c *pollerClock) Sleep(_ context.Context, d time.Duration) error {
+	if d < 0 {
+		return fmt.Errorf("negative sleep %s", d)
+	}
+	c.sleeps = append(c.sleeps, d)
+	c.now = c.now.Add(d)
+	return nil
+}
+
+func equalDurations(got, want []time.Duration) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #20 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented on branch feat/issue-21-polling-loop-timeout-backoff with two staged
  commits.

  - 827d0df feat(kaggle): add kernel status poller
  - 1d5241f feat(kaggle): expose kernel polling through adapter

  What changed:

  - Added a reusable polling layer in internal/kaggle/poller.go.
  - Added deterministic tests for terminal states, backoff, timeout, and cancellation in
    internal/kaggle/poller_test.go.
  - Exposed polling through the Kaggle adapter via PollKernelStatus in internal/kaggle/
    adapter.go.
  - Updated adapter tests and package docs in internal/kaggle/adapter_test.go and
    internal/kaggle/doc.go.

  Behavior:

  - Polls KernelStatus until a terminal state is reached.
  - Supports configurable poll interval, timeout, and optional backoff.
  - Returns timing metadata plus the last observed status/message.
  - Returns a structured timeout error when the deadline is reached.
<!-- close -->