### PR TITLE
Add structured kernel output handoff contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ For local debugging, keep using the explicit target path. Create `.kgh/config.ya
 ./kgh run --target issue7-e2e --dry-run=false --poll-interval=2s --timeout=5m
 ```
 
+Live runs return a structured JSON report. The output retrieval stage exposes a
+stable handoff under `outputs` for downstream submit and reporting logic,
+including:
+
+- `output_dir`
+- `submission_path`
+- `metrics_path`
+- per-file `submission` and `metrics` objects with explicit presence/error state
+- `validation.missing_required` and `validation.missing_optional`
+
+This lets later steps consume canonical paths directly instead of re-discovering
+files from the downloaded Kaggle output directory.
+
 The repository includes a PR workflow at [`.github/workflows/commit-trigger.yml`](.github/workflows/commit-trigger.yml) that checks the head commit for `submit:` and invokes `kgh github run` only when a trigger is present.
 
 ### Issue 7 live verification

--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -71,6 +71,8 @@ type PollResult struct {
 	Raw        kaggle.KernelStatusRawStatus   `json:"raw,omitempty"`
 }
 
+// OutputsResult is the stable handoff contract for downstream submit and
+// reporting steps after kernel outputs have been downloaded and validated.
 type OutputsResult struct {
 	OutputDir      string                 `json:"output_dir"`
 	SubmissionPath string                 `json:"submission_path"`
@@ -96,6 +98,8 @@ type OutputValidationResult struct {
 	MissingOptional []string `json:"missing_optional"`
 }
 
+// OutputFileResult records the configured and resolved state of one expected
+// output file so downstream consumers do not need to re-scan the output dir.
 type OutputFileResult struct {
 	ConfiguredPath string `json:"configured_path"`
 	ExpectedPath   string `json:"expected_path"`

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -299,6 +299,12 @@ targets:
 	if report.Outputs.SubmissionPath == "" || report.Outputs.MetricsPath == "" {
 		t.Fatalf("expected canonical output paths to be populated: %+v", report.Outputs)
 	}
+	if report.Outputs.Submission.Path != report.Outputs.SubmissionPath {
+		t.Fatalf("expected submission path to mirror structured output file path, got %+v", report.Outputs)
+	}
+	if report.Outputs.Metrics.Path != report.Outputs.MetricsPath {
+		t.Fatalf("expected metrics path to mirror structured output file path, got %+v", report.Outputs)
+	}
 	if !report.Outputs.Validation.Valid {
 		t.Fatalf("expected validation to succeed: %+v", report.Outputs.Validation)
 	}
@@ -670,6 +676,42 @@ func TestBuildOutputsResultRejectsEscapingPaths(t *testing.T) {
 	}
 	if got := result.Submission.Error; !strings.Contains(got, "resolves outside output dir") {
 		t.Fatalf("unexpected submission error %q", got)
+	}
+}
+
+func TestBuildOutputsResultUsesCanonicalOutputDirAndPaths(t *testing.T) {
+	t.Parallel()
+
+	parentDir := t.TempDir()
+	outputDir := filepath.Join(parentDir, "nested", "..", "nested")
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		t.Fatalf("mkdir output dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, "submission.csv"), []byte("id,label\n1,0\n"), 0o644); err != nil {
+		t.Fatalf("write submission output: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, "metrics.json"), []byte(`{"score":0.5}`), 0o644); err != nil {
+		t.Fatalf("write metrics output: %v", err)
+	}
+
+	execSpec := testExecutionSpec()
+	result, err := buildOutputsResult(execSpec, outputDir)
+	if err != nil {
+		t.Fatalf("build outputs result: %v", err)
+	}
+
+	expectedDir, err := filepath.Abs(filepath.Join(parentDir, "nested"))
+	if err != nil {
+		t.Fatalf("resolve expected dir: %v", err)
+	}
+	if result.OutputDir != expectedDir {
+		t.Fatalf("expected canonical output dir %q, got %q", expectedDir, result.OutputDir)
+	}
+	if result.SubmissionPath != filepath.Join(expectedDir, "submission.csv") {
+		t.Fatalf("unexpected canonical submission path %q", result.SubmissionPath)
+	}
+	if result.MetricsPath != filepath.Join(expectedDir, "metrics.json") {
+		t.Fatalf("unexpected canonical metrics path %q", result.MetricsPath)
 	}
 }
 


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #26 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented the issue-26 close-out work by making the output handoff contract explicit and locking it with tests. I documented OutputsResult and OutputFileResult as the stable downstream interface in internal/execution/execution.go:74, added a short README note describing the outputs JSON contract in README.md:39, and tightened execution tests in internal/execution/ execution_test.go:299 to assert canonical path mirroring plus canonicalized output directory/path behavior.

<!-- close -->