### PR TITLE
Integrate kaggle PB retrieval into live execution 

### DIFF
--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -83,13 +83,18 @@ type OutputsResult struct {
 }
 
 type SubmissionResult struct {
-	Enabled     bool   `json:"enabled"`
-	Skipped     bool   `json:"skipped"`
-	Competition string `json:"competition,omitempty"`
-	FilePath    string `json:"file_path,omitempty"`
-	Message     string `json:"message,omitempty"`
-	Submitted   bool   `json:"submitted"`
-	Reason      string `json:"reason,omitempty"`
+	Enabled        bool      `json:"enabled"`
+	Skipped        bool      `json:"skipped"`
+	Competition    string    `json:"competition,omitempty"`
+	FilePath       string    `json:"file_path,omitempty"`
+	Message        string    `json:"message,omitempty"`
+	Submitted      bool      `json:"submitted"`
+	Reason         string    `json:"reason,omitempty"`
+	Status         string    `json:"status,omitempty"`
+	PublicScore    string    `json:"public_score,omitempty"`
+	SubmittedAt    time.Time `json:"submitted_at,omitempty"`
+	ScoreRetrieved bool      `json:"score_retrieved"`
+	ScoreReason    string    `json:"score_reason,omitempty"`
 }
 
 type OutputValidationResult struct {
@@ -124,6 +129,7 @@ type Adapter interface {
 	PollKernelStatus(context.Context, kaggle.KernelPollRequest) (kaggle.KernelPollResult, error)
 	DownloadKernelOutput(context.Context, kaggle.DownloadKernelOutputRequest) (kaggle.DownloadKernelOutputResponse, error)
 	SubmitCompetition(context.Context, kaggle.CompetitionSubmitRequest) (kaggle.CompetitionSubmitResponse, error)
+	ListCompetitionSubmissions(context.Context, kaggle.CompetitionSubmissionsRequest) (kaggle.CompetitionSubmissionsResponse, error)
 }
 
 type Runner struct {

--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -309,7 +309,66 @@ func (r *Runner) submitOutputs(ctx context.Context, execSpec spec.ExecutionSpec,
 
 	result.Competition = resp.Competition
 	result.Submitted = resp.Submitted
+
+	submissionsResp, err := r.adapter.ListCompetitionSubmissions(ctx, kaggle.CompetitionSubmissionsRequest{
+		Competition: execSpec.Competition,
+	})
+	if err != nil {
+		result.ScoreReason = "list competition submissions"
+		return result, fmt.Errorf("retrieve latest public score: %w", err)
+	}
+
+	scoreResult, err := resolveLatestRelevantSubmission(result.Message, submissionsResp.Submissions)
+	result.Status = scoreResult.Status
+	result.PublicScore = scoreResult.PublicScore
+	result.SubmittedAt = scoreResult.SubmittedAt
+	result.ScoreRetrieved = scoreResult.ScoreRetrieved
+	result.ScoreReason = scoreResult.ScoreReason
+	if err != nil {
+		return result, fmt.Errorf("retrieve latest public score: %w", err)
+	}
+
 	return result, nil
+}
+
+func resolveLatestRelevantSubmission(message string, submissions []kaggle.CompetitionSubmission) (SubmissionResult, error) {
+	var latestMatch *kaggle.CompetitionSubmission
+	var latestScored *kaggle.CompetitionSubmission
+
+	for i := range submissions {
+		submission := &submissions[i]
+		if submission.Description != message {
+			continue
+		}
+
+		if latestMatch == nil || submission.SubmittedAt.After(latestMatch.SubmittedAt) {
+			latestMatch = submission
+		}
+		if submission.PublicScore != "" && (latestScored == nil || submission.SubmittedAt.After(latestScored.SubmittedAt)) {
+			latestScored = submission
+		}
+	}
+
+	if latestMatch == nil {
+		return SubmissionResult{
+			ScoreReason: "no matching Kaggle submission found for current run",
+		}, fmt.Errorf("no matching Kaggle submission found for current run")
+	}
+
+	if latestScored == nil {
+		return SubmissionResult{
+			Status:      latestMatch.Status,
+			SubmittedAt: latestMatch.SubmittedAt,
+			ScoreReason: "matching Kaggle submission has no public score yet",
+		}, fmt.Errorf("matching Kaggle submission has no public score yet")
+	}
+
+	return SubmissionResult{
+		Status:         latestScored.Status,
+		PublicScore:    latestScored.PublicScore,
+		SubmittedAt:    latestScored.SubmittedAt,
+		ScoreRetrieved: true,
+	}, nil
 }
 
 func effectivePollInterval(requested, fallback time.Duration) time.Duration {

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -847,6 +847,73 @@ func TestBuildOutputsResultUsesCanonicalOutputDirAndPaths(t *testing.T) {
 	}
 }
 
+func TestResolveLatestRelevantSubmissionPrefersNewestScoredMatch(t *testing.T) {
+	t.Parallel()
+
+	result, err := resolveLatestRelevantSubmission("kgh target=exp142 kernel=yourname/exp142", []kaggle.CompetitionSubmission{
+		{
+			Description: "unrelated submission",
+			Status:      "complete",
+			PublicScore: "0.99999",
+			SubmittedAt: time.Unix(50, 0),
+		},
+		{
+			Description: "kgh target=exp142 kernel=yourname/exp142",
+			Status:      "pending",
+			SubmittedAt: time.Unix(10, 0),
+		},
+		{
+			Description: "kgh target=exp142 kernel=yourname/exp142",
+			Status:      "complete",
+			PublicScore: "0.11111",
+			SubmittedAt: time.Unix(20, 0),
+		},
+		{
+			Description: "kgh target=exp142 kernel=yourname/exp142",
+			Status:      "complete",
+			PublicScore: "0.22222",
+			SubmittedAt: time.Unix(30, 0),
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !result.ScoreRetrieved {
+		t.Fatalf("expected score retrieval to succeed: %+v", result)
+	}
+	if result.PublicScore != "0.22222" {
+		t.Fatalf("unexpected public score %q", result.PublicScore)
+	}
+	if result.Status != "complete" {
+		t.Fatalf("unexpected submission status %q", result.Status)
+	}
+	if !result.SubmittedAt.Equal(time.Unix(30, 0)) {
+		t.Fatalf("unexpected submission timestamp %s", result.SubmittedAt)
+	}
+}
+
+func TestResolveLatestRelevantSubmissionFailsWhenNoMatchingSubmissionExists(t *testing.T) {
+	t.Parallel()
+
+	result, err := resolveLatestRelevantSubmission("kgh target=exp142 kernel=yourname/exp142", []kaggle.CompetitionSubmission{
+		{
+			Description: "different submission",
+			Status:      "complete",
+			PublicScore: "0.12345",
+			SubmittedAt: time.Unix(20, 0),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "no matching Kaggle submission found") {
+		t.Fatalf("unexpected error %q", err.Error())
+	}
+	if result.ScoreReason == "" || !strings.Contains(result.ScoreReason, "no matching Kaggle submission found") {
+		t.Fatalf("unexpected result %+v", result)
+	}
+}
+
 type liveAdapter struct {
 	t          *testing.T
 	pushFn     func(context.Context, kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error)

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -721,6 +721,7 @@ type liveAdapter struct {
 	pollFn     func(context.Context, kaggle.KernelPollRequest) (kaggle.KernelPollResult, error)
 	downloadFn func(context.Context, kaggle.DownloadKernelOutputRequest) (kaggle.DownloadKernelOutputResponse, error)
 	submitFn   func(context.Context, kaggle.CompetitionSubmitRequest) (kaggle.CompetitionSubmitResponse, error)
+	listFn     func(context.Context, kaggle.CompetitionSubmissionsRequest) (kaggle.CompetitionSubmissionsResponse, error)
 }
 
 func (a *liveAdapter) PushKernel(ctx context.Context, req kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error) {
@@ -749,6 +750,13 @@ func (a *liveAdapter) SubmitCompetition(ctx context.Context, req kaggle.Competit
 		a.t.Fatal("submitFn must be set")
 	}
 	return a.submitFn(ctx, req)
+}
+
+func (a *liveAdapter) ListCompetitionSubmissions(ctx context.Context, req kaggle.CompetitionSubmissionsRequest) (kaggle.CompetitionSubmissionsResponse, error) {
+	if a.listFn == nil {
+		a.t.Fatal("listFn must be set")
+	}
+	return a.listFn(ctx, req)
 }
 
 func testExecutionSpec() spec.ExecutionSpec {

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -243,6 +243,22 @@ targets:
 				Submitted:   true,
 			}, nil
 		},
+		listFn: func(_ context.Context, req kaggle.CompetitionSubmissionsRequest) (kaggle.CompetitionSubmissionsResponse, error) {
+			if req.Competition != "playground-series-s6e2" {
+				t.Fatalf("unexpected competition %q", req.Competition)
+			}
+			return kaggle.CompetitionSubmissionsResponse{
+				Submissions: []kaggle.CompetitionSubmission{
+					{
+						FileName:    "submission.csv",
+						Description: "kgh target=exp142 kernel=yourname/exp142",
+						Status:      "complete",
+						PublicScore: "0.12345",
+						SubmittedAt: time.Unix(10, 0),
+					},
+				},
+			}, nil
+		},
 	}
 
 	runner := NewRunner(adapter)
@@ -334,6 +350,18 @@ targets:
 	}
 	if report.Submission.Message != "kgh target=exp142 kernel=yourname/exp142" {
 		t.Fatalf("unexpected submission message %q", report.Submission.Message)
+	}
+	if !report.Submission.ScoreRetrieved {
+		t.Fatalf("expected score retrieval to succeed: %+v", report.Submission)
+	}
+	if report.Submission.PublicScore != "0.12345" {
+		t.Fatalf("unexpected public score %q", report.Submission.PublicScore)
+	}
+	if report.Submission.Status != "complete" {
+		t.Fatalf("unexpected submission status %q", report.Submission.Status)
+	}
+	if !report.Submission.SubmittedAt.Equal(time.Unix(10, 0)) {
+		t.Fatalf("unexpected submission timestamp %s", report.Submission.SubmittedAt)
 	}
 }
 
@@ -440,6 +468,110 @@ targets:
 	}
 	if report.Submission.Reason == "" || !strings.Contains(report.Submission.Reason, "submission output is missing") {
 		t.Fatalf("unexpected submission reason %+v", report.Submission)
+	}
+}
+
+func TestRunnerExecuteLiveFailsWhenPublicScoreCannotBeRetrieved(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	notebook := filepath.Join(dir, "notebooks", "exp142.ipynb")
+	if err := os.MkdirAll(filepath.Dir(notebook), 0o755); err != nil {
+		t.Fatalf("mkdir notebook dir: %v", err)
+	}
+	if err := os.WriteFile(notebook, []byte(`{"cells":[]}`), 0o644); err != nil {
+		t.Fatalf("write notebook: %v", err)
+	}
+
+	configPath := filepath.Join(dir, ".kgh", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`
+targets:
+  exp142:
+    notebook: `+notebook+`
+    kernel_id: yourname/exp142
+    competition: playground-series-s6e2
+    submit: true
+    outputs:
+      submission: submission.csv
+      metrics: metrics.json
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	adapter := &liveAdapter{
+		t: t,
+		pushFn: func(_ context.Context, _ kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error) {
+			return kaggle.PushKernelResponse{KernelRef: "yourname/exp142"}, nil
+		},
+		pollFn: func(_ context.Context, _ kaggle.KernelPollRequest) (kaggle.KernelPollResult, error) {
+			return kaggle.KernelPollResult{
+				KernelStatusResponse: kaggle.KernelStatusResponse{
+					KernelRef: "yourname/exp142",
+					Status:    "complete",
+				},
+				Terminal: kaggle.KernelPollTerminalStateSucceeded,
+			}, nil
+		},
+		downloadFn: func(_ context.Context, req kaggle.DownloadKernelOutputRequest) (kaggle.DownloadKernelOutputResponse, error) {
+			if err := os.WriteFile(filepath.Join(req.OutputDir, "submission.csv"), []byte("id,label\n1,0\n"), 0o644); err != nil {
+				t.Fatalf("write submission output: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(req.OutputDir, "metrics.json"), []byte(`{"score":0.5}`), 0o644); err != nil {
+				t.Fatalf("write metrics output: %v", err)
+			}
+			return kaggle.DownloadKernelOutputResponse{OutputDir: req.OutputDir}, nil
+		},
+		submitFn: func(_ context.Context, req kaggle.CompetitionSubmitRequest) (kaggle.CompetitionSubmitResponse, error) {
+			return kaggle.CompetitionSubmitResponse{
+				Competition: req.Competition,
+				Submitted:   true,
+			}, nil
+		},
+		listFn: func(_ context.Context, _ kaggle.CompetitionSubmissionsRequest) (kaggle.CompetitionSubmissionsResponse, error) {
+			return kaggle.CompetitionSubmissionsResponse{
+				Submissions: []kaggle.CompetitionSubmission{
+					{
+						FileName:    "submission.csv",
+						Description: "kgh target=exp142 kernel=yourname/exp142",
+						Status:      "pending",
+						SubmittedAt: time.Unix(10, 0),
+					},
+				},
+			}, nil
+		},
+	}
+
+	report, err := NewRunner(adapter).Execute(context.Background(), Request{
+		Target:     "exp142",
+		DryRun:     false,
+		ConfigPath: configPath,
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); !strings.Contains(got, "retrieve latest public score") {
+		t.Fatalf("unexpected error %q", got)
+	}
+	if report.Submission == nil {
+		t.Fatalf("expected submission details to be populated: %+v", report)
+	}
+	if !report.Submission.Submitted {
+		t.Fatalf("expected submission to succeed before score lookup failure: %+v", report.Submission)
+	}
+	if report.Submission.ScoreRetrieved {
+		t.Fatalf("did not expect score retrieval to succeed: %+v", report.Submission)
+	}
+	if report.Submission.Status != "pending" {
+		t.Fatalf("unexpected submission status %q", report.Submission.Status)
+	}
+	if report.Submission.PublicScore != "" {
+		t.Fatalf("expected empty public score, got %q", report.Submission.PublicScore)
+	}
+	if report.Submission.ScoreReason == "" || !strings.Contains(report.Submission.ScoreReason, "no public score yet") {
+		t.Fatalf("unexpected score reason %+v", report.Submission)
 	}
 }
 


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #78 

## Overview

What changed:
  - submission in the live execution result now carries score retrieval fields like public_score, status,
    submitted_at, score_retrieved, and score_reason.
  - The live runner now calls Kaggle competitions submissions after a successful submit and matches the latest
    relevant row by the existing submit message.
  - If submission succeeds but no matching scored row is found, the run fails clearly while preserving partial
    submission data in the returned result.
  - Dry-run behavior is unchanged.
<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->

<!-- close -->