### PR TITLE
Normalized the CLI around kgh and fixed the repo’s build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test:
 	go test ./...
 
 build:
-	go build ./cmd/kh
+	go build ./cmd/kgh
 
 fmt:
 	gofmt -w $(shell find . -name '*.go' -not -path './vendor/*')

--- a/cmd/kgh/main.go
+++ b/cmd/kgh/main.go
@@ -12,6 +12,8 @@ func main() {
 }
 
 func run(args []string) int {
+	args = stripCommandName(args)
+
 	if len(args) == 0 {
 		printUsage()
 		return 0
@@ -31,17 +33,30 @@ func run(args []string) int {
 	}
 }
 
+func stripCommandName(args []string) []string {
+	if len(args) == 0 {
+		return args
+	}
+
+	switch args[0] {
+	case "kgh", "kh":
+		return args[1:]
+	default:
+		return args
+	}
+}
+
 func printUsage() {
-	fmt.Print(`kh is a GitHub-native CLI for Kaggle workflows.
+	fmt.Print(`kgh is a GitHub-native CLI for Kaggle workflows.
 
 Usage:
-  kh <command>
+  kgh <command>
 
 Available Commands:
-  version   Print the current kh version
+  version   Print the current kgh version
   help      Show this help message
 
 Examples:
-  kh version
+  kgh version
 `)
 }

--- a/cmd/kgh/main_test.go
+++ b/cmd/kgh/main_test.go
@@ -8,6 +8,12 @@ func TestRun_Help(t *testing.T) {
 	}
 }
 
+func TestRun_StripsCommandNamePrefix(t *testing.T) {
+	if code := run([]string{"kgh", "help"}); code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+}
+
 func TestRun_UnknownCommand(t *testing.T) {
 	if code := run([]string{"wat"}); code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
I normalized the CLI around kgh and fixed the repo’s build target.

  What changed:

  - cmd/kgh/main.go:14 now strips a leading kgh or kh token before dispatch, so go run ./
    cmd/kgh/main.go kgh help no longer fails on the extra binary-name argument.
  - cmd/kgh/main.go:49 now prints kgh in the usage text instead of kh.
  - cmd/kgh/main_test.go:11 covers the leading-kgh case.
  - Makefile:6 now builds ./cmd/kgh instead of the stale ./cmd/kh.

  Verification:

  - go test ./cmd/kgh ./internal/... passes.
  - go run ./cmd/kgh/main.go kgh help now works.

  One remaining limitation: the run subcommand is still not implemented in this stub, so
  your exact command now gets past kgh but still fails on run with unknown command: run.
<!-- close -->