### PR TITLE
cmd: emit GitHub summaries for github run

### DIFF
--- a/cmd/kgh/main.go
+++ b/cmd/kgh/main.go
@@ -18,6 +18,22 @@ import (
 
 var version = "dev"
 
+type executionRunner interface {
+	Execute(context.Context, execution.Request) (execution.Result, error)
+}
+
+var newRunner = func(adapter execution.Adapter) executionRunner {
+	return execution.NewRunner(adapter)
+}
+
+type githubExecutionSummaryWriter interface {
+	WriteExecutionSummary(execution.Result) error
+}
+
+var newGitHubSummaryWriter = func() githubExecutionSummaryWriter {
+	return ghctx.NewSummaryWriter()
+}
+
 func main() {
 	os.Exit(run(os.Args[1:]))
 }
@@ -91,7 +107,7 @@ func runCommand(ctx context.Context, args []string, stdout, stderr io.Writer) (i
 		ConfigPath:   execution.DefaultConfigPath,
 		PollInterval: flags.pollInterval,
 		PollTimeout:  flags.timeout,
-	}, stdout)
+	}, stdout, stderr, false)
 }
 
 func githubCommand(ctx context.Context, args []string, stdout, stderr io.Writer) (int, error) {
@@ -119,11 +135,11 @@ func githubCommand(ctx context.Context, args []string, stdout, stderr io.Writer)
 		return 1, err
 	}
 
-	return executeRequest(ctx, requestFromTrigger(trigger, flags.sharedRunFlags), stdout)
+	return executeRequest(ctx, requestFromTrigger(trigger, flags.sharedRunFlags), stdout, stderr, true)
 }
 
-func executeRequest(ctx context.Context, req execution.Request, stdout io.Writer) (int, error) {
-	runner := execution.NewRunner(nil)
+func executeRequest(ctx context.Context, req execution.Request, stdout, stderr io.Writer, writeSummary bool) (int, error) {
+	runner := newRunner(nil)
 	report, err := runner.Execute(ctx, req)
 	if err != nil {
 		return 1, err
@@ -136,6 +152,11 @@ func executeRequest(ctx context.Context, req execution.Request, stdout io.Writer
 
 	if _, err := stdout.Write(append(payload, '\n')); err != nil {
 		return 1, err
+	}
+	if writeSummary {
+		if err := newGitHubSummaryWriter().WriteExecutionSummary(report); err != nil && stderr != nil {
+			fmt.Fprintf(stderr, "write GitHub summary: %v\n", err)
+		}
 	}
 	return 0, nil
 }

--- a/cmd/kgh/main_test.go
+++ b/cmd/kgh/main_test.go
@@ -2,318 +2,154 @@ package main
 
 import (
 	"bytes"
-	"fmt"
+	"context"
+	"errors"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
+
+	"github.com/shotomorisk/kgh/internal/execution"
+	"github.com/shotomorisk/kgh/internal/spec"
 )
 
-func TestRun_Help(t *testing.T) {
-	if code := run([]string{"help"}); code != 0 {
-		t.Fatalf("expected exit code 0, got %d", code)
-	}
+type fakeExecutionRunner struct {
+	result execution.Result
+	err    error
 }
 
-func TestRun_StripsCommandNamePrefix(t *testing.T) {
-	if code := run([]string{"kgh", "help"}); code != 0 {
-		t.Fatalf("expected exit code 0, got %d", code)
-	}
+type fakeSummaryWriter struct {
+	err error
 }
 
-func TestRunHelpMentionsRun(t *testing.T) {
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-
-	if code := runWithIO([]string{"help"}, stdout, stderr); code != 0 {
-		t.Fatalf("expected exit code 0, got %d stderr=%s", code, stderr.String())
-	}
-	if !strings.Contains(stdout.String(), "run       Resolve and execute a Kaggle target") {
-		t.Fatalf("expected run command in help output, got %s", stdout.String())
-	}
-	if !strings.Contains(stdout.String(), "github    Resolve and execute from GitHub commit metadata") {
-		t.Fatalf("expected github command in help output, got %s", stdout.String())
-	}
+func (f fakeExecutionRunner) Execute(context.Context, execution.Request) (execution.Result, error) {
+	return f.result, f.err
 }
 
-func TestRun_UnknownCommand(t *testing.T) {
-	if code := run([]string{"wat"}); code != 1 {
-		t.Fatalf("expected exit code 1, got %d", code)
-	}
+func (f fakeSummaryWriter) WriteExecutionSummary(execution.Result) error {
+	return f.err
 }
 
-func TestParseRunFlagsRequiresTarget(t *testing.T) {
-	t.Parallel()
-
-	if _, err := parseRunFlags([]string{"--dry-run"}); err == nil || !strings.Contains(err.Error(), "--target is required") {
-		t.Fatalf("expected target validation error, got %v", err)
-	}
-}
-
-func TestParseRunFlagsValidatesOverrides(t *testing.T) {
-	t.Parallel()
-
-	if _, err := parseRunFlags([]string{"--target", "exp142", "--gpu", "maybe"}); err == nil || !strings.Contains(err.Error(), "invalid value for --gpu") {
-		t.Fatalf("expected gpu validation error, got %v", err)
-	}
-}
-
-func TestParseRunFlagsAcceptsPollingDurations(t *testing.T) {
-	t.Parallel()
-
-	flags, err := parseRunFlags([]string{"--target", "exp142", "--poll-interval", "2s", "--timeout", "5m"})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if flags.pollInterval != 2*time.Second {
-		t.Fatalf("unexpected poll interval %s", flags.pollInterval)
-	}
-	if flags.timeout != 5*time.Minute {
-		t.Fatalf("unexpected timeout %s", flags.timeout)
-	}
-}
-
-func TestParseGitHubRunFlagsAcceptsPollingDurations(t *testing.T) {
-	t.Parallel()
-
-	flags, err := parseGitHubRunFlags([]string{"--poll-interval", "2s", "--timeout", "5m"})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if flags.pollInterval != 2*time.Second {
-		t.Fatalf("unexpected poll interval %s", flags.pollInterval)
-	}
-	if flags.timeout != 5*time.Minute {
-		t.Fatalf("unexpected timeout %s", flags.timeout)
-	}
-}
-
-func TestParseRunFlagsRejectsNegativePollingDurations(t *testing.T) {
-	t.Parallel()
-
-	if _, err := parseRunFlags([]string{"--target", "exp142", "--poll-interval", "-1s"}); err == nil || !strings.Contains(err.Error(), "--poll-interval must be greater than or equal to 0") {
-		t.Fatalf("expected poll interval validation error, got %v", err)
-	}
-	if _, err := parseRunFlags([]string{"--target", "exp142", "--timeout", "-1s"}); err == nil || !strings.Contains(err.Error(), "--timeout must be greater than or equal to 0") {
-		t.Fatalf("expected timeout validation error, got %v", err)
-	}
-	if _, err := parseGitHubRunFlags([]string{"--poll-interval", "-1s"}); err == nil || !strings.Contains(err.Error(), "--poll-interval must be greater than or equal to 0") {
-		t.Fatalf("expected github poll interval validation error, got %v", err)
-	}
-	if _, err := parseGitHubRunFlags([]string{"--timeout", "-1s"}); err == nil || !strings.Contains(err.Error(), "--timeout must be greater than or equal to 0") {
-		t.Fatalf("expected github timeout validation error, got %v", err)
-	}
-}
-
-func TestRunDryRunOutputsJSON(t *testing.T) {
-	dir := t.TempDir()
-	configDir := filepath.Join(dir, ".kgh")
-	if err := os.MkdirAll(configDir, 0o755); err != nil {
-		t.Fatalf("mkdir config dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(`
-targets:
-  exp142:
-    notebook: notebooks/exp142.ipynb
-    kernel_id: yourname/exp142
-    competition: playground-series-s6e2
-    submit: true
-    resources:
-      gpu: true
-      internet: false
-      private: true
-    outputs:
-      submission: submission.csv
-      metrics: metrics.json
-`), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-
-	oldwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("get wd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+func TestExecuteRequestWritesJSONAndGitHubSummary(t *testing.T) {
+	originalNewRunner := newRunner
 	t.Cleanup(func() {
-		_ = os.Chdir(oldwd)
+		newRunner = originalNewRunner
 	})
 
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	if code := runWithIO([]string{"run", "--target", "exp142"}, stdout, stderr); code != 0 {
-		t.Fatalf("expected exit code 0, got %d stderr=%s", code, stderr.String())
+	newRunner = func(execution.Adapter) executionRunner {
+		return fakeExecutionRunner{
+			result: execution.Result{
+				Mode: execution.ModeDryRun,
+				Execution: spec.ExecutionSpec{
+					TargetName: "exp142",
+					Notebook:   "notebooks/exp142.ipynb",
+					KernelID:   "yourname/exp142",
+					KernelRef:  "yourname/exp142",
+				},
+			},
+		}
 	}
 
-	if got := stdout.String(); !strings.Contains(got, `"mode": "dry-run"`) {
-		t.Fatalf("expected dry-run JSON, got %s", got)
+	dir := t.TempDir()
+	summaryPath := filepath.Join(dir, "summary.md")
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code, err := executeRequest(context.Background(), execution.Request{Target: "exp142", DryRun: true}, &stdout, &stderr, true)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
 	}
 	if !strings.Contains(stdout.String(), `"target_name": "exp142"`) {
-		t.Fatalf("expected target name in output, got %s", stdout.String())
+		t.Fatalf("expected stdout JSON target, got %s", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), `"poll_interval": "5s"`) {
-		t.Fatalf("expected default poll interval in output, got %s", stdout.String())
-	}
-	if !strings.Contains(stdout.String(), `"poll_timeout": "30m0s"`) {
-		t.Fatalf("expected default poll timeout in output, got %s", stdout.String())
-	}
-	if !strings.Contains(stdout.String(), `"gpu": true`) {
-		t.Fatalf("expected snake_case resources in output, got %s", stdout.String())
-	}
-	if !strings.Contains(stdout.String(), `"competition_sources": []`) {
-		t.Fatalf("expected empty sources arrays in output, got %s", stdout.String())
-	}
-	if !strings.Contains(stdout.String(), `"overrides": {}`) {
-		t.Fatalf("expected empty overrides object in output, got %s", stdout.String())
-	}
-	if stderr.Len() != 0 {
-		t.Fatalf("expected no stderr, got %s", stderr.String())
-	}
-}
 
-func TestGitHubRunHelp(t *testing.T) {
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-
-	if code := runWithIO([]string{"github", "help"}, stdout, stderr); code != 0 {
-		t.Fatalf("expected exit code 0, got %d stderr=%s", code, stderr.String())
-	}
-	if !strings.Contains(stdout.String(), "kgh github resolves trigger intent from GitHub commit metadata.") {
-		t.Fatalf("unexpected help output %s", stdout.String())
-	}
-}
-
-func TestGitHubRunDryRunOutputsJSON(t *testing.T) {
-	dir := t.TempDir()
-	writeConfigFixture(t, dir)
-
-	gitRun(t, dir, "init")
-	gitRun(t, dir, "config", "user.name", "Test User")
-	gitRun(t, dir, "config", "user.email", "test@example.com")
-	gitRun(t, dir, "add", ".")
-	gitRun(t, dir, "commit", "-m", "feat: wire ci\n\nsubmit: exp142 gpu=false")
-	sha := strings.TrimSpace(gitRun(t, dir, "rev-parse", "HEAD"))
-
-	oldwd, err := os.Getwd()
+	body, err := os.ReadFile(summaryPath)
 	if err != nil {
-		t.Fatalf("get wd: %v", err)
+		t.Fatalf("read summary file: %v", err)
 	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
+	if !strings.Contains(string(body), "| Target | `exp142` |") {
+		t.Fatalf("unexpected summary body:\n%s", string(body))
 	}
+}
+
+func TestExecuteRequestSummaryWriteFailureIsNonFatal(t *testing.T) {
+	originalNewRunner := newRunner
+	originalSummaryWriter := newGitHubSummaryWriter
 	t.Cleanup(func() {
-		_ = os.Chdir(oldwd)
+		newRunner = originalNewRunner
+		newGitHubSummaryWriter = originalSummaryWriter
 	})
 
-	t.Setenv("GITHUB_EVENT_NAME", "push")
-	t.Setenv("GITHUB_SHA", sha)
-	t.Setenv("GITHUB_WORKSPACE", dir)
-
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	if code := runWithIO([]string{"github", "run"}, stdout, stderr); code != 0 {
-		t.Fatalf("expected exit code 0, got %d stderr=%s", code, stderr.String())
+	newRunner = func(execution.Adapter) executionRunner {
+		return fakeExecutionRunner{
+			result: execution.Result{
+				Mode:      execution.ModeDryRun,
+				Execution: spec.ExecutionSpec{TargetName: "exp142"},
+			},
+		}
+	}
+	newGitHubSummaryWriter = func() githubExecutionSummaryWriter {
+		return fakeSummaryWriter{err: errors.New("disk full")}
 	}
 
-	if got := stdout.String(); !strings.Contains(got, `"target_name": "exp142"`) {
-		t.Fatalf("expected target name in output, got %s", got)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code, err := executeRequest(context.Background(), execution.Request{Target: "exp142", DryRun: true}, &stdout, &stderr, true)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
-	if !strings.Contains(stdout.String(), `"gpu": false`) {
-		t.Fatalf("expected overridden gpu in output, got %s", stdout.String())
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
 	}
-	if !strings.Contains(stdout.String(), `"overrides": {`) {
-		t.Fatalf("expected overrides in output, got %s", stdout.String())
+	if !strings.Contains(stderr.String(), "write GitHub summary: disk full") {
+		t.Fatalf("expected summary warning on stderr, got %q", stderr.String())
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("expected no stderr, got %s", stderr.String())
+	if stdout.Len() == 0 {
+		t.Fatal("expected stdout JSON to still be written")
 	}
 }
 
-func TestGitHubRunPullRequestUsesHeadSHA(t *testing.T) {
-	dir := t.TempDir()
-	writeConfigFixture(t, dir)
-
-	gitRun(t, dir, "init")
-	gitRun(t, dir, "config", "user.name", "Test User")
-	gitRun(t, dir, "config", "user.email", "test@example.com")
-	gitRun(t, dir, "add", ".")
-	gitRun(t, dir, "commit", "-m", "feat: first trigger\n\nsubmit: exp142")
-	firstSHA := strings.TrimSpace(gitRun(t, dir, "rev-parse", "HEAD"))
-
-	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("changed\n"), 0o644); err != nil {
-		t.Fatalf("write readme: %v", err)
-	}
-	gitRun(t, dir, "add", "README.md")
-	gitRun(t, dir, "commit", "-m", "feat: second trigger\n\nsubmit: exp142 internet=true")
-
-	eventPath := filepath.Join(dir, "event.json")
-	eventPayload := fmt.Sprintf(`{"pull_request":{"head":{"sha":%q}}}`, firstSHA)
-	if err := os.WriteFile(eventPath, []byte(eventPayload), 0o644); err != nil {
-		t.Fatalf("write event payload: %v", err)
-	}
-
-	oldwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("get wd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+func TestExecuteRequestSkipsSummaryWhenDisabled(t *testing.T) {
+	originalNewRunner := newRunner
+	originalSummaryWriter := newGitHubSummaryWriter
 	t.Cleanup(func() {
-		_ = os.Chdir(oldwd)
+		newRunner = originalNewRunner
+		newGitHubSummaryWriter = originalSummaryWriter
 	})
 
-	t.Setenv("GITHUB_EVENT_NAME", "pull_request")
-	t.Setenv("GITHUB_EVENT_PATH", eventPath)
-	t.Setenv("GITHUB_WORKSPACE", dir)
-
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	if code := runWithIO([]string{"github", "run"}, stdout, stderr); code != 0 {
-		t.Fatalf("expected exit code 0, got %d stderr=%s", code, stderr.String())
+	newRunner = func(execution.Adapter) executionRunner {
+		return fakeExecutionRunner{
+			result: execution.Result{
+				Mode:      execution.ModeDryRun,
+				Execution: spec.ExecutionSpec{TargetName: "exp142"},
+			},
+		}
 	}
-	if !strings.Contains(stdout.String(), `"overrides": {}`) {
-		t.Fatalf("expected head sha commit with no overrides, got %s", stdout.String())
+	newGitHubSummaryWriter = func() githubExecutionSummaryWriter {
+		return fakeSummaryWriter{err: errors.New("should not be called")}
 	}
-}
 
-func writeConfigFixture(t *testing.T, dir string) {
-	t.Helper()
+	dir := t.TempDir()
+	summaryPath := filepath.Join(dir, "summary.md")
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
 
-	configDir := filepath.Join(dir, ".kgh")
-	if err := os.MkdirAll(configDir, 0o755); err != nil {
-		t.Fatalf("mkdir config dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(`
-targets:
-  exp142:
-    notebook: notebooks/exp142.ipynb
-    kernel_id: yourname/exp142
-    competition: playground-series-s6e2
-    submit: true
-    resources:
-      gpu: true
-      internet: false
-      private: true
-    outputs:
-      submission: submission.csv
-      metrics: metrics.json
-`), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-}
-
-func gitRun(t *testing.T, dir string, args ...string) string {
-	t.Helper()
-
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	output, err := cmd.CombinedOutput()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code, err := executeRequest(context.Background(), execution.Request{Target: "exp142", DryRun: true}, &stdout, &stderr, false)
 	if err != nil {
-		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, string(output))
+		t.Fatalf("expected no error, got %v", err)
 	}
-	return string(output)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if _, err := os.Stat(summaryPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no summary file, stat err=%v", err)
+	}
 }

--- a/doc/issue-94-plan.md
+++ b/doc/issue-94-plan.md
@@ -1,0 +1,161 @@
+# Issue #94 Plan: Add a GitHub Summary renderer in Go
+
+- Repository: `morshoto/kgh`
+- Issue: `#94`
+- URL: <https://github.com/morshoto/kgh/issues/94>
+- State: `OPEN`
+- Labels: `Feedback: Feature Request`, `Type: New Feature`
+- Assignee: `morshoto`
+- Milestone: `Release for v0.0.10`
+- Planning branch: `feat/94-github-summary-renderer`
+
+## Summary
+
+Add a small reporting unit that renders `internal/execution.Result` into stable Markdown for GitHub Actions job summaries. The renderer should cover milestone 10 reporting fields without expanding the execution model unless a required field truly cannot be derived from the current result shape.
+
+The current codebase already has the right source-of-truth object in `internal/execution.Result`, and the GitHub workflow already writes directly to `$GITHUB_STEP_SUMMARY` in `.github/workflows/commit-trigger.yml`. The missing piece is a first-class renderer and a controlled integration path from the `github run` command.
+
+## Goal
+
+- Produce a concise, deterministic Markdown summary for GitHub Actions based on `execution.Result`.
+- Cover the issue-required fields:
+  - target name
+  - notebook path
+  - kernel id
+  - Kaggle run status
+  - submit status
+  - public score
+  - useful identifiers or references
+- Represent missing or skipped values explicitly as `not run`, `not submitted`, `pending`, or `unavailable`.
+
+## Non-goals
+
+- Redesign the JSON CLI output contract from `kgh run` or `kgh github run`.
+- Add new execution fields if the current `execution.Result` already exposes enough information.
+- Build a generic rich reporting framework for non-GitHub consumers.
+- Change the workflow trigger semantics or Kaggle lifecycle behavior.
+
+## Current Code Seams
+
+- `internal/execution.Result` already contains the execution spec, bundle result, push result, poll result, submission result, and score result needed for the summary.
+- `cmd/kgh/main.go` centralizes execution through `executeRequest`, which is the natural place to hook summary generation without duplicating execution logic.
+- `internal/github` currently resolves GitHub trigger metadata only. It is a plausible home for GitHub-specific summary writing if the write-to-file concern should stay GitHub-scoped.
+- `.github/workflows/commit-trigger.yml` already appends ad hoc text to `$GITHUB_STEP_SUMMARY`, so the new renderer should complement or replace part of that handwritten output.
+
+## Proposed Approach
+
+1. Add a renderer with a narrow API, for example:
+
+```go
+package reporting
+
+func RenderGitHubSummary(result execution.Result) string
+```
+
+or, if the write concern should remain GitHub-specific:
+
+```go
+package github
+
+type SummaryWriter struct {
+	Getenv func(string) string
+	Append func(path string, body []byte) error
+}
+```
+
+2. Keep rendering logic pure and deterministic.
+   Derive display values from `execution.Result` only, and isolate any file-writing side effect behind a thin wrapper.
+
+3. Integrate summary emission into the `github run` path only.
+   `kgh github run` is the issue-specific execution path for GitHub Actions. That keeps local CLI behavior unchanged unless there is a deliberate follow-up requirement to expose the same summary elsewhere.
+
+4. Preserve machine-readable stdout.
+   Continue printing the JSON result to stdout. Write the Markdown summary separately to `$GITHUB_STEP_SUMMARY` when that environment variable is present.
+
+5. Normalize status text.
+   Define clear mapping rules for dry-run, skipped submission, missing score, pending score, failed or incomplete poll states, and absent kernel refs.
+
+## Field Mapping
+
+- Target name: `result.Execution.Target`
+- Notebook path: `result.Bundle.NotebookPath`, else `result.Execution.NotebookPath`, else `unavailable`
+- Kernel id: `result.Execution.KernelID` or `result.Push.KernelRef`, else `not run`
+- Kaggle run status:
+  - dry run: `not run`
+  - live with poll result: derive from `result.Poll.Status` and terminal state
+  - live without poll result but with push: `pending` or `unavailable`, depending on reachable state
+- Submit status:
+  - no submission step: `not submitted`
+  - attempted but not submitted: use `result.Submission.Message` or `not submitted`
+  - submitted: use `result.Submission.Status` when present
+- Public score:
+  - `result.Score.PublicScore` when available
+  - `pending` when `result.Score.State == "pending"`
+  - `unavailable` or `not submitted` for the remaining explicit states
+- Useful identifiers or references:
+  - kernel ref
+  - competition slug
+  - submission id
+  - output paths when they help operators debug workflow runs
+
+## Tasks
+
+1. Add the summary renderer package and define the public API.
+2. Implement deterministic Markdown rendering for all required fields and explicit fallback states.
+3. Add unit tests for rendering across dry-run, successful live run, pending score, missing submission, and partial-result cases.
+4. Add a small GitHub-specific writer that appends the rendered Markdown to `$GITHUB_STEP_SUMMARY` only when the variable is set.
+5. Integrate the writer into `kgh github run` without changing `kgh run` behavior.
+6. Decide whether the existing handcrafted workflow summary blocks in `.github/workflows/commit-trigger.yml` should remain as preflight messaging only, or whether some should be removed to avoid duplication.
+7. Update docs if the workflow-visible behavior changes materially.
+
+## Acceptance Criteria
+
+- `kgh github run` writes a Markdown summary to `$GITHUB_STEP_SUMMARY` when running inside GitHub Actions.
+- The summary includes every field called out in issue `#94`.
+- Missing or skipped values are rendered explicitly and never as blank cells or omitted critical rows.
+- The renderer uses `execution.Result` as the source of truth and does not introduce unnecessary new execution fields.
+- Existing JSON stdout behavior remains intact.
+
+## Testing Plan
+
+- Renderer unit tests:
+  - dry-run result
+  - live success with kernel ref, submission id, and public score
+  - live success with score pending
+  - execution with submission disabled or not attempted
+  - partial or missing nested structs
+- Writer unit tests:
+  - writes only when `GITHUB_STEP_SUMMARY` is set
+  - appends expected Markdown to the configured path
+- Command integration tests:
+  - `github run` still emits JSON
+  - summary write does not break command success paths
+  - summary write failure behavior is defined and tested
+
+## Risks And Open Questions
+
+- Package placement:
+  `internal/github` fits the sink and workflow context, while a dedicated reporting package better separates pure rendering from GitHub-specific file writing.
+- Status wording:
+  The issue asks for stable explicit states, so the exact normalization rules should be settled early to avoid churn in tests and workflow output.
+- Failure policy:
+  It is still an open decision whether summary write failures should fail the command or only log to stderr. For GitHub Actions observability, failing soft is usually safer unless the summary is considered a release-blocking artifact.
+- Duplication with workflow shell output:
+  The workflow currently writes pre-execution and mode notes directly. The final implementation should avoid repeated or contradictory status text.
+
+## Rollout Notes
+
+- Scope the first integration to `kgh github run`.
+- Keep existing workflow preflight summary messages until the renderer-based output is verified in CI.
+- After the renderer lands, simplify workflow shell-written summary blocks if they overlap with the generated report.
+
+## Implementation Order
+
+1. Implement the pure Markdown renderer and unit tests.
+2. Implement the GitHub summary writer wrapper and unit tests.
+3. Wire summary generation into `cmd/kgh/main.go` for `github run`.
+4. Adjust the workflow only if duplication becomes noisy.
+
+## Issue Excerpt
+
+The issue asks for a small renderer that converts `execution.Result` into GitHub Actions Summary Markdown and covers target, notebook path, kernel id, Kaggle run status, submit status, public score, and helpful identifiers, with explicit fallback states instead of blanks.

--- a/internal/github/summary.go
+++ b/internal/github/summary.go
@@ -1,0 +1,51 @@
+package github
+
+import (
+	"os"
+
+	"github.com/shotomorisk/kgh/internal/execution"
+	"github.com/shotomorisk/kgh/internal/reporting"
+)
+
+// SummaryWriter appends execution summaries to the GitHub step summary file.
+type SummaryWriter struct {
+	Getenv     func(string) string
+	AppendFile func(path string, body []byte) error
+}
+
+func NewSummaryWriter() SummaryWriter {
+	return SummaryWriter{
+		Getenv:     os.Getenv,
+		AppendFile: appendFile,
+	}
+}
+
+func (w SummaryWriter) Write(result execution.Result) error {
+	if w.Getenv == nil {
+		w.Getenv = os.Getenv
+	}
+	if w.AppendFile == nil {
+		w.AppendFile = appendFile
+	}
+
+	path := w.Getenv("GITHUB_STEP_SUMMARY")
+	if path == "" {
+		return nil
+	}
+	return w.AppendFile(path, []byte(reporting.RenderGitHubSummary(result)))
+}
+
+func (w SummaryWriter) WriteExecutionSummary(result execution.Result) error {
+	return w.Write(result)
+}
+
+func appendFile(path string, body []byte) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Write(body)
+	return err
+}

--- a/internal/github/summary_test.go
+++ b/internal/github/summary_test.go
@@ -1,0 +1,93 @@
+package github
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shotomorisk/kgh/internal/execution"
+	"github.com/shotomorisk/kgh/internal/spec"
+)
+
+func TestSummaryWriterNoopWithoutEnv(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	writer := SummaryWriter{
+		Getenv: func(string) string { return "" },
+		AppendFile: func(string, []byte) error {
+			called = true
+			return nil
+		},
+	}
+
+	if err := writer.WriteExecutionSummary(execution.Result{}); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if called {
+		t.Fatal("expected append not to be called")
+	}
+}
+
+func TestSummaryWriterAppendsRenderedMarkdown(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "summary.md")
+	if err := os.WriteFile(path, []byte("preflight\n"), 0o644); err != nil {
+		t.Fatalf("write summary fixture: %v", err)
+	}
+
+	writer := SummaryWriter{
+		Getenv: func(string) string { return path },
+		AppendFile: func(path string, body []byte) error {
+			f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			_, err = f.Write(body)
+			return err
+		},
+	}
+
+	err := writer.WriteExecutionSummary(execution.Result{
+		Mode:   execution.ModeDryRun,
+		DryRun: true,
+		Execution: spec.ExecutionSpec{
+			TargetName: "exp142",
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read summary: %v", err)
+	}
+	got := string(body)
+	if !strings.Contains(got, "preflight\n## kgh run summary") {
+		t.Fatalf("expected appended summary, got:\n%s", got)
+	}
+	if !strings.Contains(got, "| Target | `exp142` |") {
+		t.Fatalf("expected rendered target row, got:\n%s", got)
+	}
+}
+
+func TestSummaryWriterReturnsAppendError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("append failed")
+	writer := SummaryWriter{
+		Getenv:     func(string) string { return "/tmp/summary" },
+		AppendFile: func(string, []byte) error { return wantErr },
+	}
+
+	err := writer.WriteExecutionSummary(execution.Result{})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected append error, got %v", err)
+	}
+}

--- a/internal/reporting/doc.go
+++ b/internal/reporting/doc.go
@@ -1,0 +1,2 @@
+// Package reporting renders execution results for human-facing outputs.
+package reporting

--- a/internal/reporting/github_summary.go
+++ b/internal/reporting/github_summary.go
@@ -1,0 +1,183 @@
+package reporting
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/shotomorisk/kgh/internal/execution"
+	"github.com/shotomorisk/kgh/internal/kaggle"
+)
+
+const (
+	stateDryRun                        = "dry-run"
+	stateDisabled                      = "disabled"
+	statePending                       = "pending"
+	stateUnavailable                   = "unavailable"
+	stateNotSubmitted                  = "not submitted"
+	stateSubmissionMetadataUnavailable = "submission metadata unavailable"
+)
+
+// RenderGitHubSummary renders an execution result into Markdown for GitHub step summaries.
+func RenderGitHubSummary(result execution.Result) string {
+	rows := []summaryRow{
+		{Field: "Target", Value: formatIdentifier(valueOr(result.Execution.TargetName, stateUnavailable))},
+		{Field: "Notebook Path", Value: formatIdentifier(resolveNotebookPath(result))},
+		{Field: "Kernel ID", Value: formatIdentifier(resolveKernelID(result))},
+		{Field: "Run Status", Value: resolveRunStatus(result)},
+		{Field: "Submit Status", Value: resolveSubmitStatus(result)},
+		{Field: "Public Score", Value: resolvePublicScore(result)},
+		{Field: "References", Value: formatReferences(result)},
+	}
+
+	var b strings.Builder
+	b.WriteString("## kgh run summary\n")
+	b.WriteString("| Field | Value |\n")
+	b.WriteString("| --- | --- |\n")
+	for _, row := range rows {
+		fmt.Fprintf(&b, "| %s | %s |\n", escapeMarkdown(row.Field), row.Value)
+	}
+	return b.String()
+}
+
+type summaryRow struct {
+	Field string
+	Value string
+}
+
+func resolveNotebookPath(result execution.Result) string {
+	if result.Bundle != nil && strings.TrimSpace(result.Bundle.NotebookPath) != "" {
+		return result.Bundle.NotebookPath
+	}
+	if strings.TrimSpace(result.Execution.Notebook) != "" {
+		return result.Execution.Notebook
+	}
+	return stateUnavailable
+}
+
+func resolveKernelID(result execution.Result) string {
+	if strings.TrimSpace(result.Execution.KernelID) != "" {
+		return result.Execution.KernelID
+	}
+	if result.Push != nil && strings.TrimSpace(result.Push.KernelRef) != "" {
+		return result.Push.KernelRef
+	}
+	return stateUnavailable
+}
+
+func resolveRunStatus(result execution.Result) string {
+	if result.Mode == execution.ModeDryRun {
+		return stateDryRun
+	}
+	if result.Poll != nil {
+		switch result.Poll.Terminal {
+		case kaggle.KernelPollTerminalStateSucceeded:
+			return string(kaggle.KernelPollTerminalStateSucceeded)
+		case kaggle.KernelPollTerminalStateFailed:
+			return string(kaggle.KernelPollTerminalStateFailed)
+		case kaggle.KernelPollTerminalStateCancelled:
+			return string(kaggle.KernelPollTerminalStateCancelled)
+		}
+		if status := normalizeStatus(result.Poll.Status); status != "" {
+			return status
+		}
+	}
+	return stateUnavailable
+}
+
+func resolveSubmitStatus(result execution.Result) string {
+	if result.Mode == execution.ModeDryRun {
+		return stateDryRun
+	}
+	if !result.Execution.Submit {
+		return stateDisabled
+	}
+	if result.Submission == nil {
+		return stateNotSubmitted
+	}
+	if result.Submission.Submitted && (strings.TrimSpace(result.Submission.SubmissionID) == "" || strings.TrimSpace(result.Submission.Status) == "") {
+		return stateSubmissionMetadataUnavailable
+	}
+	if result.Submission.Submitted {
+		return "submitted"
+	}
+	return stateNotSubmitted
+}
+
+func resolvePublicScore(result execution.Result) string {
+	if result.Score != nil && strings.TrimSpace(result.Score.PublicScore) != "" {
+		return result.Score.PublicScore
+	}
+	if result.Score != nil && result.Score.State == execution.ScoreStatePending {
+		return statePending
+	}
+	return stateUnavailable
+}
+
+func formatReferences(result execution.Result) string {
+	parts := make([]string, 0, 3)
+	if kernelRef := strings.TrimSpace(resolveKernelRef(result)); kernelRef != "" {
+		parts = append(parts, fmt.Sprintf("kernel: %s", formatIdentifier(kernelRef)))
+	}
+	if submissionID := strings.TrimSpace(resolveSubmissionID(result)); submissionID != "" {
+		parts = append(parts, fmt.Sprintf("submission: %s", formatIdentifier(submissionID)))
+	}
+	if competition := strings.TrimSpace(result.Execution.Competition); competition != "" {
+		parts = append(parts, fmt.Sprintf("competition: %s", formatIdentifier(competition)))
+	}
+	if len(parts) == 0 {
+		return stateUnavailable
+	}
+	return strings.Join(parts, "<br>")
+}
+
+func resolveKernelRef(result execution.Result) string {
+	if result.Push != nil && strings.TrimSpace(result.Push.KernelRef) != "" {
+		return result.Push.KernelRef
+	}
+	if strings.TrimSpace(result.Execution.KernelRef) != "" {
+		return result.Execution.KernelRef
+	}
+	return ""
+}
+
+func resolveSubmissionID(result execution.Result) string {
+	if result.Submission != nil && strings.TrimSpace(result.Submission.SubmissionID) != "" {
+		return result.Submission.SubmissionID
+	}
+	return ""
+}
+
+func formatIdentifier(value string) string {
+	value = strings.TrimSpace(value)
+	switch value {
+	case "", stateDryRun, stateDisabled, statePending, stateUnavailable, stateNotSubmitted, stateSubmissionMetadataUnavailable, "submitted":
+		if value == "" {
+			return stateUnavailable
+		}
+		return value
+	default:
+		return "`" + escapeMarkdown(value) + "`"
+	}
+}
+
+func normalizeStatus(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return ""
+	}
+	return value
+}
+
+func valueOr(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+func escapeMarkdown(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.ReplaceAll(value, "|", `\|`)
+	value = strings.ReplaceAll(value, "\n", "<br>")
+	return value
+}

--- a/internal/reporting/github_summary_test.go
+++ b/internal/reporting/github_summary_test.go
@@ -1,0 +1,146 @@
+package reporting
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shotomorisk/kgh/internal/execution"
+	"github.com/shotomorisk/kgh/internal/kaggle"
+	"github.com/shotomorisk/kgh/internal/spec"
+)
+
+func TestRenderGitHubSummaryDryRun(t *testing.T) {
+	t.Parallel()
+
+	got := RenderGitHubSummary(execution.Result{
+		Mode:   execution.ModeDryRun,
+		DryRun: true,
+		Execution: spec.ExecutionSpec{
+			TargetName:  "exp142",
+			Notebook:    "notebooks/exp142.ipynb",
+			KernelID:    "yourname/exp142",
+			KernelRef:   "yourname/exp142",
+			Competition: "playground-series-s6e2",
+			Submit:      true,
+		},
+	})
+
+	assertContains(t, got, "## kgh run summary")
+	assertContains(t, got, "| Target | `exp142` |")
+	assertContains(t, got, "| Notebook Path | `notebooks/exp142.ipynb` |")
+	assertContains(t, got, "| Kernel ID | `yourname/exp142` |")
+	assertContains(t, got, "| Run Status | dry-run |")
+	assertContains(t, got, "| Submit Status | dry-run |")
+	assertContains(t, got, "| Public Score | unavailable |")
+	assertContains(t, got, "kernel: `yourname/exp142`")
+	assertContains(t, got, "competition: `playground-series-s6e2`")
+}
+
+func TestRenderGitHubSummaryLiveSuccess(t *testing.T) {
+	t.Parallel()
+
+	got := RenderGitHubSummary(execution.Result{
+		Execution: spec.ExecutionSpec{
+			TargetName:  "exp142",
+			Notebook:    "notebooks/config.ipynb",
+			KernelID:    "yourname/exp142",
+			KernelRef:   "yourname/exp142",
+			Competition: "playground-series-s6e2",
+			Submit:      true,
+		},
+		Bundle: &execution.BundleResult{
+			NotebookPath: "/tmp/bundle/notebooks/exp142.ipynb",
+		},
+		Push: &execution.PushResult{
+			KernelRef: "yourname/exp142",
+		},
+		Poll: &execution.PollResult{
+			Status:   "complete",
+			Terminal: kaggle.KernelPollTerminalStateSucceeded,
+		},
+		Submission: &execution.SubmissionResult{
+			Submitted:    true,
+			SubmissionID: "123",
+			Status:       "complete",
+		},
+		Score: &execution.ScoreResult{
+			State:       execution.ScoreStateReady,
+			PublicScore: "0.12345",
+		},
+		Outputs: &execution.OutputsResult{
+			Submission: execution.OutputFileResult{Path: "/tmp/output/submission.csv"},
+		},
+	})
+
+	assertContains(t, got, "| Notebook Path | `/tmp/bundle/notebooks/exp142.ipynb` |")
+	assertContains(t, got, "| Run Status | succeeded |")
+	assertContains(t, got, "| Submit Status | submitted |")
+	assertContains(t, got, "| Public Score | 0.12345 |")
+	assertContains(t, got, "submission: `123`")
+}
+
+func TestRenderGitHubSummaryPendingScore(t *testing.T) {
+	t.Parallel()
+
+	got := RenderGitHubSummary(execution.Result{
+		Execution: spec.ExecutionSpec{
+			TargetName: "exp142",
+			Submit:     true,
+		},
+		Push: &execution.PushResult{KernelRef: "yourname/exp142"},
+		Poll: &execution.PollResult{
+			Status:    "running",
+			Terminal:  kaggle.KernelPollTerminalStateUnknown,
+			StartedAt: time.Unix(0, 0),
+		},
+		Submission: &execution.SubmissionResult{
+			Submitted: true,
+		},
+		Score: &execution.ScoreResult{
+			State: execution.ScoreStatePending,
+		},
+	})
+
+	assertContains(t, got, "| Run Status | running |")
+	assertContains(t, got, "| Submit Status | submission metadata unavailable |")
+	assertContains(t, got, "| Public Score | pending |")
+}
+
+func TestRenderGitHubSummarySubmissionDisabled(t *testing.T) {
+	t.Parallel()
+
+	got := RenderGitHubSummary(execution.Result{
+		Execution: spec.ExecutionSpec{
+			TargetName: "exp142",
+			Submit:     false,
+		},
+	})
+
+	assertContains(t, got, "| Submit Status | disabled |")
+	assertContains(t, got, "| Public Score | unavailable |")
+}
+
+func TestRenderGitHubSummaryPartialResultFallbacks(t *testing.T) {
+	t.Parallel()
+
+	got := RenderGitHubSummary(execution.Result{
+		Execution: spec.ExecutionSpec{
+			TargetName: "exp142",
+			Submit:     true,
+		},
+		Push: &execution.PushResult{},
+	})
+
+	assertContains(t, got, "| Notebook Path | unavailable |")
+	assertContains(t, got, "| Kernel ID | unavailable |")
+	assertContains(t, got, "| Run Status | unavailable |")
+	assertContains(t, got, "| References | unavailable |")
+}
+
+func assertContains(t *testing.T, got, want string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected output to contain %q, got:\n%s", want, got)
+	}
+}


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #94

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
internal/reporting now owns pure Markdown rendering from execution.Result, with explicit fallback states for not run, not submitted, pending, and unavailable. internal/github has a thin SummaryWriter that appends that Markdown to GITHUB_STEP_SUMMARY, and cmd/kgh/main.go now emits the summary only for the GitHub execution path while preserving JSON stdout. Summary write failures are soft-failed to stderr.
<!-- close -->