### PR TITLE
Nix flake for kgh 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,18 @@ go run ./cmd/kgh/main.go kgh github run
 ```
 
 For local debugging, keep using the explicit target path. Create `.kgh/config.yaml` from `.kgh/config_example.yaml`
+
+### Nix
+
+```bash
+# Enter the development shell
+nix develop
+
+# Build the kgh package
+nix build
+
+# Run deterministic package, test, vet, and format checks
+nix flake check
+```
+
+The dev shell includes Go, Python, and the Kaggle CLI. Kaggle-authenticated smoke flows still require your own credentials and are not part of `nix flake check`.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777678872,
+        "narHash": "sha256-EPIFsulyon7Z1vLQq5Fk64GR8L7cQsT+IPhcsukVbgk=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "5250617bffd85403b14dbf43c3870e7f255d2c16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "kgh - GitHub-native tool for Kaggle workflows";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      imports = [
+        ./nix/packages.nix
+        ./nix/checks.nix
+        ./nix/devShell.nix
+      ];
+    };
+}

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,0 +1,47 @@
+{ inputs, ... }:
+{
+  perSystem =
+    { pkgs, self', ... }:
+    let
+      kghPackage = pkgs.callPackage ./kgh.nix {
+        self = inputs.self;
+      };
+    in
+    {
+      checks = {
+        package = self'.packages.default;
+
+        test = kghPackage.overrideAttrs (old: {
+          pname = "${old.pname}-test";
+          doCheck = true;
+          nativeCheckInputs = (old.nativeCheckInputs or [ ]) ++ [ pkgs.git ];
+          checkPhase = ''
+            runHook preCheck
+            go test ./...
+            runHook postCheck
+          '';
+        });
+
+        vet = kghPackage.overrideAttrs (old: {
+          pname = "${old.pname}-vet";
+          doCheck = true;
+          nativeCheckInputs = (old.nativeCheckInputs or [ ]) ++ [ pkgs.git ];
+          checkPhase = ''
+            runHook preCheck
+            go vet ./...
+            runHook postCheck
+          '';
+        });
+
+        fmt = pkgs.runCommand "kgh-gofmt-check" { nativeBuildInputs = [ pkgs.go ]; } ''
+          cd ${inputs.self}
+          if [ -n "$(gofmt -l .)" ]; then
+            echo "gofmt found unformatted files" >&2
+            gofmt -l .
+            exit 1
+          fi
+          mkdir -p "$out"
+        '';
+      };
+    };
+}

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -1,0 +1,20 @@
+{ ... }:
+{
+  perSystem = { pkgs, ... }: {
+    devShells.default = pkgs.mkShell {
+      packages = with pkgs; [
+        go
+        gopls
+        gotools
+        git
+        python3
+        python3Packages.kaggle
+      ];
+
+      shellHook = ''
+        echo "kgh Nix dev shell"
+        echo "Available: go, gopls, python3, kaggle"
+      '';
+    };
+  };
+}

--- a/nix/kgh.nix
+++ b/nix/kgh.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildGoModule,
+  self,
+}:
+buildGoModule (finalAttrs: {
+  pname = "kgh";
+  version =
+    if self ? rev
+    then self.shortRev
+    else "dev";
+
+  src = lib.cleanSource self;
+  vendorHash = "sha256-g+yaVIx4jxpAQ/+WrGKxhVeliYx7nLQe/zsGpxV4Fn4=";
+
+  subPackages = [ "cmd/kgh" ];
+  doCheck = false;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X"
+    "main.version=${finalAttrs.version}"
+  ];
+
+  env.CGO_ENABLED = 0;
+
+  meta = {
+    description = "GitHub-native tool for Kaggle workflows";
+    homepage = "https://github.com/shotomorisk/kgh";
+    license = lib.licenses.mit;
+    mainProgram = "kgh";
+  };
+})

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,0 +1,8 @@
+{ inputs, ... }:
+{
+  perSystem = { pkgs, ... }: {
+    packages.default = pkgs.callPackage ./kgh.nix {
+      self = inputs.self;
+    };
+  };
+}


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
• Implemented the Nix setup: flake.nix, nix/kgh.nix, nix/packages.nix, nix/checks.nix, and nix/devShell.nix, plus README Nix usage docs in README.md. The flake exposes a default package, a dev shell with Go/Python/Kaggle CLI tooling, and deterministic fmt/test/vet checks.

Verified on the current aarch64-darwin machine:

  - nix flake show succeeded
  - nix build .#default succeeded
  - nix develop -c sh -lc 'go version && python3 --version && kaggle --help >/dev/null' succeeded
  - nix flake check succeeded
  - ./result/bin/kgh version returned dev
<!-- close -->