### PR TITLE
Return kaggle submission matadata

### DIFF
--- a/doc/local-run.md
+++ b/doc/local-run.md
@@ -65,3 +65,6 @@ Live mode returns a richer JSON report that can include:
 - poll status and terminal state
 - downloaded output paths
 - submission result when `submit: true`
+
+When `submit: true` succeeds, the live JSON includes structured submission metadata under
+`submission` and `score`, including `submission_id`, `status`, and `submitted_at`.

--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -102,23 +102,27 @@ type OutputFileResult struct {
 }
 
 type SubmissionResult struct {
-	Attempted   bool      `json:"attempted"`
-	Submitted   bool      `json:"submitted"`
-	Competition string    `json:"competition"`
-	FilePath    string    `json:"file_path"`
-	FileName    string    `json:"file_name"`
-	Message     string    `json:"message"`
-	AttemptedAt time.Time `json:"attempted_at"`
+	Attempted    bool      `json:"attempted"`
+	Submitted    bool      `json:"submitted"`
+	Competition  string    `json:"competition"`
+	FilePath     string    `json:"file_path"`
+	FileName     string    `json:"file_name"`
+	Message      string    `json:"message"`
+	AttemptedAt  time.Time `json:"attempted_at"`
+	SubmissionID string    `json:"submission_id,omitempty"`
+	Status       string    `json:"status,omitempty"`
+	SubmittedAt  time.Time `json:"submitted_at,omitempty"`
 }
 
 type ScoreResult struct {
-	State       string    `json:"state"`
-	Competition string    `json:"competition"`
-	FileName    string    `json:"file_name"`
-	Message     string    `json:"message"`
-	Status      string    `json:"status,omitempty"`
-	PublicScore string    `json:"public_score,omitempty"`
-	SubmittedAt time.Time `json:"submitted_at,omitempty"`
+	State        string    `json:"state"`
+	Competition  string    `json:"competition"`
+	FileName     string    `json:"file_name"`
+	Message      string    `json:"message"`
+	SubmissionID string    `json:"submission_id,omitempty"`
+	Status       string    `json:"status,omitempty"`
+	PublicScore  string    `json:"public_score,omitempty"`
+	SubmittedAt  time.Time `json:"submitted_at,omitempty"`
 }
 
 const (
@@ -319,7 +323,14 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 	if err != nil {
 		return report, fmt.Errorf("list kaggle competition submissions: %w", err)
 	}
-	report.Score = resolveScoreResult(execSpec.Competition, report.Submission, submissionsResp.Submissions)
+	match, ok := findRelevantSubmission(*report.Submission, submissionsResp.Submissions)
+	if !ok {
+		return report, fmt.Errorf("submission metadata unavailable: no matching Kaggle submission row found")
+	}
+	if err := applySubmissionMetadata(report.Submission, match); err != nil {
+		return report, fmt.Errorf("submission metadata unavailable: %w", err)
+	}
+	report.Score = resolveScoreResult(execSpec.Competition, report.Submission, match)
 
 	return report, nil
 }
@@ -328,23 +339,18 @@ func buildCompetitionSubmitMessage(execSpec spec.ExecutionSpec, kernelRef string
 	return fmt.Sprintf("kgh submit target=%s kernel=%s", execSpec.TargetName, kernelRef)
 }
 
-func resolveScoreResult(competition string, submission *SubmissionResult, rows []kaggle.CompetitionSubmission) *ScoreResult {
+func resolveScoreResult(competition string, submission *SubmissionResult, match kaggle.CompetitionSubmission) *ScoreResult {
 	if submission == nil {
 		return nil
 	}
 
 	score := &ScoreResult{
-		State:       ScoreStateNotFound,
-		Competition: competition,
-		FileName:    submission.FileName,
-		Message:     submission.Message,
+		State:        ScoreStateNotFound,
+		Competition:  competition,
+		FileName:     submission.FileName,
+		Message:      submission.Message,
+		SubmissionID: submission.SubmissionID,
 	}
-
-	match, ok := findRelevantSubmission(*submission, rows)
-	if !ok {
-		return score
-	}
-
 	score.Status = strings.TrimSpace(match.Status)
 	score.PublicScore = strings.TrimSpace(match.PublicScore)
 	score.SubmittedAt = match.SubmittedAt
@@ -370,16 +376,44 @@ func findRelevantSubmission(submission SubmissionResult, rows []kaggle.Competiti
 		if strings.TrimSpace(row.FileName) != submission.FileName {
 			continue
 		}
-		if row.SubmittedAt.IsZero() || row.SubmittedAt.Before(submission.AttemptedAt) {
+		if !row.SubmittedAt.IsZero() && row.SubmittedAt.Before(submission.AttemptedAt) {
 			continue
 		}
-		if !found || row.SubmittedAt.After(best.SubmittedAt) {
+		if !found {
+			best = row
+			found = true
+			continue
+		}
+		if best.SubmittedAt.IsZero() || row.SubmittedAt.After(best.SubmittedAt) {
 			best = row
 			found = true
 		}
 	}
 
 	return best, found
+}
+
+func applySubmissionMetadata(submission *SubmissionResult, match kaggle.CompetitionSubmission) error {
+	if submission == nil {
+		return fmt.Errorf("submission result is nil")
+	}
+
+	submissionID := strings.TrimSpace(match.Ref)
+	if submissionID == "" {
+		return fmt.Errorf("matched Kaggle submission is missing submission ID")
+	}
+	status := strings.TrimSpace(match.Status)
+	if status == "" {
+		return fmt.Errorf("matched Kaggle submission is missing status")
+	}
+	if match.SubmittedAt.IsZero() {
+		return fmt.Errorf("matched Kaggle submission is missing timestamp")
+	}
+
+	submission.SubmissionID = submissionID
+	submission.Status = status
+	submission.SubmittedAt = match.SubmittedAt
+	return nil
 }
 
 func effectivePollInterval(requested, fallback time.Duration) time.Duration {

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -251,6 +251,7 @@ targets:
 			return kaggle.CompetitionSubmissionsResponse{
 				Submissions: []kaggle.CompetitionSubmission{
 					{
+						Ref:         "123",
 						FileName:    "submission.csv",
 						Description: "kgh submit target=exp142 kernel=yourname/exp142",
 						Status:      "complete",
@@ -349,11 +350,23 @@ targets:
 	if report.Submission.FileName != "submission.csv" {
 		t.Fatalf("unexpected submission file name %q", report.Submission.FileName)
 	}
+	if report.Submission.SubmissionID != "123" {
+		t.Fatalf("unexpected submission ID %q", report.Submission.SubmissionID)
+	}
+	if report.Submission.Status != "complete" {
+		t.Fatalf("unexpected submission status %q", report.Submission.Status)
+	}
+	if !report.Submission.SubmittedAt.Equal(time.Date(2026, 4, 24, 12, 0, 1, 0, time.UTC)) {
+		t.Fatalf("unexpected submission timestamp %s", report.Submission.SubmittedAt)
+	}
 	if report.Score == nil {
 		t.Fatalf("expected score result, got %+v", report)
 	}
 	if report.Score.State != ScoreStateReady {
 		t.Fatalf("unexpected score state %+v", report.Score)
+	}
+	if report.Score.SubmissionID != "123" {
+		t.Fatalf("unexpected score submission ID %q", report.Score.SubmissionID)
 	}
 	if report.Score.PublicScore != "0.12345" || report.Score.Status != "complete" {
 		t.Fatalf("unexpected score result %+v", report.Score)
@@ -656,6 +669,7 @@ func TestRunnerExecuteLiveScorePendingWhenMatchedSubmissionHasNoScore(t *testing
 		listFn: func(_ context.Context, _ kaggle.CompetitionSubmissionsRequest) (kaggle.CompetitionSubmissionsResponse, error) {
 			return kaggle.CompetitionSubmissionsResponse{
 				Submissions: []kaggle.CompetitionSubmission{{
+					Ref:         "sub-1",
 					FileName:    "submission.csv",
 					Description: "kgh submit target=exp142 kernel=yourname/exp142",
 					Status:      "pending",
@@ -678,6 +692,9 @@ func TestRunnerExecuteLiveScorePendingWhenMatchedSubmissionHasNoScore(t *testing
 	}
 	if report.Score == nil || report.Score.State != ScoreStatePending {
 		t.Fatalf("expected pending score result, got %+v", report.Score)
+	}
+	if report.Submission == nil || report.Submission.SubmissionID != "sub-1" || report.Submission.Status != "pending" {
+		t.Fatalf("unexpected submission metadata %+v", report.Submission)
 	}
 	if report.Score.PublicScore != "" || report.Score.Status != "pending" {
 		t.Fatalf("unexpected pending score result %+v", report.Score)
@@ -730,11 +747,11 @@ func TestRunnerExecuteLiveScoreNotFoundWhenNoSubmissionMatchesCurrentRun(t *test
 		DryRun:     false,
 		ConfigPath: configPath,
 	})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	if err == nil {
+		t.Fatalf("expected an error, got report %+v", report)
 	}
-	if report.Score == nil || report.Score.State != ScoreStateNotFound {
-		t.Fatalf("expected not_found score result, got %+v", report.Score)
+	if got := err.Error(); !strings.Contains(got, "submission metadata unavailable: no matching Kaggle submission row found") {
+		t.Fatalf("unexpected error %q", got)
 	}
 }
 
@@ -818,6 +835,103 @@ func TestRunnerExecuteLiveListSubmissionsFailureReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "list kaggle competition submissions") {
 		t.Fatalf("unexpected error %q", err)
+	}
+}
+
+func TestRunnerExecuteLiveFailsWhenSubmissionMetadataMissingFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		row         kaggle.CompetitionSubmission
+		wantErrPart string
+	}{
+		{
+			name: "missing submission id",
+			row: kaggle.CompetitionSubmission{
+				FileName:    "submission.csv",
+				Description: "kgh submit target=exp142 kernel=yourname/exp142",
+				Status:      "complete",
+				PublicScore: "0.12345",
+				SubmittedAt: time.Date(2026, 4, 24, 12, 0, 1, 0, time.UTC),
+			},
+			wantErrPart: "matched Kaggle submission is missing submission ID",
+		},
+		{
+			name: "missing status",
+			row: kaggle.CompetitionSubmission{
+				Ref:         "sub-1",
+				FileName:    "submission.csv",
+				Description: "kgh submit target=exp142 kernel=yourname/exp142",
+				PublicScore: "0.12345",
+				SubmittedAt: time.Date(2026, 4, 24, 12, 0, 1, 0, time.UTC),
+			},
+			wantErrPart: "matched Kaggle submission is missing status",
+		},
+		{
+			name: "missing timestamp",
+			row: kaggle.CompetitionSubmission{
+				Ref:         "sub-1",
+				FileName:    "submission.csv",
+				Description: "kgh submit target=exp142 kernel=yourname/exp142",
+				Status:      "complete",
+				PublicScore: "0.12345",
+			},
+			wantErrPart: "matched Kaggle submission is missing timestamp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			configPath := writeLiveConfig(t, true)
+			adapter := &liveAdapter{
+				t: t,
+				pushFn: func(_ context.Context, _ kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error) {
+					return kaggle.PushKernelResponse{KernelRef: "yourname/exp142", Output: kaggle.Result{}}, nil
+				},
+				pollFn: func(_ context.Context, req kaggle.KernelPollRequest) (kaggle.KernelPollResult, error) {
+					return kaggle.KernelPollResult{
+						KernelStatusResponse: kaggle.KernelStatusResponse{KernelRef: req.KernelRef, Status: "complete"},
+						Attempts:             1,
+						StartedAt:            time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC),
+						FinishedAt:           time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC),
+						Elapsed:              0,
+						Terminal:             kaggle.KernelPollTerminalStateSucceeded,
+					}, nil
+				},
+				downloadFn: func(_ context.Context, req kaggle.DownloadKernelOutputRequest) (kaggle.DownloadKernelOutputResponse, error) {
+					if err := os.WriteFile(filepath.Join(req.OutputDir, "submission.csv"), []byte("id,label\n1,0\n"), 0o644); err != nil {
+						t.Fatalf("write submission output: %v", err)
+					}
+					return kaggle.DownloadKernelOutputResponse{OutputDir: req.OutputDir}, nil
+				},
+				submitFn: func(_ context.Context, req kaggle.CompetitionSubmitRequest) (kaggle.CompetitionSubmitResponse, error) {
+					return kaggle.CompetitionSubmitResponse{Competition: req.Competition, Submitted: true}, nil
+				},
+				listFn: func(_ context.Context, _ kaggle.CompetitionSubmissionsRequest) (kaggle.CompetitionSubmissionsResponse, error) {
+					return kaggle.CompetitionSubmissionsResponse{Submissions: []kaggle.CompetitionSubmission{tt.row}}, nil
+				},
+			}
+
+			runner := NewRunner(adapter)
+			runner.now = func() time.Time {
+				return time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+			}
+
+			_, err := runner.Execute(context.Background(), Request{
+				Target:     "exp142",
+				DryRun:     false,
+				ConfigPath: configPath,
+			})
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if got := err.Error(); !strings.Contains(got, tt.wantErrPart) {
+				t.Fatalf("unexpected error %q", got)
+			}
+		})
 	}
 }
 
@@ -934,12 +1048,14 @@ func TestFindRelevantSubmissionPrefersNewestMatchingRow(t *testing.T) {
 			SubmittedAt: time.Unix(50, 0),
 		},
 		{
+			Ref:         "sub-2",
 			Description: "kgh submit target=exp142 kernel=yourname/exp142",
 			FileName:    "submission.csv",
 			Status:      "pending",
 			SubmittedAt: time.Unix(10, 0),
 		},
 		{
+			Ref:         "sub-3",
 			Description: "kgh submit target=exp142 kernel=yourname/exp142",
 			FileName:    "submission.csv",
 			Status:      "complete",
@@ -947,6 +1063,7 @@ func TestFindRelevantSubmissionPrefersNewestMatchingRow(t *testing.T) {
 			SubmittedAt: time.Unix(20, 0),
 		},
 		{
+			Ref:         "sub-4",
 			Description: "kgh submit target=exp142 kernel=yourname/exp142",
 			FileName:    "submission.csv",
 			Status:      "complete",
@@ -963,37 +1080,39 @@ func TestFindRelevantSubmissionPrefersNewestMatchingRow(t *testing.T) {
 	if result.Status != "complete" {
 		t.Fatalf("unexpected submission status %q", result.Status)
 	}
+	if result.Ref != "sub-4" {
+		t.Fatalf("unexpected submission ref %q", result.Ref)
+	}
 	if !result.SubmittedAt.Equal(time.Unix(30, 0)) {
 		t.Fatalf("unexpected submission timestamp %s", result.SubmittedAt)
 	}
 }
 
-func TestResolveScoreResultReturnsNotFoundWhenNoMatchingSubmissionExists(t *testing.T) {
+func TestResolveScoreResultReturnsPendingWithoutPublicScore(t *testing.T) {
 	t.Parallel()
 
 	submission := &SubmissionResult{
-		Competition: "playground-series-s6e2",
-		FileName:    "submission.csv",
-		Message:     "kgh submit target=exp142 kernel=yourname/exp142",
-		AttemptedAt: time.Unix(5, 0),
+		Competition:  "playground-series-s6e2",
+		FileName:     "submission.csv",
+		Message:      "kgh submit target=exp142 kernel=yourname/exp142",
+		AttemptedAt:  time.Unix(5, 0),
+		SubmissionID: "sub-5",
 	}
 
-	result := resolveScoreResult("playground-series-s6e2", submission, []kaggle.CompetitionSubmission{
-		{
-			Description: "different submission",
-			FileName:    "submission.csv",
-			Status:      "complete",
-			PublicScore: "0.12345",
-			SubmittedAt: time.Unix(20, 0),
-		},
+	result := resolveScoreResult("playground-series-s6e2", submission, kaggle.CompetitionSubmission{
+		Ref:         "sub-5",
+		FileName:    "submission.csv",
+		Description: "kgh submit target=exp142 kernel=yourname/exp142",
+		Status:      "pending",
+		SubmittedAt: time.Unix(20, 0),
 	})
 	if result == nil {
 		t.Fatal("expected a score result")
 	}
-	if result.State != ScoreStateNotFound {
-		t.Fatalf("expected not_found score state, got %+v", result)
+	if result.State != ScoreStatePending {
+		t.Fatalf("expected pending score state, got %+v", result)
 	}
-	if result.PublicScore != "" || result.Status != "" {
+	if result.SubmissionID != "sub-5" || result.PublicScore != "" || result.Status != "pending" {
 		t.Fatalf("unexpected score result %+v", result)
 	}
 }

--- a/internal/kaggle/adapter.go
+++ b/internal/kaggle/adapter.go
@@ -88,6 +88,7 @@ type CompetitionSubmissionsResponse struct {
 }
 
 type CompetitionSubmission struct {
+	Ref         string
 	FileName    string
 	Description string
 	Status      string
@@ -292,7 +293,7 @@ func buildCompetitionSubmissionsCommand(req CompetitionSubmissionsRequest) ([]st
 	if req.Limit != 0 {
 		return nil, unsupportedRequest("competition submissions limit")
 	}
-	return []string{"competitions", "submissions", "-c", competition}, nil
+	return []string{"competitions", "submissions", "-c", competition, "-v"}, nil
 }
 
 func requiredValue(field string, value string) (string, error) {
@@ -340,7 +341,7 @@ func parseCompetitionSubmissionsResult(result Result) (CompetitionSubmissionsRes
 		return CompetitionSubmissionsResponse{}, nil
 	}
 	header := normalizeHeader(rows[0])
-	required := []string{"file", "description", "date", "status", "publicscore"}
+	required := []string{"ref", "file", "description", "date", "status", "publicscore"}
 	for _, name := range required {
 		if _, ok := header[name]; !ok {
 			return CompetitionSubmissionsResponse{}, unexpectedOutputError("list competition submissions", result, "missing submissions header")
@@ -353,6 +354,7 @@ func parseCompetitionSubmissionsResult(result Result) (CompetitionSubmissionsRes
 			continue
 		}
 		submission := CompetitionSubmission{
+			Ref:         valueAt(row, header, "ref"),
 			FileName:    valueAt(row, header, "file"),
 			Description: valueAt(row, header, "description"),
 			Status:      valueAt(row, header, "status"),

--- a/internal/kaggle/adapter_test.go
+++ b/internal/kaggle/adapter_test.go
@@ -359,11 +359,11 @@ func TestCLIAdapterListCompetitionSubmissions(t *testing.T) {
 	fake := &adapterFakeClient{
 		t: t,
 		runFn: func(_ context.Context, args []string, opts RunOptions) (Result, error) {
-			if !equalStrings(args, []string{"competitions", "submissions", "-c", "playground-series-s6e2"}) {
+			if !equalStrings(args, []string{"competitions", "submissions", "-c", "playground-series-s6e2", "-v"}) {
 				t.Fatalf("unexpected args %#v", args)
 			}
 			assertZeroRunOptions(t, opts)
-			return Result{Stdout: "file,description,date,status,publicScore\nsubmission.csv,submit from PR #12,2026-04-14T10:00:00Z,complete,0.12345\n"}, nil
+			return Result{Stdout: "ref,file,description,date,status,publicScore\n123,submission.csv,submit from PR #12,2026-04-14T10:00:00Z,complete,0.12345\n"}, nil
 		},
 	}
 
@@ -376,7 +376,7 @@ func TestCLIAdapterListCompetitionSubmissions(t *testing.T) {
 	if len(resp.Submissions) != 1 {
 		t.Fatalf("expected one submission, got %+v", resp.Submissions)
 	}
-	if resp.Submissions[0].FileName != "submission.csv" || resp.Submissions[0].PublicScore != "0.12345" {
+	if resp.Submissions[0].Ref != "123" || resp.Submissions[0].FileName != "submission.csv" || resp.Submissions[0].PublicScore != "0.12345" {
 		t.Fatalf("unexpected submission %+v", resp.Submissions[0])
 	}
 }
@@ -456,7 +456,7 @@ func TestCLIAdapterForwardsDebugFlag(t *testing.T) {
 				})
 				return err
 			},
-			want: []string{"competitions", "submissions", "-c", "playground-series-s6e2"},
+			want: []string{"competitions", "submissions", "-c", "playground-series-s6e2", "-v"},
 		},
 	}
 
@@ -480,7 +480,7 @@ func TestCLIAdapterForwardsDebugFlag(t *testing.T) {
 					case "push kernel":
 						return Result{Stdout: "Kernel URL: https://www.kaggle.com/code/alice/exp142\nKernel pushed successfully\n"}, nil
 					case "list competition submissions":
-						return Result{Stdout: "file,description,date,status,publicScore\nsubmission.csv,submit from PR #12,2026-04-14T10:00:00Z,complete,0.12345\n"}, nil
+						return Result{Stdout: "ref,file,description,date,status,publicScore\n123,submission.csv,submit from PR #12,2026-04-14T10:00:00Z,complete,0.12345\n"}, nil
 					default:
 						return Result{}, nil
 					}
@@ -626,7 +626,7 @@ func TestCLIAdapterReportsMalformedSubmissionDate(t *testing.T) {
 		t: t,
 		runFn: func(_ context.Context, _ []string, _ RunOptions) (Result, error) {
 			return Result{
-				Stdout: "file,description,date,status,publicScore\nsubmission.csv,submit,not-a-date,complete,0.12345\n",
+				Stdout: "ref,file,description,date,status,publicScore\n123,submission.csv,submit,not-a-date,complete,0.12345\n",
 			}, nil
 		},
 	}
@@ -938,7 +938,7 @@ func TestBuildCompetitionSubmissionsCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if !equalStrings(got, []string{"competitions", "submissions", "-c", "playground-series-s6e2"}) {
+	if !equalStrings(got, []string{"competitions", "submissions", "-c", "playground-series-s6e2", "-v"}) {
 		t.Fatalf("unexpected args %#v", got)
 	}
 }


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #79 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
The live execution report now hydrates Kaggle submission metadata into the existing submission and score objects, including submission_id, status, and submitted_at, and it fails clearly if the post-submit lookup cannot produce that metadata. The Kaggle adapter now requests CSV explicitly for submissions listing and parses the submission ref field as the source of submission_id. 

I also updated the local run docs to note the new report fields. Key changes are in internal/execution/execution.go, internal/kaggle/adapter.go, and the corresponding tests in internal/execution/execution_test.go and internal/kaggle/adapter_test.go. Docs update is in doc/local-run.md.

<!-- close -->