### PR TITLE
kaggle submission validation

### DIFF
--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -71,12 +71,12 @@ type PollResult struct {
 }
 
 type OutputsResult struct {
-	OutputDir      string                  `json:"output_dir"`
-	SubmissionPath string                  `json:"submission_path"`
-	MetricsPath    string                  `json:"metrics_path"`
-	Submission     OutputFileResult        `json:"submission"`
-	Metrics        OutputFileResult        `json:"metrics"`
-	Validation     OutputValidationResult  `json:"validation"`
+	OutputDir      string                 `json:"output_dir"`
+	SubmissionPath string                 `json:"submission_path"`
+	MetricsPath    string                 `json:"metrics_path"`
+	Submission     OutputFileResult       `json:"submission"`
+	Metrics        OutputFileResult       `json:"metrics"`
+	Validation     OutputValidationResult `json:"validation"`
 }
 
 type OutputValidationResult struct {

--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -71,12 +71,18 @@ type PollResult struct {
 }
 
 type OutputsResult struct {
-	OutputDir        string           `json:"output_dir"`
-	SubmissionPath   string           `json:"submission_path"`
-	MetricsPath      string           `json:"metrics_path"`
-	Submission       OutputFileResult `json:"submission"`
-	Metrics          OutputFileResult `json:"metrics"`
-	ValidationErrors []string         `json:"validation_errors"`
+	OutputDir      string                  `json:"output_dir"`
+	SubmissionPath string                  `json:"submission_path"`
+	MetricsPath    string                  `json:"metrics_path"`
+	Submission     OutputFileResult        `json:"submission"`
+	Metrics        OutputFileResult        `json:"metrics"`
+	Validation     OutputValidationResult  `json:"validation"`
+}
+
+type OutputValidationResult struct {
+	Valid           bool     `json:"valid"`
+	MissingRequired []string `json:"missing_required"`
+	MissingOptional []string `json:"missing_optional"`
 }
 
 type OutputFileResult struct {
@@ -84,6 +90,8 @@ type OutputFileResult struct {
 	ExpectedPath   string `json:"expected_path"`
 	Path           string `json:"path"`
 	Present        bool   `json:"present"`
+	Required       bool   `json:"required"`
+	Error          string `json:"error"`
 }
 
 type Duration time.Duration
@@ -289,8 +297,8 @@ func buildOutputsResult(execSpec spec.ExecutionSpec, outputDir string) (OutputsR
 		return OutputsResult{}, fmt.Errorf("output dir %q is not a directory", resolvedDir)
 	}
 
-	submission, submissionErr := resolveOutputFile(resolvedDir, execSpec.Outputs.Submission, "submission")
-	metrics, metricsErr := resolveOutputFile(resolvedDir, execSpec.Outputs.Metrics, "metrics")
+	submission := resolveOutputFile(resolvedDir, execSpec.Outputs.Submission, "submission", execSpec.Submit)
+	metrics := resolveOutputFile(resolvedDir, execSpec.Outputs.Metrics, "metrics", false)
 
 	result := OutputsResult{
 		OutputDir:      resolvedDir,
@@ -298,48 +306,69 @@ func buildOutputsResult(execSpec spec.ExecutionSpec, outputDir string) (OutputsR
 		MetricsPath:    metrics.Path,
 		Submission:     submission,
 		Metrics:        metrics,
+		Validation: OutputValidationResult{
+			Valid: true,
+		},
 	}
-	if submissionErr != "" {
-		result.ValidationErrors = append(result.ValidationErrors, submissionErr)
-	}
-	if metricsErr != "" {
-		result.ValidationErrors = append(result.ValidationErrors, metricsErr)
-	}
+
+	applyOutputValidation(&result.Validation, "submission", submission)
+	applyOutputValidation(&result.Validation, "metrics", metrics)
+
 	return result, nil
 }
 
-func resolveOutputFile(outputDir, configuredPath, label string) (OutputFileResult, string) {
+func resolveOutputFile(outputDir, configuredPath, label string, required bool) OutputFileResult {
 	result := OutputFileResult{
 		ConfiguredPath: configuredPath,
+		Required:       required,
 	}
 	if configuredPath == "" {
-		return result, fmt.Sprintf("%s output is not configured", label)
+		result.Error = fmt.Sprintf("%s output is not configured", label)
+		return result
 	}
 
 	expectedPath, err := filepath.Abs(filepath.Join(outputDir, filepath.Clean(configuredPath)))
 	if err != nil {
-		return result, fmt.Sprintf("resolve %s output path %q: %v", label, configuredPath, err)
+		result.Error = fmt.Sprintf("resolve %s output path %q: %v", label, configuredPath, err)
+		return result
 	}
 	result.ExpectedPath = expectedPath
 
 	if !pathWithinBase(outputDir, expectedPath) {
-		return result, fmt.Sprintf("%s output %q resolves outside output dir", label, configuredPath)
+		result.Error = fmt.Sprintf("%s output %q resolves outside output dir", label, configuredPath)
+		return result
 	}
 
 	info, err := os.Stat(expectedPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return result, fmt.Sprintf("%s output is missing: %s", label, expectedPath)
+			result.Error = fmt.Sprintf("%s output is missing: %s", label, expectedPath)
+			return result
 		}
-		return result, fmt.Sprintf("stat %s output %q: %v", label, expectedPath, err)
+		result.Error = fmt.Sprintf("stat %s output %q: %v", label, expectedPath, err)
+		return result
 	}
 	if info.IsDir() {
-		return result, fmt.Sprintf("%s output is a directory: %s", label, expectedPath)
+		result.Error = fmt.Sprintf("%s output is a directory: %s", label, expectedPath)
+		return result
 	}
 
 	result.Path = expectedPath
 	result.Present = true
-	return result, ""
+	return result
+}
+
+func applyOutputValidation(validation *OutputValidationResult, name string, result OutputFileResult) {
+	if validation == nil || result.Present {
+		return
+	}
+
+	if result.Required {
+		validation.Valid = false
+		validation.MissingRequired = append(validation.MissingRequired, name)
+		return
+	}
+	validation.MissingOptional = append(validation.MissingOptional, name)
 }
 
 func pathWithinBase(baseDir, target string) bool {

--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/shotomorisk/kgh/internal/config"
@@ -40,6 +42,7 @@ type Result struct {
 	Bundle       *BundleResult      `json:"bundle,omitempty"`
 	Push         *PushResult        `json:"push,omitempty"`
 	Poll         *PollResult        `json:"poll,omitempty"`
+	Outputs      *OutputsResult     `json:"outputs,omitempty"`
 }
 
 type BundleResult struct {
@@ -67,6 +70,22 @@ type PollResult struct {
 	Raw        kaggle.KernelStatusRawStatus   `json:"raw,omitempty"`
 }
 
+type OutputsResult struct {
+	OutputDir        string           `json:"output_dir"`
+	SubmissionPath   string           `json:"submission_path"`
+	MetricsPath      string           `json:"metrics_path"`
+	Submission       OutputFileResult `json:"submission"`
+	Metrics          OutputFileResult `json:"metrics"`
+	ValidationErrors []string         `json:"validation_errors"`
+}
+
+type OutputFileResult struct {
+	ConfiguredPath string `json:"configured_path"`
+	ExpectedPath   string `json:"expected_path"`
+	Path           string `json:"path"`
+	Present        bool   `json:"present"`
+}
+
 type Duration time.Duration
 
 func (d Duration) String() string {
@@ -80,6 +99,7 @@ func (d Duration) MarshalJSON() ([]byte, error) {
 type Adapter interface {
 	PushKernel(context.Context, kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error)
 	PollKernelStatus(context.Context, kaggle.KernelPollRequest) (kaggle.KernelPollResult, error)
+	DownloadKernelOutput(context.Context, kaggle.DownloadKernelOutputRequest) (kaggle.DownloadKernelOutputResponse, error)
 }
 
 type Runner struct {
@@ -199,6 +219,25 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 		Raw:        pollResp.KernelStatusResponse.Raw,
 	}
 
+	outputDir, err := createOutputDir()
+	if err != nil {
+		return report, fmt.Errorf("create output dir: %w", err)
+	}
+
+	downloadResp, err := r.adapter.DownloadKernelOutput(ctx, kaggle.DownloadKernelOutputRequest{
+		KernelRef: pushResp.KernelRef,
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		return report, fmt.Errorf("download kaggle output: %w", err)
+	}
+
+	outputs, err := buildOutputsResult(execSpec, downloadResp.OutputDir)
+	if err != nil {
+		return report, fmt.Errorf("build output handoff: %w", err)
+	}
+	report.Outputs = &outputs
+
 	return report, nil
 }
 
@@ -220,4 +259,93 @@ func effectivePollTimeout(requested, fallback time.Duration) time.Duration {
 		return fallback
 	}
 	return 30 * time.Minute
+}
+
+const outputTempPrefix = "kgh-kernel-output-*"
+
+func createOutputDir() (string, error) {
+	outputDir, err := os.MkdirTemp("", outputTempPrefix)
+	if err != nil {
+		return "", err
+	}
+	if err := os.Chmod(outputDir, 0o700); err != nil {
+		_ = os.RemoveAll(outputDir)
+		return "", err
+	}
+	return outputDir, nil
+}
+
+func buildOutputsResult(execSpec spec.ExecutionSpec, outputDir string) (OutputsResult, error) {
+	resolvedDir, err := filepath.Abs(filepath.Clean(outputDir))
+	if err != nil {
+		return OutputsResult{}, err
+	}
+
+	info, err := os.Stat(resolvedDir)
+	if err != nil {
+		return OutputsResult{}, err
+	}
+	if !info.IsDir() {
+		return OutputsResult{}, fmt.Errorf("output dir %q is not a directory", resolvedDir)
+	}
+
+	submission, submissionErr := resolveOutputFile(resolvedDir, execSpec.Outputs.Submission, "submission")
+	metrics, metricsErr := resolveOutputFile(resolvedDir, execSpec.Outputs.Metrics, "metrics")
+
+	result := OutputsResult{
+		OutputDir:      resolvedDir,
+		SubmissionPath: submission.Path,
+		MetricsPath:    metrics.Path,
+		Submission:     submission,
+		Metrics:        metrics,
+	}
+	if submissionErr != "" {
+		result.ValidationErrors = append(result.ValidationErrors, submissionErr)
+	}
+	if metricsErr != "" {
+		result.ValidationErrors = append(result.ValidationErrors, metricsErr)
+	}
+	return result, nil
+}
+
+func resolveOutputFile(outputDir, configuredPath, label string) (OutputFileResult, string) {
+	result := OutputFileResult{
+		ConfiguredPath: configuredPath,
+	}
+	if configuredPath == "" {
+		return result, fmt.Sprintf("%s output is not configured", label)
+	}
+
+	expectedPath, err := filepath.Abs(filepath.Join(outputDir, filepath.Clean(configuredPath)))
+	if err != nil {
+		return result, fmt.Sprintf("resolve %s output path %q: %v", label, configuredPath, err)
+	}
+	result.ExpectedPath = expectedPath
+
+	if !pathWithinBase(outputDir, expectedPath) {
+		return result, fmt.Sprintf("%s output %q resolves outside output dir", label, configuredPath)
+	}
+
+	info, err := os.Stat(expectedPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return result, fmt.Sprintf("%s output is missing: %s", label, expectedPath)
+		}
+		return result, fmt.Sprintf("stat %s output %q: %v", label, expectedPath, err)
+	}
+	if info.IsDir() {
+		return result, fmt.Sprintf("%s output is a directory: %s", label, expectedPath)
+	}
+
+	result.Path = expectedPath
+	result.Present = true
+	return result, ""
+}
+
+func pathWithinBase(baseDir, target string) bool {
+	rel, err := filepath.Rel(baseDir, target)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && rel != "." && filepath.Dir(rel) != ".." && rel != ""
 }

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -2,13 +2,16 @@ package execution
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/shotomorisk/kgh/internal/config"
 	"github.com/shotomorisk/kgh/internal/kaggle"
+	"github.com/shotomorisk/kgh/internal/spec"
 )
 
 func TestRunnerExecuteDryRun(t *testing.T) {
@@ -213,6 +216,15 @@ targets:
 				Terminal:   kaggle.KernelPollTerminalStateSucceeded,
 			}, nil
 		},
+		downloadFn: func(_ context.Context, req kaggle.DownloadKernelOutputRequest) (kaggle.DownloadKernelOutputResponse, error) {
+			if err := os.WriteFile(filepath.Join(req.OutputDir, "submission.csv"), []byte("id,label\n1,0\n"), 0o644); err != nil {
+				t.Fatalf("write submission output: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(req.OutputDir, "metrics.json"), []byte(`{"score":0.5}`), 0o644); err != nil {
+				t.Fatalf("write metrics output: %v", err)
+			}
+			return kaggle.DownloadKernelOutputResponse{OutputDir: req.OutputDir}, nil
+		},
 	}
 
 	runner := NewRunner(adapter)
@@ -239,6 +251,9 @@ targets:
 	if report.Bundle == nil || report.Push == nil || report.Poll == nil {
 		t.Fatalf("expected live report sections to be populated: %+v", report)
 	}
+	if report.Outputs == nil {
+		t.Fatalf("expected live outputs to be populated: %+v", report)
+	}
 	if report.Push.KernelRef != "yourname/exp142" {
 		t.Fatalf("unexpected pushed kernel ref %q", report.Push.KernelRef)
 	}
@@ -254,12 +269,169 @@ targets:
 	if time.Duration(report.PollTimeout) != 15*time.Second {
 		t.Fatalf("unexpected effective poll timeout %s", report.PollTimeout)
 	}
+	if report.Outputs.OutputDir == "" {
+		t.Fatal("expected output dir to be populated")
+	}
+	if !report.Outputs.Submission.Present {
+		t.Fatalf("expected submission output to be present: %+v", report.Outputs.Submission)
+	}
+	if !report.Outputs.Metrics.Present {
+		t.Fatalf("expected metrics output to be present: %+v", report.Outputs.Metrics)
+	}
+	if report.Outputs.SubmissionPath == "" || report.Outputs.MetricsPath == "" {
+		t.Fatalf("expected canonical output paths to be populated: %+v", report.Outputs)
+	}
+	if len(report.Outputs.ValidationErrors) != 0 {
+		t.Fatalf("expected no validation errors, got %+v", report.Outputs.ValidationErrors)
+	}
+}
+
+func TestRunnerExecuteLiveMissingOutputsAreExplicit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	notebook := filepath.Join(dir, "notebooks", "exp142.ipynb")
+	if err := os.MkdirAll(filepath.Dir(notebook), 0o755); err != nil {
+		t.Fatalf("mkdir notebook dir: %v", err)
+	}
+	if err := os.WriteFile(notebook, []byte(`{"cells":[]}`), 0o644); err != nil {
+		t.Fatalf("write notebook: %v", err)
+	}
+
+	configPath := filepath.Join(dir, ".kgh", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`
+targets:
+  exp142:
+    notebook: `+notebook+`
+    kernel_id: yourname/exp142
+    competition: playground-series-s6e2
+    submit: true
+    resources:
+      private: true
+    outputs:
+      submission: submission.csv
+      metrics: metrics.json
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	adapter := &liveAdapter{
+		t: t,
+		pushFn: func(_ context.Context, _ kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error) {
+			return kaggle.PushKernelResponse{KernelRef: "yourname/exp142"}, nil
+		},
+		pollFn: func(_ context.Context, _ kaggle.KernelPollRequest) (kaggle.KernelPollResult, error) {
+			return kaggle.KernelPollResult{
+				KernelStatusResponse: kaggle.KernelStatusResponse{
+					KernelRef: "yourname/exp142",
+					Status:    "complete",
+				},
+				Terminal: kaggle.KernelPollTerminalStateSucceeded,
+			}, nil
+		},
+		downloadFn: func(_ context.Context, req kaggle.DownloadKernelOutputRequest) (kaggle.DownloadKernelOutputResponse, error) {
+			if err := os.WriteFile(filepath.Join(req.OutputDir, "submission.csv"), []byte("id,label\n1,0\n"), 0o644); err != nil {
+				t.Fatalf("write submission output: %v", err)
+			}
+			return kaggle.DownloadKernelOutputResponse{OutputDir: req.OutputDir}, nil
+		},
+	}
+
+	report, err := NewRunner(adapter).Execute(context.Background(), Request{
+		Target:     "exp142",
+		DryRun:     false,
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if report.Outputs == nil {
+		t.Fatalf("expected outputs handoff, got %+v", report)
+	}
+	if !report.Outputs.Submission.Present {
+		t.Fatalf("expected submission to be present: %+v", report.Outputs.Submission)
+	}
+	if report.Outputs.Metrics.Present {
+		t.Fatalf("expected metrics to be missing: %+v", report.Outputs.Metrics)
+	}
+	if report.Outputs.SubmissionPath == "" {
+		t.Fatalf("expected submission path to be set: %+v", report.Outputs)
+	}
+	if report.Outputs.MetricsPath != "" {
+		t.Fatalf("expected empty metrics path for missing output, got %q", report.Outputs.MetricsPath)
+	}
+	if len(report.Outputs.ValidationErrors) != 1 {
+		t.Fatalf("expected one validation error, got %+v", report.Outputs.ValidationErrors)
+	}
+	if got := report.Outputs.ValidationErrors[0]; !strings.Contains(got, "metrics output is missing") {
+		t.Fatalf("unexpected validation error %q", got)
+	}
+}
+
+func TestBuildOutputsResultDeterministicJSON(t *testing.T) {
+	t.Parallel()
+
+	outputDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outputDir, "submission.csv"), []byte("id,label\n1,0\n"), 0o644); err != nil {
+		t.Fatalf("write submission output: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, "metrics.json"), []byte(`{"score":0.5}`), 0o644); err != nil {
+		t.Fatalf("write metrics output: %v", err)
+	}
+
+	execSpec := testExecutionSpec()
+	first, err := buildOutputsResult(execSpec, outputDir)
+	if err != nil {
+		t.Fatalf("build outputs result: %v", err)
+	}
+	second, err := buildOutputsResult(execSpec, outputDir)
+	if err != nil {
+		t.Fatalf("build outputs result: %v", err)
+	}
+
+	firstJSON, err := json.Marshal(first)
+	if err != nil {
+		t.Fatalf("marshal first outputs result: %v", err)
+	}
+	secondJSON, err := json.Marshal(second)
+	if err != nil {
+		t.Fatalf("marshal second outputs result: %v", err)
+	}
+	if string(firstJSON) != string(secondJSON) {
+		t.Fatalf("expected deterministic outputs json, got %q and %q", string(firstJSON), string(secondJSON))
+	}
+}
+
+func TestBuildOutputsResultRejectsEscapingPaths(t *testing.T) {
+	t.Parallel()
+
+	outputDir := t.TempDir()
+	execSpec := testExecutionSpec()
+	execSpec.Outputs.Submission = "../submission.csv"
+
+	result, err := buildOutputsResult(execSpec, outputDir)
+	if err != nil {
+		t.Fatalf("build outputs result: %v", err)
+	}
+	if result.Submission.Present {
+		t.Fatalf("expected escaping submission path to be rejected: %+v", result.Submission)
+	}
+	if len(result.ValidationErrors) == 0 {
+		t.Fatalf("expected validation errors, got %+v", result)
+	}
+	if got := result.ValidationErrors[0]; !strings.Contains(got, "resolves outside output dir") {
+		t.Fatalf("unexpected validation error %q", got)
+	}
 }
 
 type liveAdapter struct {
-	t      *testing.T
-	pushFn func(context.Context, kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error)
-	pollFn func(context.Context, kaggle.KernelPollRequest) (kaggle.KernelPollResult, error)
+	t          *testing.T
+	pushFn     func(context.Context, kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error)
+	pollFn     func(context.Context, kaggle.KernelPollRequest) (kaggle.KernelPollResult, error)
+	downloadFn func(context.Context, kaggle.DownloadKernelOutputRequest) (kaggle.DownloadKernelOutputResponse, error)
 }
 
 func (a *liveAdapter) PushKernel(ctx context.Context, req kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error) {
@@ -274,4 +446,20 @@ func (a *liveAdapter) PollKernelStatus(ctx context.Context, req kaggle.KernelPol
 		a.t.Fatal("pollFn must be set")
 	}
 	return a.pollFn(ctx, req)
+}
+
+func (a *liveAdapter) DownloadKernelOutput(ctx context.Context, req kaggle.DownloadKernelOutputRequest) (kaggle.DownloadKernelOutputResponse, error) {
+	if a.downloadFn == nil {
+		a.t.Fatal("downloadFn must be set")
+	}
+	return a.downloadFn(ctx, req)
+}
+
+func testExecutionSpec() spec.ExecutionSpec {
+	return spec.ExecutionSpec{
+		Outputs: config.Outputs{
+			Submission: "submission.csv",
+			Metrics:    "metrics.json",
+		},
+	}
 }

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -281,12 +281,21 @@ targets:
 	if report.Outputs.SubmissionPath == "" || report.Outputs.MetricsPath == "" {
 		t.Fatalf("expected canonical output paths to be populated: %+v", report.Outputs)
 	}
-	if len(report.Outputs.ValidationErrors) != 0 {
-		t.Fatalf("expected no validation errors, got %+v", report.Outputs.ValidationErrors)
+	if !report.Outputs.Validation.Valid {
+		t.Fatalf("expected validation to succeed: %+v", report.Outputs.Validation)
+	}
+	if len(report.Outputs.Validation.MissingRequired) != 0 || len(report.Outputs.Validation.MissingOptional) != 0 {
+		t.Fatalf("expected no missing outputs, got %+v", report.Outputs.Validation)
+	}
+	if !report.Outputs.Submission.Required || report.Outputs.Submission.Error != "" {
+		t.Fatalf("expected required submission with no error: %+v", report.Outputs.Submission)
+	}
+	if report.Outputs.Metrics.Required || report.Outputs.Metrics.Error != "" {
+		t.Fatalf("expected optional metrics with no error: %+v", report.Outputs.Metrics)
 	}
 }
 
-func TestRunnerExecuteLiveMissingOutputsAreExplicit(t *testing.T) {
+func TestRunnerExecuteLiveMissingRequiredSubmissionFailsValidation(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -333,6 +342,95 @@ targets:
 			}, nil
 		},
 		downloadFn: func(_ context.Context, req kaggle.DownloadKernelOutputRequest) (kaggle.DownloadKernelOutputResponse, error) {
+			if err := os.WriteFile(filepath.Join(req.OutputDir, "metrics.json"), []byte(`{"score":0.5}`), 0o644); err != nil {
+				t.Fatalf("write metrics output: %v", err)
+			}
+			return kaggle.DownloadKernelOutputResponse{OutputDir: req.OutputDir}, nil
+		},
+	}
+
+	report, err := NewRunner(adapter).Execute(context.Background(), Request{
+		Target:     "exp142",
+		DryRun:     false,
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if report.Outputs == nil {
+		t.Fatalf("expected outputs handoff, got %+v", report)
+	}
+	if report.Outputs.Submission.Present {
+		t.Fatalf("expected submission to be missing: %+v", report.Outputs.Submission)
+	}
+	if !report.Outputs.Metrics.Present {
+		t.Fatalf("expected metrics to be present: %+v", report.Outputs.Metrics)
+	}
+	if report.Outputs.SubmissionPath != "" {
+		t.Fatalf("expected empty submission path for missing output, got %q", report.Outputs.SubmissionPath)
+	}
+	if report.Outputs.MetricsPath == "" {
+		t.Fatalf("expected metrics path to be set: %+v", report.Outputs)
+	}
+	if report.Outputs.Validation.Valid {
+		t.Fatalf("expected validation to fail: %+v", report.Outputs.Validation)
+	}
+	if len(report.Outputs.Validation.MissingRequired) != 1 || report.Outputs.Validation.MissingRequired[0] != "submission" {
+		t.Fatalf("expected submission in missing required list, got %+v", report.Outputs.Validation)
+	}
+	if len(report.Outputs.Validation.MissingOptional) != 0 {
+		t.Fatalf("expected no missing optional outputs, got %+v", report.Outputs.Validation)
+	}
+	if report.Outputs.Submission.Error == "" || !strings.Contains(report.Outputs.Submission.Error, "submission output is missing") {
+		t.Fatalf("unexpected submission error %+v", report.Outputs.Submission)
+	}
+}
+
+func TestRunnerExecuteLiveMissingOptionalMetricsDoesNotFailValidation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	notebook := filepath.Join(dir, "notebooks", "exp142.ipynb")
+	if err := os.MkdirAll(filepath.Dir(notebook), 0o755); err != nil {
+		t.Fatalf("mkdir notebook dir: %v", err)
+	}
+	if err := os.WriteFile(notebook, []byte(`{"cells":[]}`), 0o644); err != nil {
+		t.Fatalf("write notebook: %v", err)
+	}
+
+	configPath := filepath.Join(dir, ".kgh", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`
+targets:
+  exp142:
+    notebook: `+notebook+`
+    kernel_id: yourname/exp142
+    competition: playground-series-s6e2
+    submit: false
+    outputs:
+      submission: submission.csv
+      metrics: metrics.json
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	adapter := &liveAdapter{
+		t: t,
+		pushFn: func(_ context.Context, _ kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error) {
+			return kaggle.PushKernelResponse{KernelRef: "yourname/exp142"}, nil
+		},
+		pollFn: func(_ context.Context, _ kaggle.KernelPollRequest) (kaggle.KernelPollResult, error) {
+			return kaggle.KernelPollResult{
+				KernelStatusResponse: kaggle.KernelStatusResponse{
+					KernelRef: "yourname/exp142",
+					Status:    "complete",
+				},
+				Terminal: kaggle.KernelPollTerminalStateSucceeded,
+			}, nil
+		},
+		downloadFn: func(_ context.Context, req kaggle.DownloadKernelOutputRequest) (kaggle.DownloadKernelOutputResponse, error) {
 			if err := os.WriteFile(filepath.Join(req.OutputDir, "submission.csv"), []byte("id,label\n1,0\n"), 0o644); err != nil {
 				t.Fatalf("write submission output: %v", err)
 			}
@@ -351,23 +449,97 @@ targets:
 	if report.Outputs == nil {
 		t.Fatalf("expected outputs handoff, got %+v", report)
 	}
-	if !report.Outputs.Submission.Present {
-		t.Fatalf("expected submission to be present: %+v", report.Outputs.Submission)
+	if !report.Outputs.Validation.Valid {
+		t.Fatalf("expected validation to succeed for optional metrics: %+v", report.Outputs.Validation)
 	}
-	if report.Outputs.Metrics.Present {
-		t.Fatalf("expected metrics to be missing: %+v", report.Outputs.Metrics)
+	if len(report.Outputs.Validation.MissingRequired) != 0 {
+		t.Fatalf("expected no missing required outputs, got %+v", report.Outputs.Validation)
 	}
-	if report.Outputs.SubmissionPath == "" {
-		t.Fatalf("expected submission path to be set: %+v", report.Outputs)
+	if len(report.Outputs.Validation.MissingOptional) != 1 || report.Outputs.Validation.MissingOptional[0] != "metrics" {
+		t.Fatalf("expected metrics in missing optional list, got %+v", report.Outputs.Validation)
 	}
-	if report.Outputs.MetricsPath != "" {
-		t.Fatalf("expected empty metrics path for missing output, got %q", report.Outputs.MetricsPath)
+	if report.Outputs.Metrics.Required {
+		t.Fatalf("expected metrics to remain optional: %+v", report.Outputs.Metrics)
 	}
-	if len(report.Outputs.ValidationErrors) != 1 {
-		t.Fatalf("expected one validation error, got %+v", report.Outputs.ValidationErrors)
+	if report.Outputs.Metrics.Error == "" || !strings.Contains(report.Outputs.Metrics.Error, "metrics output is missing") {
+		t.Fatalf("unexpected metrics error %+v", report.Outputs.Metrics)
 	}
-	if got := report.Outputs.ValidationErrors[0]; !strings.Contains(got, "metrics output is missing") {
-		t.Fatalf("unexpected validation error %q", got)
+}
+
+func TestRunnerExecuteLiveMissingSubmissionIsOptionalWhenSubmitDisabled(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	notebook := filepath.Join(dir, "notebooks", "exp142.ipynb")
+	if err := os.MkdirAll(filepath.Dir(notebook), 0o755); err != nil {
+		t.Fatalf("mkdir notebook dir: %v", err)
+	}
+	if err := os.WriteFile(notebook, []byte(`{"cells":[]}`), 0o644); err != nil {
+		t.Fatalf("write notebook: %v", err)
+	}
+
+	configPath := filepath.Join(dir, ".kgh", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`
+targets:
+  exp142:
+    notebook: `+notebook+`
+    kernel_id: yourname/exp142
+    competition: playground-series-s6e2
+    submit: false
+    outputs:
+      submission: submission.csv
+      metrics: metrics.json
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	adapter := &liveAdapter{
+		t: t,
+		pushFn: func(_ context.Context, _ kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error) {
+			return kaggle.PushKernelResponse{KernelRef: "yourname/exp142"}, nil
+		},
+		pollFn: func(_ context.Context, _ kaggle.KernelPollRequest) (kaggle.KernelPollResult, error) {
+			return kaggle.KernelPollResult{
+				KernelStatusResponse: kaggle.KernelStatusResponse{
+					KernelRef: "yourname/exp142",
+					Status:    "complete",
+				},
+				Terminal: kaggle.KernelPollTerminalStateSucceeded,
+			}, nil
+		},
+		downloadFn: func(_ context.Context, req kaggle.DownloadKernelOutputRequest) (kaggle.DownloadKernelOutputResponse, error) {
+			if err := os.WriteFile(filepath.Join(req.OutputDir, "metrics.json"), []byte(`{"score":0.5}`), 0o644); err != nil {
+				t.Fatalf("write metrics output: %v", err)
+			}
+			return kaggle.DownloadKernelOutputResponse{OutputDir: req.OutputDir}, nil
+		},
+	}
+
+	report, err := NewRunner(adapter).Execute(context.Background(), Request{
+		Target:     "exp142",
+		DryRun:     false,
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if report.Outputs == nil {
+		t.Fatalf("expected outputs handoff, got %+v", report)
+	}
+	if !report.Outputs.Validation.Valid {
+		t.Fatalf("expected validation to succeed for optional submission: %+v", report.Outputs.Validation)
+	}
+	if report.Outputs.Submission.Required {
+		t.Fatalf("expected submission to be optional when submit=false: %+v", report.Outputs.Submission)
+	}
+	if len(report.Outputs.Validation.MissingOptional) != 1 || report.Outputs.Validation.MissingOptional[0] != "submission" {
+		t.Fatalf("expected submission in missing optional list, got %+v", report.Outputs.Validation)
+	}
+	if report.Outputs.Submission.Error == "" || !strings.Contains(report.Outputs.Submission.Error, "submission output is missing") {
+		t.Fatalf("unexpected submission error %+v", report.Outputs.Submission)
 	}
 }
 
@@ -419,11 +591,14 @@ func TestBuildOutputsResultRejectsEscapingPaths(t *testing.T) {
 	if result.Submission.Present {
 		t.Fatalf("expected escaping submission path to be rejected: %+v", result.Submission)
 	}
-	if len(result.ValidationErrors) == 0 {
-		t.Fatalf("expected validation errors, got %+v", result)
+	if result.Validation.Valid {
+		t.Fatalf("expected validation to fail, got %+v", result.Validation)
 	}
-	if got := result.ValidationErrors[0]; !strings.Contains(got, "resolves outside output dir") {
-		t.Fatalf("unexpected validation error %q", got)
+	if len(result.Validation.MissingRequired) != 1 || result.Validation.MissingRequired[0] != "submission" {
+		t.Fatalf("expected submission in missing required list, got %+v", result.Validation)
+	}
+	if got := result.Submission.Error; !strings.Contains(got, "resolves outside output dir") {
+		t.Fatalf("unexpected submission error %q", got)
 	}
 }
 
@@ -457,6 +632,7 @@ func (a *liveAdapter) DownloadKernelOutput(ctx context.Context, req kaggle.Downl
 
 func testExecutionSpec() spec.ExecutionSpec {
 	return spec.ExecutionSpec{
+		Submit: true,
 		Outputs: config.Outputs{
 			Submission: "submission.csv",
 			Metrics:    "metrics.json",


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #24 
- [ ] Github issue: Closes: #25 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
The execution tests are updated with both happy-path and missing-output coverage,
  including explicit validation messages and path-escape rejection. I’m running the
  package tests now to catch any contract or compile issues before widening to the full
  test suite.

Implemented the validation phase in internal/execution/execution.go:67.
  execution.Result.outputs now carries a typed validation block with valid,
  missing_required, and missing_optional, and each output entry now includes required and
  error so downstream steps can branch without parsing free-form strings. Requiredness is
  derived as planned: submission is required only when submit: true; metrics remains
  optional.

  Updated coverage in internal/execution/execution_test.go:129 for successful validation,
  missing required submission, missing optional metrics, optional submission when
  submit=false, escaping-path rejection, and deterministic JSON output.
<!-- close -->