### PR TITLE
Add commit-trigger GitHub entrypoint

### DIFF
--- a/.github/workflows/commit-trigger.yml
+++ b/.github/workflows/commit-trigger.yml
@@ -1,0 +1,78 @@
+name: Commit Trigger
+
+on:
+    pull_request:
+        types: [opened, synchronize, reopened]
+
+permissions:
+    contents: read
+
+jobs:
+    commit-trigger:
+        name: Commit Trigger
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.pull_request.head.sha }}
+
+            - name: Detect submit trigger
+              id: trigger
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  message="$(git show -s --format=%B "${{ github.event.pull_request.head.sha }}")"
+                  if grep -Eq '^[[:space:]]*submit:' <<<"$message"; then
+                    echo "should_run=true" >> "$GITHUB_OUTPUT"
+                    {
+                      echo "## kgh commit trigger"
+                      echo "Detected a \`submit:\` command in the head commit message."
+                    } >> "$GITHUB_STEP_SUMMARY"
+                    exit 0
+                  fi
+
+                  echo "should_run=false" >> "$GITHUB_OUTPUT"
+                  {
+                    echo "## kgh commit trigger"
+                    echo "No \`submit:\` command found in the head commit message. Skipping Kaggle execution."
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Set up Go
+              if: steps.trigger.outputs.should_run == 'true'
+              uses: actions/setup-go@v5
+              with:
+                  go-version-file: go.mod
+                  cache: false
+
+            - name: Install Kaggle CLI
+              if: steps.trigger.outputs.should_run == 'true'
+              shell: bash
+              run: python3 -m pip install --upgrade kaggle
+
+            - name: Resolve and execute commit trigger
+              if: steps.trigger.outputs.should_run == 'true'
+              shell: bash
+              env:
+                  KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_API_TOKEN }}
+                  KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
+                  KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}
+              run: |
+                  set -euo pipefail
+                  args=(github run)
+                  if [[ -n "${KAGGLE_API_TOKEN:-}" || ( -n "${KAGGLE_USERNAME:-}" && -n "${KAGGLE_KEY:-}" ) ]]; then
+                    {
+                      echo "## kgh commit trigger mode"
+                      echo "Running the commit-trigger path in live mode."
+                    } >> "$GITHUB_STEP_SUMMARY"
+                    args+=(--dry-run=false)
+                  else
+                    {
+                      echo "## kgh commit trigger mode"
+                      echo "Kaggle credentials are unavailable, so the commit-trigger path is running in dry-run mode."
+                    } >> "$GITHUB_STEP_SUMMARY"
+                  fi
+
+                  go run ./cmd/kgh/main.go kgh "${args[@]}"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,20 @@ go build ./cmd/kgh
 ./kgh version
 ```
 
-To run a target locally, create `.kgh/config.yaml` from `.kgh/config_example.yaml` and then:
+The primary CI path is the GitHub commit trigger. In GitHub Actions, `kgh` reads the checked-out head commit message and looks for exactly one command in this form:
+
+```text
+submit: <target> [gpu=<bool>] [internet=<bool>]
+```
+
+The CLI entrypoint for that path is:
+
+```bash
+./kgh github run
+./kgh github run --dry-run=false
+```
+
+For local debugging, keep using the explicit target path. Create `.kgh/config.yaml` from `.kgh/config_example.yaml` and then:
 
 ```bash
 ./kgh run --target issue7-e2e
@@ -38,6 +51,8 @@ To run a target locally, create `.kgh/config.yaml` from `.kgh/config_example.yam
 ```bash
 ./kgh run --target issue7-e2e --dry-run=false --poll-interval=2s --timeout=5m
 ```
+
+The repository includes a PR workflow at [`.github/workflows/commit-trigger.yml`](.github/workflows/commit-trigger.yml) that checks the head commit for `submit:` and invokes `kgh github run` only when a trigger is present.
 
 ### Issue 7 live verification
 
@@ -61,6 +76,7 @@ Verification commands:
 ```bash
 go run ./cmd/kgh/main.go kgh run --target issue7-e2e --dry-run
 go run ./cmd/kgh/main.go kgh run --target issue7-e2e --dry-run=false --poll-interval=2s --timeout=5m
+go run ./cmd/kgh/main.go kgh github run
 kaggle kernels status bloodymonday/issue7-e2e
 ```
 

--- a/cmd/kgh/main.go
+++ b/cmd/kgh/main.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/shotomorisk/kgh/internal/execution"
+	ghctx "github.com/shotomorisk/kgh/internal/github"
+	"github.com/shotomorisk/kgh/internal/parser"
 )
 
 var version = "dev"
@@ -45,6 +47,12 @@ func runWithIO(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintln(stderr, err)
 		}
 		return code
+	case "github":
+		code, err := githubCommand(context.Background(), args[1:], stdout, stderr)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+		}
+		return code
 	default:
 		fmt.Fprintf(stderr, "unknown command: %s\n\n", args[0])
 		printUsage(stderr)
@@ -52,13 +60,21 @@ func runWithIO(args []string, stdout, stderr io.Writer) int {
 	}
 }
 
-type runFlags struct {
-	target       string
+type sharedRunFlags struct {
 	dryRun       bool
-	gpu          *bool
-	internet     *bool
 	pollInterval time.Duration
 	timeout      time.Duration
+}
+
+type runFlags struct {
+	target   string
+	gpu      *bool
+	internet *bool
+	sharedRunFlags
+}
+
+type githubRunFlags struct {
+	sharedRunFlags
 }
 
 func runCommand(ctx context.Context, args []string, stdout, stderr io.Writer) (int, error) {
@@ -67,8 +83,7 @@ func runCommand(ctx context.Context, args []string, stdout, stderr io.Writer) (i
 		return 1, err
 	}
 
-	runner := execution.NewRunner(nil)
-	report, err := runner.Execute(ctx, execution.Request{
+	return executeRequest(ctx, execution.Request{
 		Target:       flags.target,
 		DryRun:       flags.dryRun,
 		GPU:          flags.gpu,
@@ -76,7 +91,40 @@ func runCommand(ctx context.Context, args []string, stdout, stderr io.Writer) (i
 		ConfigPath:   execution.DefaultConfigPath,
 		PollInterval: flags.pollInterval,
 		PollTimeout:  flags.timeout,
-	})
+	}, stdout)
+}
+
+func githubCommand(ctx context.Context, args []string, stdout, stderr io.Writer) (int, error) {
+	if len(args) == 0 {
+		printGitHubUsage(stdout)
+		return 0, nil
+	}
+
+	switch args[0] {
+	case "help", "--help", "-h":
+		printGitHubUsage(stdout)
+		return 0, nil
+	case "run":
+	default:
+		return 1, fmt.Errorf("unknown github subcommand: %s", args[0])
+	}
+
+	flags, err := parseGitHubRunFlags(args[1:])
+	if err != nil {
+		return 1, err
+	}
+
+	trigger, err := ghctx.NewTriggerResolver().Resolve(ctx)
+	if err != nil {
+		return 1, err
+	}
+
+	return executeRequest(ctx, requestFromTrigger(trigger, flags.sharedRunFlags), stdout)
+}
+
+func executeRequest(ctx context.Context, req execution.Request, stdout io.Writer) (int, error) {
+	runner := execution.NewRunner(nil)
+	report, err := runner.Execute(ctx, req)
 	if err != nil {
 		return 1, err
 	}
@@ -125,16 +173,57 @@ func parseRunFlags(args []string) (runFlags, error) {
 	if len(fs.Args()) != 0 {
 		return runFlags{}, fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
-	if flags.pollInterval < 0 {
-		return runFlags{}, fmt.Errorf("--poll-interval must be greater than or equal to 0")
-	}
-	if flags.timeout < 0 {
-		return runFlags{}, fmt.Errorf("--timeout must be greater than or equal to 0")
+	if err := validateSharedRunFlags(flags.sharedRunFlags); err != nil {
+		return runFlags{}, err
 	}
 	if strings.TrimSpace(flags.target) == "" {
 		return runFlags{}, fmt.Errorf("--target is required")
 	}
 	return flags, nil
+}
+
+func parseGitHubRunFlags(args []string) (githubRunFlags, error) {
+	fs := flag.NewFlagSet("github run", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	var flags githubRunFlags
+
+	fs.BoolVar(&flags.dryRun, "dry-run", true, "print resolved execution JSON without invoking Kaggle")
+	fs.DurationVar(&flags.pollInterval, "poll-interval", 0, "poll interval for live Kaggle status checks")
+	fs.DurationVar(&flags.timeout, "timeout", 0, "timeout for live Kaggle polling")
+
+	if err := fs.Parse(args); err != nil {
+		return githubRunFlags{}, err
+	}
+	if len(fs.Args()) != 0 {
+		return githubRunFlags{}, fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if err := validateSharedRunFlags(flags.sharedRunFlags); err != nil {
+		return githubRunFlags{}, err
+	}
+	return flags, nil
+}
+
+func validateSharedRunFlags(flags sharedRunFlags) error {
+	if flags.pollInterval < 0 {
+		return fmt.Errorf("--poll-interval must be greater than or equal to 0")
+	}
+	if flags.timeout < 0 {
+		return fmt.Errorf("--timeout must be greater than or equal to 0")
+	}
+	return nil
+}
+
+func requestFromTrigger(trigger parser.Trigger, flags sharedRunFlags) execution.Request {
+	return execution.Request{
+		Target:       trigger.Target,
+		DryRun:       flags.dryRun,
+		GPU:          trigger.GPU,
+		Internet:     trigger.Internet,
+		ConfigPath:   execution.DefaultConfigPath,
+		PollInterval: flags.pollInterval,
+		PollTimeout:  flags.timeout,
+	}
 }
 
 func boolPtr(v bool) *bool {
@@ -150,13 +239,34 @@ Usage:
 Available Commands:
   version   Print the current kgh version
   help      Show this help message
+  github    Resolve and execute from GitHub commit metadata
   run       Resolve and execute a Kaggle target
 
 Examples:
   kgh run --target exp142
   kgh run --target exp142 --poll-interval=2s --timeout=5m
   kgh run --target exp142 --dry-run=false
+  kgh github run
   kgh version
+`)
+}
+
+func printGitHubUsage(w io.Writer) {
+	fmt.Fprint(w, `kgh github resolves trigger intent from GitHub commit metadata.
+
+Usage:
+  kgh github run [flags]
+
+Flags:
+  --dry-run         print resolved execution JSON without invoking Kaggle (default true)
+  --poll-interval   poll interval for live Kaggle status checks
+  --timeout         timeout for live Kaggle polling
+
+Environment:
+  GITHUB_EVENT_NAME   GitHub Actions event name
+  GITHUB_EVENT_PATH   path to the GitHub event payload JSON
+  GITHUB_SHA          current commit SHA for push events
+  GITHUB_WORKSPACE    repository checkout path for reading commit metadata
 `)
 }
 

--- a/cmd/kgh/main_test.go
+++ b/cmd/kgh/main_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -30,6 +32,9 @@ func TestRunHelpMentionsRun(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "run       Resolve and execute a Kaggle target") {
 		t.Fatalf("expected run command in help output, got %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "github    Resolve and execute from GitHub commit metadata") {
+		t.Fatalf("expected github command in help output, got %s", stdout.String())
 	}
 }
 
@@ -70,6 +75,21 @@ func TestParseRunFlagsAcceptsPollingDurations(t *testing.T) {
 	}
 }
 
+func TestParseGitHubRunFlagsAcceptsPollingDurations(t *testing.T) {
+	t.Parallel()
+
+	flags, err := parseGitHubRunFlags([]string{"--poll-interval", "2s", "--timeout", "5m"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if flags.pollInterval != 2*time.Second {
+		t.Fatalf("unexpected poll interval %s", flags.pollInterval)
+	}
+	if flags.timeout != 5*time.Minute {
+		t.Fatalf("unexpected timeout %s", flags.timeout)
+	}
+}
+
 func TestParseRunFlagsRejectsNegativePollingDurations(t *testing.T) {
 	t.Parallel()
 
@@ -78,6 +98,12 @@ func TestParseRunFlagsRejectsNegativePollingDurations(t *testing.T) {
 	}
 	if _, err := parseRunFlags([]string{"--target", "exp142", "--timeout", "-1s"}); err == nil || !strings.Contains(err.Error(), "--timeout must be greater than or equal to 0") {
 		t.Fatalf("expected timeout validation error, got %v", err)
+	}
+	if _, err := parseGitHubRunFlags([]string{"--poll-interval", "-1s"}); err == nil || !strings.Contains(err.Error(), "--poll-interval must be greater than or equal to 0") {
+		t.Fatalf("expected github poll interval validation error, got %v", err)
+	}
+	if _, err := parseGitHubRunFlags([]string{"--timeout", "-1s"}); err == nil || !strings.Contains(err.Error(), "--timeout must be greater than or equal to 0") {
+		t.Fatalf("expected github timeout validation error, got %v", err)
 	}
 }
 
@@ -146,4 +172,148 @@ targets:
 	if stderr.Len() != 0 {
 		t.Fatalf("expected no stderr, got %s", stderr.String())
 	}
+}
+
+func TestGitHubRunHelp(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	if code := runWithIO([]string{"github", "help"}, stdout, stderr); code != 0 {
+		t.Fatalf("expected exit code 0, got %d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "kgh github resolves trigger intent from GitHub commit metadata.") {
+		t.Fatalf("unexpected help output %s", stdout.String())
+	}
+}
+
+func TestGitHubRunDryRunOutputsJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeConfigFixture(t, dir)
+
+	gitRun(t, dir, "init")
+	gitRun(t, dir, "config", "user.name", "Test User")
+	gitRun(t, dir, "config", "user.email", "test@example.com")
+	gitRun(t, dir, "add", ".")
+	gitRun(t, dir, "commit", "-m", "feat: wire ci\n\nsubmit: exp142 gpu=false")
+	sha := strings.TrimSpace(gitRun(t, dir, "rev-parse", "HEAD"))
+
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get wd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldwd)
+	})
+
+	t.Setenv("GITHUB_EVENT_NAME", "push")
+	t.Setenv("GITHUB_SHA", sha)
+	t.Setenv("GITHUB_WORKSPACE", dir)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runWithIO([]string{"github", "run"}, stdout, stderr); code != 0 {
+		t.Fatalf("expected exit code 0, got %d stderr=%s", code, stderr.String())
+	}
+
+	if got := stdout.String(); !strings.Contains(got, `"target_name": "exp142"`) {
+		t.Fatalf("expected target name in output, got %s", got)
+	}
+	if !strings.Contains(stdout.String(), `"gpu": false`) {
+		t.Fatalf("expected overridden gpu in output, got %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), `"overrides": {`) {
+		t.Fatalf("expected overrides in output, got %s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr, got %s", stderr.String())
+	}
+}
+
+func TestGitHubRunPullRequestUsesHeadSHA(t *testing.T) {
+	dir := t.TempDir()
+	writeConfigFixture(t, dir)
+
+	gitRun(t, dir, "init")
+	gitRun(t, dir, "config", "user.name", "Test User")
+	gitRun(t, dir, "config", "user.email", "test@example.com")
+	gitRun(t, dir, "add", ".")
+	gitRun(t, dir, "commit", "-m", "feat: first trigger\n\nsubmit: exp142")
+	firstSHA := strings.TrimSpace(gitRun(t, dir, "rev-parse", "HEAD"))
+
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("changed\n"), 0o644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	gitRun(t, dir, "add", "README.md")
+	gitRun(t, dir, "commit", "-m", "feat: second trigger\n\nsubmit: exp142 internet=true")
+
+	eventPath := filepath.Join(dir, "event.json")
+	eventPayload := fmt.Sprintf(`{"pull_request":{"head":{"sha":%q}}}`, firstSHA)
+	if err := os.WriteFile(eventPath, []byte(eventPayload), 0o644); err != nil {
+		t.Fatalf("write event payload: %v", err)
+	}
+
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get wd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldwd)
+	})
+
+	t.Setenv("GITHUB_EVENT_NAME", "pull_request")
+	t.Setenv("GITHUB_EVENT_PATH", eventPath)
+	t.Setenv("GITHUB_WORKSPACE", dir)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runWithIO([]string{"github", "run"}, stdout, stderr); code != 0 {
+		t.Fatalf("expected exit code 0, got %d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"overrides": {}`) {
+		t.Fatalf("expected head sha commit with no overrides, got %s", stdout.String())
+	}
+}
+
+func writeConfigFixture(t *testing.T, dir string) {
+	t.Helper()
+
+	configDir := filepath.Join(dir, ".kgh")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(`
+targets:
+  exp142:
+    notebook: notebooks/exp142.ipynb
+    kernel_id: yourname/exp142
+    competition: playground-series-s6e2
+    submit: true
+    resources:
+      gpu: true
+      internet: false
+      private: true
+    outputs:
+      submission: submission.csv
+      metrics: metrics.json
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func gitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, string(output))
+	}
+	return string(output)
 }

--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -43,6 +43,7 @@ type Result struct {
 	Push         *PushResult        `json:"push,omitempty"`
 	Poll         *PollResult        `json:"poll,omitempty"`
 	Outputs      *OutputsResult     `json:"outputs,omitempty"`
+	Submission   *SubmissionResult  `json:"submission,omitempty"`
 }
 
 type BundleResult struct {
@@ -79,6 +80,16 @@ type OutputsResult struct {
 	Validation     OutputValidationResult `json:"validation"`
 }
 
+type SubmissionResult struct {
+	Enabled     bool   `json:"enabled"`
+	Skipped     bool   `json:"skipped"`
+	Competition string `json:"competition,omitempty"`
+	FilePath    string `json:"file_path,omitempty"`
+	Message     string `json:"message,omitempty"`
+	Submitted   bool   `json:"submitted"`
+	Reason      string `json:"reason,omitempty"`
+}
+
 type OutputValidationResult struct {
 	Valid           bool     `json:"valid"`
 	MissingRequired []string `json:"missing_required"`
@@ -108,6 +119,7 @@ type Adapter interface {
 	PushKernel(context.Context, kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error)
 	PollKernelStatus(context.Context, kaggle.KernelPollRequest) (kaggle.KernelPollResult, error)
 	DownloadKernelOutput(context.Context, kaggle.DownloadKernelOutputRequest) (kaggle.DownloadKernelOutputResponse, error)
+	SubmitCompetition(context.Context, kaggle.CompetitionSubmitRequest) (kaggle.CompetitionSubmitResponse, error)
 }
 
 type Runner struct {
@@ -246,7 +258,48 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 	}
 	report.Outputs = &outputs
 
+	submission, err := r.submitOutputs(ctx, execSpec, pushResp.KernelRef, outputs)
+	report.Submission = &submission
+	if err != nil {
+		return report, err
+	}
+
 	return report, nil
+}
+
+func (r *Runner) submitOutputs(ctx context.Context, execSpec spec.ExecutionSpec, kernelRef string, outputs OutputsResult) (SubmissionResult, error) {
+	if !execSpec.Submit {
+		return SubmissionResult{
+			Enabled:     false,
+			Skipped:     true,
+			Competition: execSpec.Competition,
+			Reason:      "submission disabled for target",
+		}, nil
+	}
+
+	result := SubmissionResult{
+		Enabled:     true,
+		Competition: execSpec.Competition,
+		FilePath:    outputs.Submission.Path,
+		Message:     submissionMessage(execSpec.TargetName, kernelRef),
+	}
+	if !outputs.Submission.Present {
+		result.Reason = outputs.Submission.Error
+		return result, fmt.Errorf("submit enabled but submission artifact is missing: %s", outputs.Submission.Error)
+	}
+
+	resp, err := r.adapter.SubmitCompetition(ctx, kaggle.CompetitionSubmitRequest{
+		Competition: execSpec.Competition,
+		FilePath:    outputs.Submission.Path,
+		Message:     result.Message,
+	})
+	if err != nil {
+		return result, fmt.Errorf("submit kaggle competition: %w", err)
+	}
+
+	result.Competition = resp.Competition
+	result.Submitted = resp.Submitted
+	return result, nil
 }
 
 func effectivePollInterval(requested, fallback time.Duration) time.Duration {
@@ -267,6 +320,10 @@ func effectivePollTimeout(requested, fallback time.Duration) time.Duration {
 		return fallback
 	}
 	return 30 * time.Minute
+}
+
+func submissionMessage(targetName, kernelRef string) string {
+	return fmt.Sprintf("kgh target=%s kernel=%s", targetName, kernelRef)
 }
 
 const outputTempPrefix = "kgh-kernel-output-*"

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -95,6 +95,9 @@ targets:
 	if time.Duration(report.PollTimeout) != 30*time.Minute {
 		t.Fatalf("unexpected poll timeout %s", report.PollTimeout)
 	}
+	if report.Submission != nil {
+		t.Fatalf("expected no submission details for dry-run, got %+v", report.Submission)
+	}
 }
 
 func TestRunnerExecuteMissingTarget(t *testing.T) {
@@ -225,6 +228,21 @@ targets:
 			}
 			return kaggle.DownloadKernelOutputResponse{OutputDir: req.OutputDir}, nil
 		},
+		submitFn: func(_ context.Context, req kaggle.CompetitionSubmitRequest) (kaggle.CompetitionSubmitResponse, error) {
+			if req.Competition != "playground-series-s6e2" {
+				t.Fatalf("unexpected competition %q", req.Competition)
+			}
+			if filepath.Base(req.FilePath) != "submission.csv" {
+				t.Fatalf("unexpected submission file %q", req.FilePath)
+			}
+			if req.Message != "kgh target=exp142 kernel=yourname/exp142" {
+				t.Fatalf("unexpected submission message %q", req.Message)
+			}
+			return kaggle.CompetitionSubmitResponse{
+				Competition: req.Competition,
+				Submitted:   true,
+			}, nil
+		},
 	}
 
 	runner := NewRunner(adapter)
@@ -293,6 +311,24 @@ targets:
 	if report.Outputs.Metrics.Required || report.Outputs.Metrics.Error != "" {
 		t.Fatalf("expected optional metrics with no error: %+v", report.Outputs.Metrics)
 	}
+	if report.Submission == nil {
+		t.Fatalf("expected submission details to be populated: %+v", report)
+	}
+	if !report.Submission.Enabled || report.Submission.Skipped {
+		t.Fatalf("expected enabled non-skipped submission: %+v", report.Submission)
+	}
+	if !report.Submission.Submitted {
+		t.Fatalf("expected submission to succeed: %+v", report.Submission)
+	}
+	if report.Submission.Competition != "playground-series-s6e2" {
+		t.Fatalf("unexpected submission competition %q", report.Submission.Competition)
+	}
+	if report.Submission.FilePath != report.Outputs.SubmissionPath {
+		t.Fatalf("expected submission file path to match outputs, got %+v vs %+v", report.Submission, report.Outputs)
+	}
+	if report.Submission.Message != "kgh target=exp142 kernel=yourname/exp142" {
+		t.Fatalf("unexpected submission message %q", report.Submission.Message)
+	}
 }
 
 func TestRunnerExecuteLiveMissingRequiredSubmissionFailsValidation(t *testing.T) {
@@ -354,11 +390,17 @@ targets:
 		DryRun:     false,
 		ConfigPath: configPath,
 	})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); !strings.Contains(got, "submit enabled but submission artifact is missing") {
+		t.Fatalf("unexpected error %q", got)
 	}
 	if report.Outputs == nil {
 		t.Fatalf("expected outputs handoff, got %+v", report)
+	}
+	if report.Submission == nil {
+		t.Fatalf("expected submission details on failure, got %+v", report)
 	}
 	if report.Outputs.Submission.Present {
 		t.Fatalf("expected submission to be missing: %+v", report.Outputs.Submission)
@@ -383,6 +425,15 @@ targets:
 	}
 	if report.Outputs.Submission.Error == "" || !strings.Contains(report.Outputs.Submission.Error, "submission output is missing") {
 		t.Fatalf("unexpected submission error %+v", report.Outputs.Submission)
+	}
+	if !report.Submission.Enabled || report.Submission.Submitted {
+		t.Fatalf("expected attempted but unsuccessful submission metadata: %+v", report.Submission)
+	}
+	if report.Submission.FilePath != "" {
+		t.Fatalf("expected empty submission file path when output is missing, got %+v", report.Submission)
+	}
+	if report.Submission.Reason == "" || !strings.Contains(report.Submission.Reason, "submission output is missing") {
+		t.Fatalf("unexpected submission reason %+v", report.Submission)
 	}
 }
 
@@ -436,6 +487,10 @@ targets:
 			}
 			return kaggle.DownloadKernelOutputResponse{OutputDir: req.OutputDir}, nil
 		},
+		submitFn: func(_ context.Context, _ kaggle.CompetitionSubmitRequest) (kaggle.CompetitionSubmitResponse, error) {
+			t.Fatal("did not expect submission when submit=false")
+			return kaggle.CompetitionSubmitResponse{}, nil
+		},
 	}
 
 	report, err := NewRunner(adapter).Execute(context.Background(), Request{
@@ -463,6 +518,12 @@ targets:
 	}
 	if report.Outputs.Metrics.Error == "" || !strings.Contains(report.Outputs.Metrics.Error, "metrics output is missing") {
 		t.Fatalf("unexpected metrics error %+v", report.Outputs.Metrics)
+	}
+	if report.Submission == nil {
+		t.Fatalf("expected submission details to explain skip: %+v", report)
+	}
+	if report.Submission.Enabled || !report.Submission.Skipped || report.Submission.Reason != "submission disabled for target" {
+		t.Fatalf("unexpected submission skip details %+v", report.Submission)
 	}
 }
 
@@ -516,6 +577,10 @@ targets:
 			}
 			return kaggle.DownloadKernelOutputResponse{OutputDir: req.OutputDir}, nil
 		},
+		submitFn: func(_ context.Context, _ kaggle.CompetitionSubmitRequest) (kaggle.CompetitionSubmitResponse, error) {
+			t.Fatal("did not expect submission when submit=false")
+			return kaggle.CompetitionSubmitResponse{}, nil
+		},
 	}
 
 	report, err := NewRunner(adapter).Execute(context.Background(), Request{
@@ -540,6 +605,12 @@ targets:
 	}
 	if report.Outputs.Submission.Error == "" || !strings.Contains(report.Outputs.Submission.Error, "submission output is missing") {
 		t.Fatalf("unexpected submission error %+v", report.Outputs.Submission)
+	}
+	if report.Submission == nil {
+		t.Fatalf("expected submission details to explain skip: %+v", report)
+	}
+	if report.Submission.Enabled || !report.Submission.Skipped || report.Submission.Reason != "submission disabled for target" {
+		t.Fatalf("unexpected submission skip details %+v", report.Submission)
 	}
 }
 
@@ -607,6 +678,7 @@ type liveAdapter struct {
 	pushFn     func(context.Context, kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error)
 	pollFn     func(context.Context, kaggle.KernelPollRequest) (kaggle.KernelPollResult, error)
 	downloadFn func(context.Context, kaggle.DownloadKernelOutputRequest) (kaggle.DownloadKernelOutputResponse, error)
+	submitFn   func(context.Context, kaggle.CompetitionSubmitRequest) (kaggle.CompetitionSubmitResponse, error)
 }
 
 func (a *liveAdapter) PushKernel(ctx context.Context, req kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error) {
@@ -628,6 +700,13 @@ func (a *liveAdapter) DownloadKernelOutput(ctx context.Context, req kaggle.Downl
 		a.t.Fatal("downloadFn must be set")
 	}
 	return a.downloadFn(ctx, req)
+}
+
+func (a *liveAdapter) SubmitCompetition(ctx context.Context, req kaggle.CompetitionSubmitRequest) (kaggle.CompetitionSubmitResponse, error) {
+	if a.submitFn == nil {
+		a.t.Fatal("submitFn must be set")
+	}
+	return a.submitFn(ctx, req)
 }
 
 func testExecutionSpec() spec.ExecutionSpec {

--- a/internal/github/trigger.go
+++ b/internal/github/trigger.go
@@ -1,0 +1,119 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/shotomorisk/kgh/internal/execx"
+	"github.com/shotomorisk/kgh/internal/parser"
+)
+
+// TriggerResolver resolves a single submit trigger from GitHub Actions context.
+type TriggerResolver struct {
+	Getenv   func(string) string
+	ReadFile func(string) ([]byte, error)
+	Runner   execx.Runner
+}
+
+// NewTriggerResolver constructs a production resolver backed by process env, file reads, and git.
+func NewTriggerResolver() TriggerResolver {
+	return TriggerResolver{
+		Getenv:   os.Getenv,
+		ReadFile: os.ReadFile,
+		Runner:   execx.NewRunner(),
+	}
+}
+
+// Resolve reads GitHub Actions metadata, loads the selected commit message, and parses one trigger.
+func (r TriggerResolver) Resolve(ctx context.Context) (parser.Trigger, error) {
+	if r.Getenv == nil {
+		r.Getenv = os.Getenv
+	}
+	if r.ReadFile == nil {
+		r.ReadFile = os.ReadFile
+	}
+	if r.Runner == nil {
+		r.Runner = execx.NewRunner()
+	}
+
+	eventName := strings.TrimSpace(r.Getenv("GITHUB_EVENT_NAME"))
+	if eventName == "" {
+		return parser.Trigger{}, fmt.Errorf("GITHUB_EVENT_NAME is required")
+	}
+
+	sha, err := r.resolveSHA(eventName)
+	if err != nil {
+		return parser.Trigger{}, err
+	}
+
+	message, err := r.readCommitMessage(ctx, sha)
+	if err != nil {
+		return parser.Trigger{}, err
+	}
+
+	trigger, err := parser.ParseCommitMessage(message)
+	if err != nil {
+		return parser.Trigger{}, fmt.Errorf("parse commit message for %s: %w", sha, err)
+	}
+
+	return trigger, nil
+}
+
+func (r TriggerResolver) resolveSHA(eventName string) (string, error) {
+	switch eventName {
+	case "push":
+		sha := strings.TrimSpace(r.Getenv("GITHUB_SHA"))
+		if sha == "" {
+			return "", fmt.Errorf("GITHUB_SHA is required for push events")
+		}
+		return sha, nil
+	case "pull_request", "pull_request_target":
+		eventPath := strings.TrimSpace(r.Getenv("GITHUB_EVENT_PATH"))
+		if eventPath == "" {
+			return "", fmt.Errorf("GITHUB_EVENT_PATH is required for %s events", eventName)
+		}
+		body, err := r.ReadFile(eventPath)
+		if err != nil {
+			return "", fmt.Errorf("read GitHub event payload %q: %w", eventPath, err)
+		}
+
+		var payload struct {
+			PullRequest struct {
+				Head struct {
+					SHA string `json:"sha"`
+				} `json:"head"`
+			} `json:"pull_request"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return "", fmt.Errorf("parse GitHub event payload %q: %w", eventPath, err)
+		}
+
+		sha := strings.TrimSpace(payload.PullRequest.Head.SHA)
+		if sha == "" {
+			return "", fmt.Errorf("pull_request.head.sha is required for %s events", eventName)
+		}
+		return sha, nil
+	default:
+		return "", fmt.Errorf("unsupported GitHub event %q", eventName)
+	}
+}
+
+func (r TriggerResolver) readCommitMessage(ctx context.Context, sha string) (string, error) {
+	opts := execx.Options{}
+	if workspace := strings.TrimSpace(r.Getenv("GITHUB_WORKSPACE")); workspace != "" {
+		opts.Dir = workspace
+	}
+
+	result, err := r.Runner.Run(ctx, execx.Command{
+		Path: "git",
+		Args: []string{"show", "-s", "--format=%B", "--no-patch", sha},
+	}, opts)
+	if err != nil {
+		return "", fmt.Errorf("read commit message for %s: %w", sha, err)
+	}
+
+	return strings.TrimRight(result.Stdout, "\n"), nil
+}

--- a/internal/github/trigger_test.go
+++ b/internal/github/trigger_test.go
@@ -1,0 +1,186 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shotomorisk/kgh/internal/execx"
+)
+
+func TestTriggerResolverResolvePushEvent(t *testing.T) {
+	t.Parallel()
+
+	resolver := TriggerResolver{
+		Getenv: envMap(map[string]string{
+			"GITHUB_EVENT_NAME": "push",
+			"GITHUB_SHA":        "abc123",
+		}),
+		ReadFile: os.ReadFile,
+		Runner: fakeRunner{run: func(_ context.Context, cmd execx.Command, opts execx.Options) (execx.Result, error) {
+			if cmd.Path != "git" {
+				t.Fatalf("unexpected command %q", cmd.Path)
+			}
+			if got := strings.Join(cmd.Args, " "); got != "show -s --format=%B --no-patch abc123" {
+				t.Fatalf("unexpected args %q", got)
+			}
+			if opts.Dir != "" {
+				t.Fatalf("unexpected dir %q", opts.Dir)
+			}
+			return execx.Result{Stdout: "feat: tune pipeline\n\nsubmit: exp142 gpu=false\n"}, nil
+		}},
+	}
+
+	trigger, err := resolver.Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if trigger.Target != "exp142" {
+		t.Fatalf("unexpected target %q", trigger.Target)
+	}
+	if trigger.GPU == nil || *trigger.GPU != false {
+		t.Fatalf("expected gpu override false, got %+v", trigger.GPU)
+	}
+}
+
+func TestTriggerResolverResolvePullRequestEvent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	eventPath := filepath.Join(dir, "event.json")
+	if err := os.WriteFile(eventPath, []byte(`{"pull_request":{"head":{"sha":"deadbeef"}}}`), 0o644); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+
+	resolver := TriggerResolver{
+		Getenv: envMap(map[string]string{
+			"GITHUB_EVENT_NAME": "pull_request",
+			"GITHUB_EVENT_PATH": eventPath,
+			"GITHUB_WORKSPACE":  "/tmp/workspace",
+		}),
+		ReadFile: os.ReadFile,
+		Runner: fakeRunner{run: func(_ context.Context, cmd execx.Command, opts execx.Options) (execx.Result, error) {
+			if got := strings.Join(cmd.Args, " "); got != "show -s --format=%B --no-patch deadbeef" {
+				t.Fatalf("unexpected args %q", got)
+			}
+			if opts.Dir != "/tmp/workspace" {
+				t.Fatalf("unexpected workspace %q", opts.Dir)
+			}
+			return execx.Result{Stdout: "submit: exp142 internet=true\n"}, nil
+		}},
+	}
+
+	trigger, err := resolver.Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if trigger.Target != "exp142" {
+		t.Fatalf("unexpected target %q", trigger.Target)
+	}
+	if trigger.Internet == nil || *trigger.Internet != true {
+		t.Fatalf("expected internet override true, got %+v", trigger.Internet)
+	}
+}
+
+func TestTriggerResolverRejectsUnsupportedEvent(t *testing.T) {
+	t.Parallel()
+
+	_, err := TriggerResolver{
+		Getenv: envMap(map[string]string{
+			"GITHUB_EVENT_NAME": "workflow_dispatch",
+		}),
+	}.Resolve(context.Background())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); !strings.Contains(got, `unsupported GitHub event "workflow_dispatch"`) {
+		t.Fatalf("unexpected error %q", got)
+	}
+}
+
+func TestTriggerResolverRejectsMissingPullRequestSHA(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	eventPath := filepath.Join(dir, "event.json")
+	if err := os.WriteFile(eventPath, []byte(`{"pull_request":{"head":{}}}`), 0o644); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+
+	_, err := TriggerResolver{
+		Getenv: envMap(map[string]string{
+			"GITHUB_EVENT_NAME": "pull_request",
+			"GITHUB_EVENT_PATH": eventPath,
+		}),
+		ReadFile: os.ReadFile,
+	}.Resolve(context.Background())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); !strings.Contains(got, "pull_request.head.sha is required") {
+		t.Fatalf("unexpected error %q", got)
+	}
+}
+
+func TestTriggerResolverWrapsGitReadFailure(t *testing.T) {
+	t.Parallel()
+
+	resolver := TriggerResolver{
+		Getenv: envMap(map[string]string{
+			"GITHUB_EVENT_NAME": "push",
+			"GITHUB_SHA":        "abc123",
+		}),
+		ReadFile: os.ReadFile,
+		Runner: fakeRunner{run: func(_ context.Context, _ execx.Command, _ execx.Options) (execx.Result, error) {
+			return execx.Result{}, errors.New("git failed")
+		}},
+	}
+
+	_, err := resolver.Resolve(context.Background())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); !strings.Contains(got, "read commit message for abc123") {
+		t.Fatalf("unexpected error %q", got)
+	}
+}
+
+func TestTriggerResolverWrapsParseFailure(t *testing.T) {
+	t.Parallel()
+
+	resolver := TriggerResolver{
+		Getenv: envMap(map[string]string{
+			"GITHUB_EVENT_NAME": "push",
+			"GITHUB_SHA":        "abc123",
+		}),
+		ReadFile: os.ReadFile,
+		Runner: fakeRunner{run: func(_ context.Context, _ execx.Command, _ execx.Options) (execx.Result, error) {
+			return execx.Result{Stdout: "feat: no trigger here\n"}, nil
+		}},
+	}
+
+	_, err := resolver.Resolve(context.Background())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); !strings.Contains(got, "parse commit message for abc123") {
+		t.Fatalf("unexpected error %q", got)
+	}
+}
+
+type fakeRunner struct {
+	run func(context.Context, execx.Command, execx.Options) (execx.Result, error)
+}
+
+func (f fakeRunner) Run(ctx context.Context, cmd execx.Command, opts execx.Options) (execx.Result, error) {
+	return f.run(ctx, cmd, opts)
+}
+
+func envMap(values map[string]string) func(string) string {
+	return func(key string) string {
+		return values[key]
+	}
+}


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #62 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented the commit-trigger CI entrypoint and kept the existing explicit local path intact.

The main changes are in cmd/kgh/main.go:1, which now supports kgh github run, and the new resolver in internal/ github/trigger.go:1, which resolves the authoritative commit SHA from GitHub Actions context, reads that commit message from git, and parses exactly one submit: trigger. I added coverage in cmd/kgh/main_test.go:1 and internal/github/trigger_test.go:1, including real temp-repo CLI tests for push and pull_request behavior.

I also added the PR workflow at .github/workflows/commit-trigger.yml:1 and updated README.md:1 to document github run as the CI path and run --target as the manual/debug path.

Verification: go test ./... passed.
<!-- close -->