### PR TITLE
Release Wording Correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v0.0.9](https://github.com/morshoto/kgh/compare/v0.0.8...v0.0.9) - 2026-05-03
+- build(deps): bump actions/checkout from 4 to 6 by @dependabot[bot] in https://github.com/morshoto/kgh/pull/83
+- Integrate Kaggle score retrieval into live execution result payloads by @morshoto in https://github.com/morshoto/kgh/pull/87
+- Nix flake for kgh  by @morshoto in https://github.com/morshoto/kgh/pull/88
+- Retrieve and model Kaggle public score in live execution results by @morshoto in https://github.com/morshoto/kgh/pull/76
+- Return Kaggle submission metadata in live execution results by @morshoto in https://github.com/morshoto/kgh/pull/89
+- Kaggle submission row lookup after live submit by @morshoto in https://github.com/morshoto/kgh/pull/92
+
 ## [v0.0.8](https://github.com/morshoto/kgh/compare/v0.0.7...v0.0.8) - 2026-05-02
 - kaggle submission validation by @morshoto in https://github.com/morshoto/kgh/pull/60
 - chore: refine dependabot ecosystems by @morshoto in https://github.com/morshoto/kgh/pull/70

--- a/doc/local-run.md
+++ b/doc/local-run.md
@@ -57,7 +57,7 @@ kgh run --target exp142 --poll-interval=2s --timeout=5m
 
 Dry-run returns the resolved execution contract as JSON.
 
-Live mode returns a richer JSON report that can include:
+Live mode returns a richer JSON report payload that can include:
 
 - resolved execution metadata
 - staged bundle information
@@ -66,5 +66,6 @@ Live mode returns a richer JSON report that can include:
 - downloaded output paths
 - submission result when `submit: true`
 
-When `submit: true` succeeds, the live JSON includes structured submission metadata under
-`submission` and `score`, including `submission_id`, `status`, and `submitted_at`.
+When `submit: true` succeeds, the live JSON/report payload includes structured submission
+metadata under `submission` and `score`, including `submission_id`, `status`, and
+`submitted_at`.


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #91 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Updated CHANGELOG.md:1 and doc/local-run.md:57 so v0.0.9 is described as live execution result/report payload support, not GitHub Summary or PR comment reporting. The changelog now uses payload-scoped wording like “Integrate Kaggle score retrieval into live execution result payloads” and “Return Kaggle submission metadata in live execution results.” I did not change any CLI/API/workflow behavior, and doc/prd_v1.md:1 remains untouched. Verification was a diff- only check; no tests were needed for these wording changes. One caveat: if the tagpr-from-v0.0.8 release PR is already open, its branch currently has its own generated CHANGELOG.md, so that PR branch will need the same wording sync before merge.

<!-- close -->