### PR TITLE
Terminal failure timeout states with tests data

### DIFF
--- a/internal/kaggle/adapter_test.go
+++ b/internal/kaggle/adapter_test.go
@@ -159,6 +159,49 @@ func TestCLIAdapterPollKernelStatus(t *testing.T) {
 	}
 }
 
+func TestCLIAdapterPollKernelStatusPropagatesTerminalError(t *testing.T) {
+	t.Parallel()
+
+	clock := &pollerClock{now: time.Unix(0, 0)}
+	fake := &pollerFakeStatusClient{
+		t: t,
+		responses: []KernelStatusResponse{
+			{KernelRef: "alice/exp142", Status: "running", Message: "queued"},
+			{KernelRef: "alice/exp142", Status: "cancelled", Message: "user cancelled"},
+		},
+	}
+	adapter := &CLIAdapter{
+		client: &adapterFakeClient{t: t, runFn: func(context.Context, []string, RunOptions) (Result, error) {
+			t.Fatal("PollKernelStatus should not invoke Run directly")
+			return Result{}, nil
+		}},
+		newPoller: func(KernelStatusQuerier) *KernelPoller {
+			return NewKernelPollerWithDeps(fake, clock.Now, clock.Sleep)
+		},
+	}
+
+	result, err := adapter.PollKernelStatus(context.Background(), KernelPollRequest{
+		KernelRef: "alice/exp142",
+		Interval:  time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var terminalErr *KernelPollTerminalError
+	if !errors.As(err, &terminalErr) {
+		t.Fatalf("expected KernelPollTerminalError, got %T", err)
+	}
+	if terminalErr.Terminal != KernelPollTerminalStateCancelled {
+		t.Fatalf("unexpected terminal state %q", terminalErr.Terminal)
+	}
+	if result.Terminal != KernelPollTerminalStateCancelled {
+		t.Fatalf("unexpected result terminal state %q", result.Terminal)
+	}
+	if result.Status != "cancelled" || result.Message != "user cancelled" {
+		t.Fatalf("unexpected poll result %+v", result)
+	}
+}
+
 func TestParseKernelStatusResultPreservesRawFields(t *testing.T) {
 	t.Parallel()
 

--- a/internal/kaggle/lifecycle_test.go
+++ b/internal/kaggle/lifecycle_test.go
@@ -1,0 +1,263 @@
+package kaggle
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestKernelLifecyclePushStatusAndPollSuccess(t *testing.T) {
+	t.Parallel()
+
+	clock := &pollerClock{now: time.Unix(0, 0)}
+	client := &lifecycleScriptedClient{
+		t: t,
+		steps: []lifecycleScriptedStep{
+			{
+				args: []string{"kernels", "push", "-p", "/tmp/work tree"},
+				result: Result{
+					Stdout:   "Kernel URL: https://www.kaggle.com/code/alice/exp142\nKernel pushed successfully\n",
+					Stderr:   "",
+					ExitCode: 0,
+				},
+			},
+			{
+				args: []string{"kernels", "status", "-p", "alice/exp142"},
+				result: Result{
+					Stdout:   "status: running\nmessage: queued for execution\n",
+					Stderr:   "",
+					ExitCode: 0,
+				},
+			},
+			{
+				args: []string{"kernels", "status", "-p", "alice/exp142"},
+				result: Result{
+					Stdout:   "status: running\nmessage: still queued\n",
+					Stderr:   "",
+					ExitCode: 0,
+				},
+			},
+			{
+				args: []string{"kernels", "status", "-p", "alice/exp142"},
+				result: Result{
+					Stdout:   "status: complete\nmessage: finished\n",
+					Stderr:   "",
+					ExitCode: 0,
+				},
+			},
+		},
+	}
+
+	adapter := &CLIAdapter{
+		client: client,
+		newPoller: func(querier KernelStatusQuerier) *KernelPoller {
+			return NewKernelPollerWithDeps(querier, clock.Now, clock.Sleep)
+		},
+	}
+
+	pushResp, err := adapter.PushKernel(context.Background(), PushKernelRequest{
+		WorkDir: "/tmp/work tree",
+	})
+	if err != nil {
+		t.Fatalf("expected push to succeed, got %v", err)
+	}
+	if pushResp.KernelRef != "alice/exp142" {
+		t.Fatalf("unexpected kernel ref %q", pushResp.KernelRef)
+	}
+
+	statusResp, err := adapter.KernelStatus(context.Background(), KernelStatusRequest{
+		KernelRef: pushResp.KernelRef,
+	})
+	if err != nil {
+		t.Fatalf("expected status lookup to succeed, got %v", err)
+	}
+	if statusResp.Status != "running" {
+		t.Fatalf("unexpected status %q", statusResp.Status)
+	}
+	if statusResp.Message != "queued for execution" {
+		t.Fatalf("unexpected message %q", statusResp.Message)
+	}
+
+	pollResp, err := adapter.PollKernelStatus(context.Background(), KernelPollRequest{
+		KernelRef: pushResp.KernelRef,
+		Interval:  time.Second,
+	})
+	if err != nil {
+		t.Fatalf("expected poll to succeed, got %v", err)
+	}
+	if pollResp.Terminal != KernelPollTerminalStateSucceeded {
+		t.Fatalf("unexpected terminal state %q", pollResp.Terminal)
+	}
+	if pollResp.Status != "complete" || pollResp.Message != "finished" {
+		t.Fatalf("unexpected poll result %+v", pollResp)
+	}
+	if pollResp.Attempts != 2 {
+		t.Fatalf("unexpected attempts %d", pollResp.Attempts)
+	}
+	if !equalDurations(clock.sleeps, []time.Duration{time.Second}) {
+		t.Fatalf("unexpected sleep schedule %#v", clock.sleeps)
+	}
+}
+
+func TestKernelLifecyclePollTimeout(t *testing.T) {
+	t.Parallel()
+
+	clock := &pollerClock{now: time.Unix(0, 0)}
+	client := &lifecycleScriptedClient{
+		t: t,
+		steps: []lifecycleScriptedStep{
+			{
+				args: []string{"kernels", "status", "-p", "alice/exp142"},
+				result: Result{
+					Stdout:   "status: running\nmessage: queued\n",
+					Stderr:   "",
+					ExitCode: 0,
+				},
+			},
+			{
+				args: []string{"kernels", "status", "-p", "alice/exp142"},
+				result: Result{
+					Stdout:   "status: running\nmessage: still queued\n",
+					Stderr:   "",
+					ExitCode: 0,
+				},
+			},
+			{
+				args: []string{"kernels", "status", "-p", "alice/exp142"},
+				result: Result{
+					Stdout:   "status: running\nmessage: still queued\n",
+					Stderr:   "",
+					ExitCode: 0,
+				},
+			},
+		},
+	}
+
+	adapter := &CLIAdapter{
+		client: client,
+		newPoller: func(querier KernelStatusQuerier) *KernelPoller {
+			return NewKernelPollerWithDeps(querier, clock.Now, clock.Sleep)
+		},
+	}
+
+	_, err := adapter.PollKernelStatus(context.Background(), KernelPollRequest{
+		KernelRef: "alice/exp142",
+		Interval:  2 * time.Second,
+		Timeout:   5 * time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected polling to time out")
+	}
+
+	var timeoutErr *KernelPollTimeoutError
+	if !errors.As(err, &timeoutErr) {
+		t.Fatalf("expected KernelPollTimeoutError, got %T", err)
+	}
+	if timeoutErr.KernelRef != "alice/exp142" {
+		t.Fatalf("unexpected kernel ref %q", timeoutErr.KernelRef)
+	}
+	if timeoutErr.Timeout != 5*time.Second {
+		t.Fatalf("unexpected timeout %s", timeoutErr.Timeout)
+	}
+	if timeoutErr.Attempts != 3 {
+		t.Fatalf("unexpected attempts %d", timeoutErr.Attempts)
+	}
+	if timeoutErr.LastStatus != "running" {
+		t.Fatalf("unexpected last status %q", timeoutErr.LastStatus)
+	}
+}
+
+func TestKernelLifecycleReportsMalformedStatusOutput(t *testing.T) {
+	t.Parallel()
+
+	client := &lifecycleScriptedClient{
+		t: t,
+		steps: []lifecycleScriptedStep{
+			{
+				args: []string{"kernels", "status", "-p", "alice/exp142"},
+				result: Result{
+					Stdout:   "message: queued\n",
+					Stderr:   "",
+					ExitCode: 0,
+				},
+			},
+		},
+	}
+
+	_, err := (&CLIAdapter{client: client}).KernelStatus(context.Background(), KernelStatusRequest{
+		KernelRef: "alice/exp142",
+	})
+	if err == nil {
+		t.Fatal("expected status parsing to fail")
+	}
+
+	var adapterErr *AdapterError
+	if !errors.As(err, &adapterErr) {
+		t.Fatalf("expected AdapterError, got %T", err)
+	}
+	if adapterErr.Category != ErrorCategoryUnexpectedOutput {
+		t.Fatalf("unexpected category %q", adapterErr.Category)
+	}
+}
+
+func TestKernelLifecycleReportsFailingStatusCommand(t *testing.T) {
+	t.Parallel()
+
+	client := &lifecycleScriptedClient{
+		t: t,
+		steps: []lifecycleScriptedStep{
+			{
+				args: []string{"kernels", "status", "-p", "alice/exp142"},
+				err: &CommandError{
+					ExitCode: 1,
+					Stderr:   "401 Unauthorized: invalid credentials",
+					Err:      errors.New("exit status 1"),
+				},
+			},
+		},
+	}
+
+	_, err := (&CLIAdapter{client: client}).KernelStatus(context.Background(), KernelStatusRequest{
+		KernelRef: "alice/exp142",
+	})
+	if err == nil {
+		t.Fatal("expected status command failure")
+	}
+
+	var adapterErr *AdapterError
+	if !errors.As(err, &adapterErr) {
+		t.Fatalf("expected AdapterError, got %T", err)
+	}
+	if adapterErr.Category != ErrorCategoryInvalidCredentials {
+		t.Fatalf("unexpected category %q", adapterErr.Category)
+	}
+}
+
+type lifecycleScriptedStep struct {
+	args   []string
+	result Result
+	err    error
+}
+
+type lifecycleScriptedClient struct {
+	t     *testing.T
+	steps []lifecycleScriptedStep
+	calls int
+}
+
+func (c *lifecycleScriptedClient) Run(_ context.Context, args []string, opts RunOptions) (Result, error) {
+	if c.calls >= len(c.steps) {
+		c.t.Fatalf("unexpected call %d with args %#v", c.calls+1, args)
+	}
+
+	step := c.steps[c.calls]
+	c.calls++
+
+	if !equalStrings(args, step.args) {
+		c.t.Fatalf("unexpected args %#v", args)
+	}
+	assertZeroRunOptions(c.t, opts)
+
+	return step.result, step.err
+}

--- a/internal/kaggle/poller.go
+++ b/internal/kaggle/poller.go
@@ -41,7 +41,43 @@ type KernelPollResult struct {
 	StartedAt  time.Time
 	FinishedAt time.Time
 	Elapsed    time.Duration
+	Terminal   KernelPollTerminalState
 }
+
+// KernelPollTerminalState classifies the final observed poll outcome.
+type KernelPollTerminalState string
+
+const (
+	KernelPollTerminalStateUnknown   KernelPollTerminalState = ""
+	KernelPollTerminalStateSucceeded KernelPollTerminalState = "succeeded"
+	KernelPollTerminalStateFailed    KernelPollTerminalState = "failed"
+	KernelPollTerminalStateCancelled KernelPollTerminalState = "cancelled"
+)
+
+// KernelPollTerminalError reports a terminal non-success run state with context.
+type KernelPollTerminalError struct {
+	KernelRef   string
+	Terminal    KernelPollTerminalState
+	Attempts    int
+	LastStatus  string
+	LastMessage string
+	Err         error
+}
+
+func (e *KernelPollTerminalError) Error() string {
+	if e == nil {
+		return "kaggle kernel run terminated"
+	}
+	if e.KernelRef == "" {
+		return fmt.Sprintf("kaggle kernel run terminated: %s", e.Terminal)
+	}
+	if e.LastStatus == "" {
+		return fmt.Sprintf("kaggle kernel %s run terminated: %s", e.KernelRef, e.Terminal)
+	}
+	return fmt.Sprintf("kaggle kernel %s run terminated: %s (last status: %s)", e.KernelRef, e.Terminal, e.LastStatus)
+}
+
+func (e *KernelPollTerminalError) Unwrap() error { return e.Err }
 
 // KernelPollTimeoutError reports that polling stopped because the timeout expired.
 type KernelPollTimeoutError struct {
@@ -146,9 +182,20 @@ func (p *KernelPoller) Poll(ctx context.Context, req KernelPollRequest) (KernelP
 
 		result.KernelStatusResponse = status
 		result.Attempts = attempts
-		if isTerminalKernelStatus(status.Status) {
+		terminalState, terminal := classifyTerminalKernelStatus(status.Status)
+		if terminal {
 			result.FinishedAt = p.now()
 			result.Elapsed = result.FinishedAt.Sub(startedAt)
+			result.Terminal = terminalState
+			if terminalState != KernelPollTerminalStateSucceeded {
+				return result, &KernelPollTerminalError{
+					KernelRef:   kernelRef,
+					Terminal:    terminalState,
+					Attempts:    attempts,
+					LastStatus:  result.Status,
+					LastMessage: result.Message,
+				}
+			}
 			return result, nil
 		}
 
@@ -201,10 +248,19 @@ func sleepContext(ctx context.Context, d time.Duration) error {
 }
 
 func isTerminalKernelStatus(status string) bool {
+	_, terminal := classifyTerminalKernelStatus(status)
+	return terminal
+}
+
+func classifyTerminalKernelStatus(status string) (KernelPollTerminalState, bool) {
 	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "complete", "completed", "failed", "failure", "error", "cancelled", "canceled", "aborted", "terminated":
-		return true
+	case "complete", "completed":
+		return KernelPollTerminalStateSucceeded, true
+	case "failed", "failure", "error":
+		return KernelPollTerminalStateFailed, true
+	case "cancelled", "canceled", "aborted", "terminated":
+		return KernelPollTerminalStateCancelled, true
 	default:
-		return false
+		return KernelPollTerminalStateUnknown, false
 	}
 }

--- a/internal/kaggle/poller_test.go
+++ b/internal/kaggle/poller_test.go
@@ -34,6 +34,9 @@ func TestKernelPollerStopsOnTerminalStatus(t *testing.T) {
 	if result.Status != "complete" || result.Message != "finished" {
 		t.Fatalf("unexpected result %+v", result)
 	}
+	if result.Terminal != KernelPollTerminalStateSucceeded {
+		t.Fatalf("unexpected terminal state %q", result.Terminal)
+	}
 	if result.StartedAt != time.Unix(0, 0) {
 		t.Fatalf("unexpected start time %s", result.StartedAt)
 	}
@@ -121,6 +124,9 @@ func TestKernelPollerReturnsTimeoutError(t *testing.T) {
 	if result.Status != "running" || result.Message != "still queued" {
 		t.Fatalf("unexpected partial result %+v", result)
 	}
+	if result.Terminal != KernelPollTerminalStateUnknown {
+		t.Fatalf("unexpected terminal state %q", result.Terminal)
+	}
 	if result.Elapsed != 5*time.Second {
 		t.Fatalf("unexpected elapsed %s", result.Elapsed)
 	}
@@ -156,6 +162,82 @@ func TestKernelPollerHonorsContextCancellation(t *testing.T) {
 	}
 }
 
+func TestKernelPollerReturnsTerminalErrorForFailedStatus(t *testing.T) {
+	t.Parallel()
+
+	clock := &pollerClock{now: time.Unix(0, 0)}
+	client := &pollerFakeClient{
+		t: t,
+		responses: []KernelStatusResponse{
+			{KernelRef: "alice/exp142", Status: "running", Message: "queued"},
+			{KernelRef: "alice/exp142", Status: "failed", Message: "kernel crashed"},
+		},
+	}
+	poller := NewKernelPollerWithDeps(client, clock.Now, clock.Sleep)
+
+	result, err := poller.Poll(context.Background(), KernelPollRequest{
+		KernelRef: "alice/exp142",
+		Interval:  2 * time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var terminalErr *KernelPollTerminalError
+	if !errors.As(err, &terminalErr) {
+		t.Fatalf("expected KernelPollTerminalError, got %T", err)
+	}
+	if terminalErr.Terminal != KernelPollTerminalStateFailed {
+		t.Fatalf("unexpected terminal state %q", terminalErr.Terminal)
+	}
+	if terminalErr.LastStatus != "failed" || terminalErr.LastMessage != "kernel crashed" {
+		t.Fatalf("unexpected terminal error %+v", terminalErr)
+	}
+	if result.Terminal != KernelPollTerminalStateFailed {
+		t.Fatalf("unexpected result terminal state %q", result.Terminal)
+	}
+	if result.Attempts != 2 {
+		t.Fatalf("unexpected attempts %d", result.Attempts)
+	}
+}
+
+func TestKernelPollerReturnsTerminalErrorForCancelledStatus(t *testing.T) {
+	t.Parallel()
+
+	clock := &pollerClock{now: time.Unix(0, 0)}
+	client := &pollerFakeClient{
+		t: t,
+		responses: []KernelStatusResponse{
+			{KernelRef: "alice/exp142", Status: "running", Message: "queued"},
+			{KernelRef: "alice/exp142", Status: "cancelled", Message: "user cancelled"},
+		},
+	}
+	poller := NewKernelPollerWithDeps(client, clock.Now, clock.Sleep)
+
+	result, err := poller.Poll(context.Background(), KernelPollRequest{
+		KernelRef: "alice/exp142",
+		Interval:  2 * time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var terminalErr *KernelPollTerminalError
+	if !errors.As(err, &terminalErr) {
+		t.Fatalf("expected KernelPollTerminalError, got %T", err)
+	}
+	if terminalErr.Terminal != KernelPollTerminalStateCancelled {
+		t.Fatalf("unexpected terminal state %q", terminalErr.Terminal)
+	}
+	if terminalErr.LastStatus != "cancelled" || terminalErr.LastMessage != "user cancelled" {
+		t.Fatalf("unexpected terminal error %+v", terminalErr)
+	}
+	if result.Terminal != KernelPollTerminalStateCancelled {
+		t.Fatalf("unexpected result terminal state %q", result.Terminal)
+	}
+	if result.Attempts != 2 {
+		t.Fatalf("unexpected attempts %d", result.Attempts)
+	}
+}
+
 func TestIsTerminalKernelStatus(t *testing.T) {
 	t.Parallel()
 
@@ -179,6 +261,35 @@ func TestIsTerminalKernelStatus(t *testing.T) {
 
 			if got := isTerminalKernelStatus(tt.status); got != tt.want {
 				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestClassifyTerminalKernelStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status string
+		want   KernelPollTerminalState
+		ok     bool
+	}{
+		{status: "complete", want: KernelPollTerminalStateSucceeded, ok: true},
+		{status: "failed", want: KernelPollTerminalStateFailed, ok: true},
+		{status: "error", want: KernelPollTerminalStateFailed, ok: true},
+		{status: "cancelled", want: KernelPollTerminalStateCancelled, ok: true},
+		{status: "aborted", want: KernelPollTerminalStateCancelled, ok: true},
+		{status: "running", want: KernelPollTerminalStateUnknown, ok: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.status, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := classifyTerminalKernelStatus(tt.status)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("unexpected classification got=(%q,%v) want=(%q,%v)", got, ok, tt.want, tt.ok)
 			}
 		})
 	}


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #22 
- [ ] Github issue: Closes: #23 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented in internal/kaggle/lifecycle_test.go.

  What changed:

  - Added a deterministic lifecycle test that exercises PushKernel -> KernelStatus ->
    PollKernelStatus with scripted fake CLI output.
  - Added adapter-level timeout coverage through the real poller wiring, using the
    existing fake clock.
  - Added malformed status output coverage.
  - Added failing status command coverage via normalized CommandError handling.

  Verification:

  - go test ./internal/kaggle/...
  - go test ./...
<!-- close -->