### PR TITLE
kgh run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ go build ./cmd/kgh
 ./kgh version
 ```
 
+To run a target locally, create `.kgh/config.yaml` from `.kgh/config_example.yaml` and then:
+
+```bash
+./kgh run --target exp142
+./kgh run --target exp142 --dry-run=false
+```
+
 ### Kaggle smoke test
 
 Use the live smoke path only when you need to validate the adapter against real Kaggle credentials and the Kaggle CLI.

--- a/cmd/kgh/main.go
+++ b/cmd/kgh/main.go
@@ -1,8 +1,16 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"flag"
 	"fmt"
+	"io"
 	"os"
+	"strconv"
+	"strings"
+
+	"github.com/shotomorisk/kgh/internal/execution"
 )
 
 var version = "dev"
@@ -12,25 +20,130 @@ func main() {
 }
 
 func run(args []string) int {
+	return runWithIO(args, os.Stdout, os.Stderr)
+}
+
+func runWithIO(args []string, stdout, stderr io.Writer) int {
 	args = stripCommandName(args)
 
 	if len(args) == 0 {
-		printUsage()
+		printUsage(stdout)
 		return 0
 	}
 
 	switch args[0] {
 	case "version", "--version", "-v":
-		fmt.Println(version)
+		fmt.Fprintln(stdout, version)
 		return 0
 	case "help", "--help", "-h":
-		printUsage()
+		printUsage(stdout)
 		return 0
+	case "run":
+		code, err := runCommand(context.Background(), args[1:], stdout, stderr)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+		}
+		return code
 	default:
-		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", args[0])
-		printUsage()
+		fmt.Fprintf(stderr, "unknown command: %s\n\n", args[0])
+		printUsage(stderr)
 		return 1
 	}
+}
+
+type runFlags struct {
+	target   string
+	dryRun   bool
+	gpu      *bool
+	internet *bool
+}
+
+func runCommand(ctx context.Context, args []string, stdout, stderr io.Writer) (int, error) {
+	flags, err := parseRunFlags(args)
+	if err != nil {
+		return 1, err
+	}
+
+	runner := execution.NewRunner(nil)
+	report, err := runner.Execute(ctx, execution.Request{
+		Target:     flags.target,
+		DryRun:     flags.dryRun,
+		GPU:        flags.gpu,
+		Internet:   flags.internet,
+		ConfigPath: execution.DefaultConfigPath,
+	})
+	if err != nil {
+		return 1, err
+	}
+
+	payload, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return 1, fmt.Errorf("marshal run output: %w", err)
+	}
+
+	if _, err := stdout.Write(append(payload, '\n')); err != nil {
+		return 1, err
+	}
+	return 0, nil
+}
+
+func parseRunFlags(args []string) (runFlags, error) {
+	fs := flag.NewFlagSet("run", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	var flags runFlags
+
+	fs.StringVar(&flags.target, "target", "", "target name to run")
+	fs.BoolVar(&flags.dryRun, "dry-run", true, "print resolved execution JSON without invoking Kaggle")
+	fs.Func("gpu", "override GPU setting with true or false", func(value string) error {
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("invalid value for --gpu: %q: expected true or false", value)
+		}
+		flags.gpu = boolPtr(parsed)
+		return nil
+	})
+	fs.Func("internet", "override internet setting with true or false", func(value string) error {
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("invalid value for --internet: %q: expected true or false", value)
+		}
+		flags.internet = boolPtr(parsed)
+		return nil
+	})
+
+	if err := fs.Parse(args); err != nil {
+		return runFlags{}, err
+	}
+	if len(fs.Args()) != 0 {
+		return runFlags{}, fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if strings.TrimSpace(flags.target) == "" {
+		return runFlags{}, fmt.Errorf("--target is required")
+	}
+	return flags, nil
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprint(w, `kgh is a GitHub-native CLI for Kaggle workflows.
+
+Usage:
+  kgh <command>
+
+Available Commands:
+  version   Print the current kgh version
+  help      Show this help message
+  run       Resolve and execute a Kaggle target
+
+Examples:
+  kgh run --target exp142
+  kgh run --target exp142 --dry-run=false
+  kgh version
+`)
 }
 
 func stripCommandName(args []string) []string {
@@ -44,19 +157,4 @@ func stripCommandName(args []string) []string {
 	default:
 		return args
 	}
-}
-
-func printUsage() {
-	fmt.Print(`kgh is a GitHub-native CLI for Kaggle workflows.
-
-Usage:
-  kgh <command>
-
-Available Commands:
-  version   Print the current kgh version
-  help      Show this help message
-
-Examples:
-  kgh version
-`)
 }

--- a/cmd/kgh/main_test.go
+++ b/cmd/kgh/main_test.go
@@ -20,6 +20,18 @@ func TestRun_StripsCommandNamePrefix(t *testing.T) {
 	}
 }
 
+func TestRunHelpMentionsRun(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	if code := runWithIO([]string{"help"}, stdout, stderr); code != 0 {
+		t.Fatalf("expected exit code 0, got %d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "run       Resolve and execute a Kaggle target") {
+		t.Fatalf("expected run command in help output, got %s", stdout.String())
+	}
+}
+
 func TestRun_UnknownCommand(t *testing.T) {
 	if code := run([]string{"wat"}); code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)

--- a/cmd/kgh/main_test.go
+++ b/cmd/kgh/main_test.go
@@ -1,6 +1,12 @@
 package main
 
-import "testing"
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestRun_Help(t *testing.T) {
 	if code := run([]string{"help"}); code != 0 {
@@ -17,5 +23,73 @@ func TestRun_StripsCommandNamePrefix(t *testing.T) {
 func TestRun_UnknownCommand(t *testing.T) {
 	if code := run([]string{"wat"}); code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
+	}
+}
+
+func TestParseRunFlagsRequiresTarget(t *testing.T) {
+	t.Parallel()
+
+	if _, err := parseRunFlags([]string{"--dry-run"}); err == nil || !strings.Contains(err.Error(), "--target is required") {
+		t.Fatalf("expected target validation error, got %v", err)
+	}
+}
+
+func TestParseRunFlagsValidatesOverrides(t *testing.T) {
+	t.Parallel()
+
+	if _, err := parseRunFlags([]string{"--target", "exp142", "--gpu", "maybe"}); err == nil || !strings.Contains(err.Error(), "invalid value for --gpu") {
+		t.Fatalf("expected gpu validation error, got %v", err)
+	}
+}
+
+func TestRunDryRunOutputsJSON(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, ".kgh")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(`
+targets:
+  exp142:
+    notebook: notebooks/exp142.ipynb
+    kernel_id: yourname/exp142
+    competition: playground-series-s6e2
+    submit: true
+    resources:
+      gpu: true
+      internet: false
+      private: true
+    outputs:
+      submission: submission.csv
+      metrics: metrics.json
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get wd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldwd)
+	})
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runWithIO([]string{"run", "--target", "exp142"}, stdout, stderr); code != 0 {
+		t.Fatalf("expected exit code 0, got %d stderr=%s", code, stderr.String())
+	}
+
+	if got := stdout.String(); !strings.Contains(got, `"mode": "dry-run"`) {
+		t.Fatalf("expected dry-run JSON, got %s", got)
+	}
+	if !strings.Contains(stdout.String(), `"target_name": "exp142"`) {
+		t.Fatalf("expected target name in output, got %s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr, got %s", stderr.String())
 	}
 }

--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -1,0 +1,126 @@
+package execution
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/shotomorisk/kgh/internal/config"
+	"github.com/shotomorisk/kgh/internal/kaggle"
+	"github.com/shotomorisk/kgh/internal/parser"
+	"github.com/shotomorisk/kgh/internal/planner"
+	"github.com/shotomorisk/kgh/internal/spec"
+)
+
+const DefaultConfigPath = config.DefaultPath
+
+const (
+	ModeDryRun = "dry-run"
+	ModeLive   = "live"
+)
+
+type Request struct {
+	Target     string
+	DryRun     bool
+	GPU        *bool
+	Internet   *bool
+	ConfigPath string
+}
+
+type Result struct {
+	Mode       string             `json:"mode"`
+	DryRun     bool               `json:"dry_run"`
+	ConfigPath string             `json:"config_path"`
+	Execution  spec.ExecutionSpec `json:"execution"`
+	Bundle     *BundleResult      `json:"bundle,omitempty"`
+	Push       *PushResult        `json:"push,omitempty"`
+	Poll       *PollResult        `json:"poll,omitempty"`
+}
+
+type BundleResult struct {
+	WorkDir      string `json:"work_dir"`
+	NotebookPath string `json:"notebook_path"`
+	MetadataPath string `json:"metadata_path"`
+}
+
+type PushResult struct {
+	KernelRef string `json:"kernel_ref"`
+	ExitCode  int    `json:"exit_code"`
+	Stdout    string `json:"stdout,omitempty"`
+	Stderr    string `json:"stderr,omitempty"`
+}
+
+type PollResult struct {
+	KernelRef  string                         `json:"kernel_ref"`
+	Status     string                         `json:"status"`
+	Message    string                         `json:"message,omitempty"`
+	Attempts   int                            `json:"attempts"`
+	Terminal   kaggle.KernelPollTerminalState `json:"terminal,omitempty"`
+	StartedAt  time.Time                      `json:"started_at"`
+	FinishedAt time.Time                      `json:"finished_at"`
+	Elapsed    time.Duration                  `json:"elapsed"`
+}
+
+type Adapter interface {
+	PushKernel(context.Context, kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error)
+	PollKernelStatus(context.Context, kaggle.KernelPollRequest) (kaggle.KernelPollResult, error)
+}
+
+type Runner struct {
+	loadConfig   func(string) (config.Config, error)
+	adapter      Adapter
+	pollTimeout  time.Duration
+	pollInterval time.Duration
+}
+
+func NewRunner(adapter Adapter) *Runner {
+	if adapter == nil {
+		adapter = kaggle.NewAdapter(kaggle.NewClient()).(Adapter)
+	}
+	return &Runner{
+		loadConfig:   config.Load,
+		adapter:      adapter,
+		pollTimeout:  30 * time.Minute,
+		pollInterval: 5 * time.Second,
+	}
+}
+
+func (r *Runner) Execute(ctx context.Context, req Request) (Result, error) {
+	if r == nil {
+		return Result{}, fmt.Errorf("execution runner is nil")
+	}
+	if r.loadConfig == nil {
+		r.loadConfig = config.Load
+	}
+	if req.ConfigPath == "" {
+		req.ConfigPath = DefaultConfigPath
+	}
+
+	cfg, err := r.loadConfig(req.ConfigPath)
+	if err != nil {
+		return Result{}, fmt.Errorf("load config %q: %w", req.ConfigPath, err)
+	}
+
+	trigger := parser.Trigger{
+		Target:   req.Target,
+		GPU:      req.GPU,
+		Internet: req.Internet,
+	}
+
+	execSpec, err := planner.Resolve(cfg, trigger)
+	if err != nil {
+		return Result{}, err
+	}
+
+	report := Result{
+		Mode:       ModeDryRun,
+		DryRun:     true,
+		ConfigPath: req.ConfigPath,
+		Execution:  execSpec,
+	}
+	if !req.DryRun {
+		return Result{}, fmt.Errorf("live execution is not implemented yet")
+	}
+
+	return report, nil
+}

--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -59,6 +59,7 @@ type PollResult struct {
 	StartedAt  time.Time                      `json:"started_at"`
 	FinishedAt time.Time                      `json:"finished_at"`
 	Elapsed    time.Duration                  `json:"elapsed"`
+	Raw        kaggle.KernelStatusRawStatus   `json:"raw,omitempty"`
 }
 
 type Adapter interface {
@@ -119,7 +120,75 @@ func (r *Runner) Execute(ctx context.Context, req Request) (Result, error) {
 		Execution:  execSpec,
 	}
 	if !req.DryRun {
-		return Result{}, fmt.Errorf("live execution is not implemented yet")
+		return r.executeLive(ctx, execSpec, report)
+	}
+
+	return report, nil
+}
+
+func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, report Result) (Result, error) {
+	if r.adapter == nil {
+		return Result{}, fmt.Errorf("live execution requires a Kaggle adapter")
+	}
+
+	bundle, err := kaggle.StageKernelBundle(execSpec)
+	if err != nil {
+		return Result{}, fmt.Errorf("stage kaggle bundle: %w", err)
+	}
+	defer func() {
+		if bundle.Cleanup != nil {
+			_ = bundle.Cleanup()
+		}
+	}()
+
+	report.Mode = ModeLive
+	report.DryRun = false
+	report.Bundle = &BundleResult{
+		WorkDir:      bundle.WorkDir,
+		NotebookPath: bundle.NotebookPath,
+		MetadataPath: bundle.MetadataPath,
+	}
+
+	pushResp, err := r.adapter.PushKernel(ctx, kaggle.PushKernelRequest{
+		WorkDir: bundle.WorkDir,
+	})
+	if err != nil {
+		return report, fmt.Errorf("push kaggle kernel: %w", err)
+	}
+	report.Push = &PushResult{
+		KernelRef: pushResp.KernelRef,
+		ExitCode:  pushResp.Output.ExitCode,
+		Stdout:    pushResp.Output.Stdout,
+		Stderr:    pushResp.Output.Stderr,
+	}
+
+	pollTimeout := r.pollTimeout
+	if pollTimeout <= 0 {
+		pollTimeout = 30 * time.Minute
+	}
+	pollInterval := r.pollInterval
+	if pollInterval <= 0 {
+		pollInterval = 5 * time.Second
+	}
+
+	pollResp, err := r.adapter.PollKernelStatus(ctx, kaggle.KernelPollRequest{
+		KernelRef: pushResp.KernelRef,
+		Interval:  pollInterval,
+		Timeout:   pollTimeout,
+	})
+	if err != nil {
+		return report, fmt.Errorf("poll kaggle kernel: %w", err)
+	}
+	report.Poll = &PollResult{
+		KernelRef:  pollResp.KernelRef,
+		Status:     pollResp.Status,
+		Message:    pollResp.Message,
+		Attempts:   pollResp.Attempts,
+		Terminal:   pollResp.Terminal,
+		StartedAt:  pollResp.StartedAt,
+		FinishedAt: pollResp.FinishedAt,
+		Elapsed:    pollResp.Elapsed,
+		Raw:        pollResp.KernelStatusResponse.Raw,
 	}
 
 	return report, nil

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/shotomorisk/kgh/internal/kaggle"
 )
 
 func TestRunnerExecuteDryRun(t *testing.T) {
@@ -127,4 +130,128 @@ func TestRunnerExecuteConfigLoadFailure(t *testing.T) {
 	if got := err.Error(); !strings.Contains(got, "load config") {
 		t.Fatalf("unexpected error %q", got)
 	}
+}
+
+func TestRunnerExecuteLive(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	notebook := filepath.Join(dir, "notebooks", "exp142.ipynb")
+	if err := os.MkdirAll(filepath.Dir(notebook), 0o755); err != nil {
+		t.Fatalf("mkdir notebook dir: %v", err)
+	}
+	if err := os.WriteFile(notebook, []byte(`{"cells":[]}`), 0o644); err != nil {
+		t.Fatalf("write notebook: %v", err)
+	}
+
+	configPath := filepath.Join(dir, ".kgh", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`
+targets:
+  exp142:
+    notebook: `+notebook+`
+    kernel_id: yourname/exp142
+    competition: playground-series-s6e2
+    submit: true
+    resources:
+      gpu: true
+      internet: false
+      private: true
+    outputs:
+      submission: submission.csv
+      metrics: metrics.json
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	adapter := &liveAdapter{
+		t: t,
+		pushFn: func(_ context.Context, req kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error) {
+			if req.WorkDir == "" {
+				t.Fatal("expected work dir to be set")
+			}
+			return kaggle.PushKernelResponse{
+				KernelRef: "yourname/exp142",
+				Output: kaggle.Result{
+					Stdout:   "Kernel URL: https://www.kaggle.com/code/yourname/exp142\n",
+					Stderr:   "",
+					ExitCode: 0,
+				},
+			}, nil
+		},
+		pollFn: func(_ context.Context, req kaggle.KernelPollRequest) (kaggle.KernelPollResult, error) {
+			if req.KernelRef != "yourname/exp142" {
+				t.Fatalf("unexpected kernel ref %q", req.KernelRef)
+			}
+			return kaggle.KernelPollResult{
+				KernelStatusResponse: kaggle.KernelStatusResponse{
+					KernelRef: "yourname/exp142",
+					Status:    "complete",
+					Message:   "finished",
+					Raw: kaggle.KernelStatusRawStatus{
+						Fields: map[string]string{"status": "complete"},
+					},
+				},
+				Attempts:   2,
+				StartedAt:  time.Unix(0, 0),
+				FinishedAt: time.Unix(5, 0),
+				Elapsed:    5 * time.Second,
+				Terminal:   kaggle.KernelPollTerminalStateSucceeded,
+			}, nil
+		},
+	}
+
+	runner := NewRunner(adapter)
+	runner.pollTimeout = 10 * time.Second
+	runner.pollInterval = time.Second
+
+	report, err := runner.Execute(context.Background(), Request{
+		Target:     "exp142",
+		DryRun:     false,
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if report.Mode != ModeLive {
+		t.Fatalf("unexpected mode %q", report.Mode)
+	}
+	if report.DryRun {
+		t.Fatalf("expected dry-run flag to be false")
+	}
+	if report.Bundle == nil || report.Push == nil || report.Poll == nil {
+		t.Fatalf("expected live report sections to be populated: %+v", report)
+	}
+	if report.Push.KernelRef != "yourname/exp142" {
+		t.Fatalf("unexpected pushed kernel ref %q", report.Push.KernelRef)
+	}
+	if report.Poll.Status != "complete" {
+		t.Fatalf("unexpected poll status %q", report.Poll.Status)
+	}
+	if report.Poll.Terminal != kaggle.KernelPollTerminalStateSucceeded {
+		t.Fatalf("unexpected terminal state %q", report.Poll.Terminal)
+	}
+}
+
+type liveAdapter struct {
+	t      *testing.T
+	pushFn func(context.Context, kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error)
+	pollFn func(context.Context, kaggle.KernelPollRequest) (kaggle.KernelPollResult, error)
+}
+
+func (a *liveAdapter) PushKernel(ctx context.Context, req kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error) {
+	if a.pushFn == nil {
+		a.t.Fatal("pushFn must be set")
+	}
+	return a.pushFn(ctx, req)
+}
+
+func (a *liveAdapter) PollKernelStatus(ctx context.Context, req kaggle.KernelPollRequest) (kaggle.KernelPollResult, error) {
+	if a.pollFn == nil {
+		a.t.Fatal("pollFn must be set")
+	}
+	return a.pollFn(ctx, req)
 }

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -1,0 +1,130 @@
+package execution
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunnerExecuteDryRun(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, ".kgh")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+targets:
+  exp142:
+    notebook: notebooks/exp142.ipynb
+    kernel_id: yourname/exp142
+    competition: playground-series-s6e2
+    submit: true
+    resources:
+      gpu: true
+      internet: false
+      private: true
+    sources:
+      competition_sources:
+        - playground-series-s6e2
+      dataset_sources:
+        - yourname/feature-pack-v3
+    outputs:
+      submission: submission.csv
+      metrics: metrics.json
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	gpu := false
+	internet := true
+
+	runner := NewRunner(nil)
+	report, err := runner.Execute(context.Background(), Request{
+		Target:     "exp142",
+		DryRun:     true,
+		GPU:        &gpu,
+		Internet:   &internet,
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if report.Mode != ModeDryRun {
+		t.Fatalf("unexpected mode %q", report.Mode)
+	}
+	if !report.DryRun {
+		t.Fatalf("expected dry-run flag to be true")
+	}
+	if report.Execution.TargetName != "exp142" {
+		t.Fatalf("unexpected target name %q", report.Execution.TargetName)
+	}
+	if report.Execution.Notebook != "notebooks/exp142.ipynb" {
+		t.Fatalf("unexpected notebook %q", report.Execution.Notebook)
+	}
+	if report.Execution.KernelID != "yourname/exp142" {
+		t.Fatalf("unexpected kernel id %q", report.Execution.KernelID)
+	}
+	if report.Execution.Resources.GPU {
+		t.Fatalf("expected gpu override to be false")
+	}
+	if !report.Execution.Resources.Internet {
+		t.Fatalf("expected internet override to be true")
+	}
+	if report.Execution.Outputs.Submission != "submission.csv" {
+		t.Fatalf("unexpected submission output %q", report.Execution.Outputs.Submission)
+	}
+	if report.Execution.Outputs.Metrics != "metrics.json" {
+		t.Fatalf("unexpected metrics output %q", report.Execution.Outputs.Metrics)
+	}
+}
+
+func TestRunnerExecuteMissingTarget(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+targets:
+  exp142:
+    notebook: notebooks/exp142.ipynb
+    kernel_id: yourname/exp142
+    competition: playground-series-s6e2
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := NewRunner(nil).Execute(context.Background(), Request{
+		Target:     "missing",
+		DryRun:     true,
+		ConfigPath: configPath,
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); !strings.Contains(got, `unknown target "missing"`) {
+		t.Fatalf("unexpected error %q", got)
+	}
+}
+
+func TestRunnerExecuteConfigLoadFailure(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewRunner(nil).Execute(context.Background(), Request{
+		Target:     "exp142",
+		DryRun:     true,
+		ConfigPath: filepath.Join(t.TempDir(), "missing.yaml"),
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); !strings.Contains(got, "load config") {
+		t.Fatalf("unexpected error %q", got)
+	}
+}


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #57 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented and committed in stages:

  - 8c405d3 feat: add kgh run dry-run wiring
  - d192504 feat: wire live kaggle execution
  - 0a77e20 docs: update run command usage

  What changed:

  - Added kgh run to the CLI with required --target, default --dry-run=true, and --gpu /
    --internet overrides.
  - Added internal/execution to load .kgh/config.yaml, resolve targets through the
    existing planner/spec layers, and emit structured JSON for dry-run.
  - Wired live mode to stage a Kaggle bundle, push it, and poll for completion, returning
    structured push/poll status.
  - Updated help text and README usage for the new command.

  Verification:

  - go test ./...
  - go build ./cmd/kgh

  Relevant files:

  - cmd/kgh/main.go
  - internal/execution/execution.go
  - README.md
<!-- close -->