### PR TITLE
Add Github run reporting and PR comment upsert

### DIFF
--- a/.github/workflows/commit-trigger.yml
+++ b/.github/workflows/commit-trigger.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
     contents: read
+    issues: write
 
 jobs:
     commit-trigger:
@@ -14,6 +15,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
+            issues: write
         steps:
             - uses: actions/checkout@v6
               with:

--- a/.github/workflows/commit-trigger.yml
+++ b/.github/workflows/commit-trigger.yml
@@ -39,13 +39,15 @@ jobs:
                       const repositoryFullName = `${owner}/${repo}`;
                       let prNumber = '';
                       let headSha = '';
+                      let headRepository = repositoryFullName;
                       let sameRepo = true;
                       let source = 'pull_request';
 
                       if (context.eventName === 'pull_request') {
                         prNumber = String(context.payload.pull_request.number);
                         headSha = context.payload.pull_request.head.sha;
-                        sameRepo = context.payload.pull_request.head.repo.full_name === repositoryFullName;
+                        headRepository = context.payload.pull_request.head.repo.full_name;
+                        sameRepo = headRepository === repositoryFullName;
                       } else if (context.eventName === 'workflow_dispatch') {
                         source = 'workflow_dispatch';
                         prNumber = core.getInput('pr_number', { required: true }).trim();
@@ -55,7 +57,8 @@ jobs:
                           repo,
                           pull_number: Number(prNumber),
                         });
-                        sameRepo = pullRequest.head.repo.full_name === repositoryFullName;
+                        headRepository = pullRequest.head.repo.full_name;
+                        sameRepo = headRepository === repositoryFullName;
                         headSha = requestedHeadSha || pullRequest.head.sha;
                         source = requestedHeadSha ? 'workflow_dispatch_exact_sha' : 'workflow_dispatch_pr_head';
                       } else {
@@ -65,17 +68,17 @@ jobs:
 
                       core.setOutput('pr_number', prNumber);
                       core.setOutput('head_sha', headSha);
+                      core.setOutput('head_repository', headRepository);
                       core.setOutput('same_repo', sameRepo ? 'true' : 'false');
                       core.setOutput('source', source);
 
             - uses: actions/checkout@v6
-              if: steps.context.outputs.same_repo == 'true'
               with:
+                  repository: ${{ steps.context.outputs.head_repository }}
                   ref: ${{ steps.context.outputs.head_sha }}
 
             - name: Detect submit trigger
               id: trigger
-              if: steps.context.outputs.same_repo == 'true'
               shell: bash
               env:
                   KGH_PR_NUMBER: ${{ steps.context.outputs.pr_number }}
@@ -109,20 +112,8 @@ jobs:
                     fi
                   } >> "$GITHUB_STEP_SUMMARY"
 
-            - name: Skip fork pull requests
-              if: steps.context.outputs.same_repo != 'true'
-              shell: bash
-              env:
-                  KGH_PR_NUMBER: ${{ steps.context.outputs.pr_number }}
-              run: |
-                  set -euo pipefail
-                  {
-                    echo "## kgh commit trigger"
-                    echo "PR #${KGH_PR_NUMBER} comes from a fork repository. Skipping Kaggle execution for safety."
-                  } >> "$GITHUB_STEP_SUMMARY"
-
             - name: Set up Go
-              if: steps.context.outputs.same_repo == 'true' && steps.trigger.outputs.should_run == 'true'
+              if: steps.trigger.outputs.should_run == 'true'
               uses: actions/setup-go@v6
               with:
                   go-version-file: go.mod
@@ -134,18 +125,27 @@ jobs:
               run: python3 -m pip install --upgrade kaggle
 
             - name: Resolve and execute commit trigger
-              if: steps.context.outputs.same_repo == 'true' && steps.trigger.outputs.should_run == 'true'
+              if: steps.trigger.outputs.should_run == 'true'
               shell: bash
               env:
+                  GITHUB_TOKEN: ${{ github.token }}
                   KGH_PULL_REQUEST_NUMBER: ${{ steps.context.outputs.pr_number }}
                   KGH_TRIGGER_SHA: ${{ steps.context.outputs.head_sha }}
                   KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_API_TOKEN }}
                   KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
                   KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}
+                  KGH_SAME_REPO: ${{ steps.context.outputs.same_repo }}
               run: |
                   set -euo pipefail
                   args=(github run)
-                  if [[ -n "${KAGGLE_API_TOKEN:-}" || ( -n "${KAGGLE_USERNAME:-}" && -n "${KAGGLE_KEY:-}" ) ]]; then
+
+                  if [[ "${KGH_SAME_REPO}" != "true" ]]; then
+                    {
+                      echo "## kgh commit trigger mode"
+                      echo "This PR comes from a fork repository, so live Kaggle execution is not allowed."
+                      echo "The commit-trigger path is running in dry-run mode to validate trigger parsing and execution planning safely."
+                    } >> "$GITHUB_STEP_SUMMARY"
+                  elif [[ -n "${KAGGLE_API_TOKEN:-}" || ( -n "${KAGGLE_USERNAME:-}" && -n "${KAGGLE_KEY:-}" ) ]]; then
                     {
                       echo "## kgh commit trigger mode"
                       echo "Kaggle credentials were loaded from GitHub Actions secrets, so the commit-trigger path is running in live mode."
@@ -154,9 +154,10 @@ jobs:
                   else
                     {
                       echo "## kgh commit trigger mode"
-                      echo "No Kaggle credentials were available from GitHub Actions secrets, so live execution is not safe."
-                      echo "The commit-trigger path is intentionally falling back to dry-run mode instead of silently skipping execution."
+                      echo "Kaggle credentials are missing, so live Kaggle execution cannot run safely."
+                      echo "Configure KAGGLE_API_TOKEN or KAGGLE_USERNAME/KAGGLE_KEY in repository secrets."
                     } >> "$GITHUB_STEP_SUMMARY"
+                    exit 1
                   fi
 
                   go run ./cmd/kgh/main.go kgh "${args[@]}"

--- a/.github/workflows/commit-trigger.yml
+++ b/.github/workflows/commit-trigger.yml
@@ -148,13 +148,14 @@ jobs:
                   if [[ -n "${KAGGLE_API_TOKEN:-}" || ( -n "${KAGGLE_USERNAME:-}" && -n "${KAGGLE_KEY:-}" ) ]]; then
                     {
                       echo "## kgh commit trigger mode"
-                      echo "Running the commit-trigger path in live mode."
+                      echo "Kaggle credentials were loaded from GitHub Actions secrets, so the commit-trigger path is running in live mode."
                     } >> "$GITHUB_STEP_SUMMARY"
                     args+=(--dry-run=false)
                   else
                     {
                       echo "## kgh commit trigger mode"
-                      echo "Kaggle credentials are unavailable, so the commit-trigger path is running in dry-run mode."
+                      echo "No Kaggle credentials were available from GitHub Actions secrets, so live execution is not safe."
+                      echo "The commit-trigger path is intentionally falling back to dry-run mode instead of silently skipping execution."
                     } >> "$GITHUB_STEP_SUMMARY"
                   fi
 

--- a/.github/workflows/commit-trigger.yml
+++ b/.github/workflows/commit-trigger.yml
@@ -3,35 +3,98 @@ name: Commit Trigger
 on:
     pull_request:
         types: [opened, synchronize, reopened]
+    workflow_dispatch:
+        inputs:
+            pr_number:
+                description: Pull request number to rerun
+                required: true
+                type: string
+            head_sha:
+                description: Optional exact PR head commit SHA to rerun
+                required: false
+                type: string
 
 permissions:
     contents: read
     issues: write
+    pull-requests: read
 
 jobs:
     commit-trigger:
         name: Commit Trigger
-        if: github.event.pull_request.head.repo.full_name == github.repository
         runs-on: ubuntu-latest
         permissions:
             contents: read
             issues: write
+            pull-requests: read
         steps:
-            - uses: actions/checkout@v6
+            - name: Resolve trigger context
+              id: context
+              uses: actions/github-script@v9
               with:
-                  ref: ${{ github.event.pull_request.head.sha }}
+                  github-token: ${{ github.token }}
+                  script: |
+                      const owner = context.repo.owner;
+                      const repo = context.repo.repo;
+                      const repositoryFullName = `${owner}/${repo}`;
+                      let prNumber = '';
+                      let headSha = '';
+                      let sameRepo = true;
+                      let source = 'pull_request';
+
+                      if (context.eventName === 'pull_request') {
+                        prNumber = String(context.payload.pull_request.number);
+                        headSha = context.payload.pull_request.head.sha;
+                        sameRepo = context.payload.pull_request.head.repo.full_name === repositoryFullName;
+                      } else if (context.eventName === 'workflow_dispatch') {
+                        source = 'workflow_dispatch';
+                        prNumber = core.getInput('pr_number', { required: true }).trim();
+                        const requestedHeadSha = core.getInput('head_sha').trim();
+                        const { data: pullRequest } = await github.rest.pulls.get({
+                          owner,
+                          repo,
+                          pull_number: Number(prNumber),
+                        });
+                        sameRepo = pullRequest.head.repo.full_name === repositoryFullName;
+                        headSha = requestedHeadSha || pullRequest.head.sha;
+                        source = requestedHeadSha ? 'workflow_dispatch_exact_sha' : 'workflow_dispatch_pr_head';
+                      } else {
+                        core.setFailed(`unsupported event ${context.eventName}`);
+                        return;
+                      }
+
+                      core.setOutput('pr_number', prNumber);
+                      core.setOutput('head_sha', headSha);
+                      core.setOutput('same_repo', sameRepo ? 'true' : 'false');
+                      core.setOutput('source', source);
+
+            - uses: actions/checkout@v6
+              if: steps.context.outputs.same_repo == 'true'
+              with:
+                  ref: ${{ steps.context.outputs.head_sha }}
 
             - name: Detect submit trigger
               id: trigger
+              if: steps.context.outputs.same_repo == 'true'
               shell: bash
+              env:
+                  KGH_PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+                  KGH_TRIGGER_SOURCE: ${{ steps.context.outputs.source }}
+                  KGH_TRIGGER_SHA: ${{ steps.context.outputs.head_sha }}
               run: |
                   set -euo pipefail
-                  message="$(git show -s --format=%B "${{ github.event.pull_request.head.sha }}")"
+                  message="$(git show -s --format=%B "${KGH_TRIGGER_SHA}")"
                   if grep -Eq '^[[:space:]]*submit:' <<<"$message"; then
                     echo "should_run=true" >> "$GITHUB_OUTPUT"
                     {
                       echo "## kgh commit trigger"
-                      echo "Detected a \`submit:\` command in the head commit message."
+                      if [[ "${KGH_TRIGGER_SOURCE}" == workflow_dispatch_exact_sha ]]; then
+                        echo "Manual rerun for PR #${KGH_PR_NUMBER} is targeting commit \`${KGH_TRIGGER_SHA}\`."
+                      elif [[ "${KGH_TRIGGER_SOURCE}" == workflow_dispatch_pr_head ]]; then
+                        echo "Manual rerun for PR #${KGH_PR_NUMBER} is targeting the current PR head \`${KGH_TRIGGER_SHA}\`."
+                      else
+                        echo "Detected a \`submit:\` command in the head commit message."
+                      fi
                     } >> "$GITHUB_STEP_SUMMARY"
                     exit 0
                   fi
@@ -39,25 +102,43 @@ jobs:
                   echo "should_run=false" >> "$GITHUB_OUTPUT"
                   {
                     echo "## kgh commit trigger"
-                    echo "No \`submit:\` command found in the head commit message. Skipping Kaggle execution."
+                    if [[ "${KGH_TRIGGER_SOURCE}" == workflow_dispatch_exact_sha || "${KGH_TRIGGER_SOURCE}" == workflow_dispatch_pr_head ]]; then
+                      echo "Manual rerun for PR #${KGH_PR_NUMBER} found no \`submit:\` command in commit \`${KGH_TRIGGER_SHA}\`. Skipping Kaggle execution."
+                    else
+                      echo "No \`submit:\` command found in the head commit message. Skipping Kaggle execution."
+                    fi
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Skip fork pull requests
+              if: steps.context.outputs.same_repo != 'true'
+              shell: bash
+              env:
+                  KGH_PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+              run: |
+                  set -euo pipefail
+                  {
+                    echo "## kgh commit trigger"
+                    echo "PR #${KGH_PR_NUMBER} comes from a fork repository. Skipping Kaggle execution for safety."
                   } >> "$GITHUB_STEP_SUMMARY"
 
             - name: Set up Go
-              if: steps.trigger.outputs.should_run == 'true'
+              if: steps.context.outputs.same_repo == 'true' && steps.trigger.outputs.should_run == 'true'
               uses: actions/setup-go@v6
               with:
                   go-version-file: go.mod
                   cache: false
 
             - name: Install Kaggle CLI
-              if: steps.trigger.outputs.should_run == 'true'
+              if: steps.context.outputs.same_repo == 'true' && steps.trigger.outputs.should_run == 'true'
               shell: bash
               run: python3 -m pip install --upgrade kaggle
 
             - name: Resolve and execute commit trigger
-              if: steps.trigger.outputs.should_run == 'true'
+              if: steps.context.outputs.same_repo == 'true' && steps.trigger.outputs.should_run == 'true'
               shell: bash
               env:
+                  KGH_PULL_REQUEST_NUMBER: ${{ steps.context.outputs.pr_number }}
+                  KGH_TRIGGER_SHA: ${{ steps.context.outputs.head_sha }}
                   KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_API_TOKEN }}
                   KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
                   KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}

--- a/.github/workflows/commit-trigger.yml
+++ b/.github/workflows/commit-trigger.yml
@@ -16,17 +16,21 @@ on:
 
 permissions:
     contents: read
-    issues: write
     pull-requests: read
 
 jobs:
-    commit-trigger:
-        name: Commit Trigger
+    resolve-trigger:
+        name: Resolve Trigger
         runs-on: ubuntu-latest
         permissions:
             contents: read
-            issues: write
             pull-requests: read
+        outputs:
+            pr_number: ${{ steps.context.outputs.pr_number }}
+            head_sha: ${{ steps.context.outputs.head_sha }}
+            same_repo: ${{ steps.context.outputs.same_repo }}
+            source: ${{ steps.context.outputs.source }}
+            should_run: ${{ steps.trigger.outputs.should_run }}
         steps:
             - name: Resolve trigger context
               id: context
@@ -72,80 +76,113 @@ jobs:
                       core.setOutput('same_repo', sameRepo ? 'true' : 'false');
                       core.setOutput('source', source);
 
-            - uses: actions/checkout@v6
-              with:
-                  repository: ${{ steps.context.outputs.head_repository }}
-                  ref: ${{ steps.context.outputs.head_sha }}
-
             - name: Detect submit trigger
               id: trigger
+              uses: actions/github-script@v9
+              with:
+                  github-token: ${{ github.token }}
+                  script: |
+                      const headRepository = process.env.HEAD_REPOSITORY;
+                      const headSha = process.env.HEAD_SHA;
+                      const prNumber = process.env.PR_NUMBER;
+                      const triggerSource = process.env.TRIGGER_SOURCE;
+                      const [owner, repo] = headRepository.split('/');
+                      if (!owner || !repo) {
+                        core.setFailed(`invalid head repository ${headRepository}`);
+                        return;
+                      }
+
+                      const { data: commit } = await github.rest.repos.getCommit({
+                        owner,
+                        repo,
+                        ref: headSha,
+                      });
+                      const message = commit.commit.message || '';
+                      const shouldRun = /^[\t ]*submit:/m.test(message);
+                      core.setOutput('should_run', shouldRun ? 'true' : 'false');
+
+                      const lines = ['## kgh commit trigger'];
+                      if (shouldRun) {
+                        if (triggerSource === 'workflow_dispatch_exact_sha') {
+                          lines.push(`Manual rerun for PR #${prNumber} is targeting commit \`${headSha}\`.`);
+                        } else if (triggerSource === 'workflow_dispatch_pr_head') {
+                          lines.push(`Manual rerun for PR #${prNumber} is targeting the current PR head \`${headSha}\`.`);
+                        } else {
+                          lines.push('Detected a `submit:` command in the head commit message.');
+                        }
+                      } else if (triggerSource === 'workflow_dispatch_exact_sha' || triggerSource === 'workflow_dispatch_pr_head') {
+                        lines.push(`Manual rerun for PR #${prNumber} found no \`submit:\` command in commit \`${headSha}\`. Skipping Kaggle execution.`);
+                      } else {
+                        lines.push('No `submit:` command found in the head commit message. Skipping Kaggle execution.');
+                      }
+
+                      require('fs').appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);
+              env:
+                  HEAD_REPOSITORY: ${{ steps.context.outputs.head_repository }}
+                  HEAD_SHA: ${{ steps.context.outputs.head_sha }}
+                  PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+                  TRIGGER_SOURCE: ${{ steps.context.outputs.source }}
+
+    fail-fork-pr:
+        name: Fail Fork Pull Requests Safely
+        runs-on: ubuntu-latest
+        needs: resolve-trigger
+        if: needs.resolve-trigger.outputs.same_repo != 'true' && needs.resolve-trigger.outputs.should_run == 'true'
+        permissions:
+            contents: read
+            pull-requests: read
+        steps:
+            - name: Explain fork restriction
               shell: bash
               env:
-                  KGH_PR_NUMBER: ${{ steps.context.outputs.pr_number }}
-                  KGH_TRIGGER_SOURCE: ${{ steps.context.outputs.source }}
-                  KGH_TRIGGER_SHA: ${{ steps.context.outputs.head_sha }}
+                  KGH_PR_NUMBER: ${{ needs.resolve-trigger.outputs.pr_number }}
               run: |
                   set -euo pipefail
-                  message="$(git show -s --format=%B "${KGH_TRIGGER_SHA}")"
-                  if grep -Eq '^[[:space:]]*submit:' <<<"$message"; then
-                    echo "should_run=true" >> "$GITHUB_OUTPUT"
-                    {
-                      echo "## kgh commit trigger"
-                      if [[ "${KGH_TRIGGER_SOURCE}" == workflow_dispatch_exact_sha ]]; then
-                        echo "Manual rerun for PR #${KGH_PR_NUMBER} is targeting commit \`${KGH_TRIGGER_SHA}\`."
-                      elif [[ "${KGH_TRIGGER_SOURCE}" == workflow_dispatch_pr_head ]]; then
-                        echo "Manual rerun for PR #${KGH_PR_NUMBER} is targeting the current PR head \`${KGH_TRIGGER_SHA}\`."
-                      else
-                        echo "Detected a \`submit:\` command in the head commit message."
-                      fi
-                    } >> "$GITHUB_STEP_SUMMARY"
-                    exit 0
-                  fi
-
-                  echo "should_run=false" >> "$GITHUB_OUTPUT"
                   {
-                    echo "## kgh commit trigger"
-                    if [[ "${KGH_TRIGGER_SOURCE}" == workflow_dispatch_exact_sha || "${KGH_TRIGGER_SOURCE}" == workflow_dispatch_pr_head ]]; then
-                      echo "Manual rerun for PR #${KGH_PR_NUMBER} found no \`submit:\` command in commit \`${KGH_TRIGGER_SHA}\`. Skipping Kaggle execution."
-                    else
-                      echo "No \`submit:\` command found in the head commit message. Skipping Kaggle execution."
-                    fi
+                    echo "## kgh commit trigger mode"
+                    echo "PR #${KGH_PR_NUMBER} comes from a fork repository, so executing fork-controlled code is not allowed."
+                    echo "Re-run from a trusted branch or maintainer-controlled workflow to execute this trigger."
                   } >> "$GITHUB_STEP_SUMMARY"
+                  exit 1
+
+    execute-same-repo:
+        name: Execute Same-Repo Trigger
+        runs-on: ubuntu-latest
+        needs: resolve-trigger
+        if: needs.resolve-trigger.outputs.same_repo == 'true' && needs.resolve-trigger.outputs.should_run == 'true'
+        permissions:
+            contents: read
+            issues: write
+            pull-requests: read
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  ref: ${{ needs.resolve-trigger.outputs.head_sha }}
 
             - name: Set up Go
-              if: steps.trigger.outputs.should_run == 'true'
               uses: actions/setup-go@v6
               with:
                   go-version-file: go.mod
                   cache: false
 
             - name: Install Kaggle CLI
-              if: steps.context.outputs.same_repo == 'true' && steps.trigger.outputs.should_run == 'true'
               shell: bash
               run: python3 -m pip install --upgrade kaggle
 
             - name: Resolve and execute commit trigger
-              if: steps.trigger.outputs.should_run == 'true'
               shell: bash
               env:
                   GITHUB_TOKEN: ${{ github.token }}
-                  KGH_PULL_REQUEST_NUMBER: ${{ steps.context.outputs.pr_number }}
-                  KGH_TRIGGER_SHA: ${{ steps.context.outputs.head_sha }}
+                  KGH_PULL_REQUEST_NUMBER: ${{ needs.resolve-trigger.outputs.pr_number }}
+                  KGH_TRIGGER_SHA: ${{ needs.resolve-trigger.outputs.head_sha }}
                   KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_API_TOKEN }}
                   KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
                   KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}
-                  KGH_SAME_REPO: ${{ steps.context.outputs.same_repo }}
               run: |
                   set -euo pipefail
                   args=(github run)
 
-                  if [[ "${KGH_SAME_REPO}" != "true" ]]; then
-                    {
-                      echo "## kgh commit trigger mode"
-                      echo "This PR comes from a fork repository, so live Kaggle execution is not allowed."
-                      echo "The commit-trigger path is running in dry-run mode to validate trigger parsing and execution planning safely."
-                    } >> "$GITHUB_STEP_SUMMARY"
-                  elif [[ -n "${KAGGLE_API_TOKEN:-}" || ( -n "${KAGGLE_USERNAME:-}" && -n "${KAGGLE_KEY:-}" ) ]]; then
+                  if [[ -n "${KAGGLE_API_TOKEN:-}" || ( -n "${KAGGLE_USERNAME:-}" && -n "${KAGGLE_KEY:-}" ) ]]; then
                     {
                       echo "## kgh commit trigger mode"
                       echo "Kaggle credentials were loaded from GitHub Actions secrets, so the commit-trigger path is running in live mode."

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ kgh
 
 # local kgh config
 .kgh/config.yaml
+
+# Go build cache
+.gocache/

--- a/cmd/kgh/main.go
+++ b/cmd/kgh/main.go
@@ -26,12 +26,12 @@ var newRunner = func(adapter execution.Adapter) executionRunner {
 	return execution.NewRunner(adapter)
 }
 
-type githubExecutionSummaryWriter interface {
-	WriteExecutionSummary(execution.Result) error
+type githubExecutionReporter interface {
+	WriteExecutionReport(context.Context, execution.Result) error
 }
 
-var newGitHubSummaryWriter = func() githubExecutionSummaryWriter {
-	return ghctx.NewSummaryWriter()
+var newGitHubReporter = func() githubExecutionReporter {
+	return ghctx.NewRunReporter()
 }
 
 func main() {
@@ -154,8 +154,8 @@ func executeRequest(ctx context.Context, req execution.Request, stdout, stderr i
 		return 1, err
 	}
 	if writeSummary {
-		if err := newGitHubSummaryWriter().WriteExecutionSummary(report); err != nil && stderr != nil {
-			fmt.Fprintf(stderr, "write GitHub summary: %v\n", err)
+		if err := newGitHubReporter().WriteExecutionReport(ctx, report); err != nil && stderr != nil {
+			fmt.Fprintf(stderr, "%v\n", err)
 		}
 	}
 	return 0, nil

--- a/cmd/kgh/main_test.go
+++ b/cmd/kgh/main_test.go
@@ -22,11 +22,19 @@ type fakeSummaryWriter struct {
 	err error
 }
 
+type fakeGitHubReporter struct {
+	err error
+}
+
 func (f fakeExecutionRunner) Execute(context.Context, execution.Request) (execution.Result, error) {
 	return f.result, f.err
 }
 
 func (f fakeSummaryWriter) WriteExecutionSummary(execution.Result) error {
+	return f.err
+}
+
+func (f fakeGitHubReporter) WriteExecutionReport(context.Context, execution.Result) error {
 	return f.err
 }
 
@@ -49,10 +57,11 @@ func TestExecuteRequestWritesJSONAndGitHubSummary(t *testing.T) {
 			},
 		}
 	}
-
 	dir := t.TempDir()
 	summaryPath := filepath.Join(dir, "summary.md")
 	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+	t.Setenv("GITHUB_EVENT_NAME", "push")
+	t.Setenv("GITHUB_REPOSITORY", "shotomorisk/kgh")
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -81,10 +90,10 @@ func TestExecuteRequestWritesJSONAndGitHubSummary(t *testing.T) {
 
 func TestExecuteRequestSummaryWriteFailureIsNonFatal(t *testing.T) {
 	originalNewRunner := newRunner
-	originalSummaryWriter := newGitHubSummaryWriter
+	originalReporter := newGitHubReporter
 	t.Cleanup(func() {
 		newRunner = originalNewRunner
-		newGitHubSummaryWriter = originalSummaryWriter
+		newGitHubReporter = originalReporter
 	})
 
 	newRunner = func(execution.Adapter) executionRunner {
@@ -95,8 +104,8 @@ func TestExecuteRequestSummaryWriteFailureIsNonFatal(t *testing.T) {
 			},
 		}
 	}
-	newGitHubSummaryWriter = func() githubExecutionSummaryWriter {
-		return fakeSummaryWriter{err: errors.New("disk full")}
+	newGitHubReporter = func() githubExecutionReporter {
+		return fakeGitHubReporter{err: errors.New("write GitHub summary: disk full")}
 	}
 
 	var stdout bytes.Buffer
@@ -109,7 +118,7 @@ func TestExecuteRequestSummaryWriteFailureIsNonFatal(t *testing.T) {
 		t.Fatalf("expected exit code 0, got %d", code)
 	}
 	if !strings.Contains(stderr.String(), "write GitHub summary: disk full") {
-		t.Fatalf("expected summary warning on stderr, got %q", stderr.String())
+		t.Fatalf("expected reporting warning on stderr, got %q", stderr.String())
 	}
 	if stdout.Len() == 0 {
 		t.Fatal("expected stdout JSON to still be written")
@@ -118,10 +127,10 @@ func TestExecuteRequestSummaryWriteFailureIsNonFatal(t *testing.T) {
 
 func TestExecuteRequestSkipsSummaryWhenDisabled(t *testing.T) {
 	originalNewRunner := newRunner
-	originalSummaryWriter := newGitHubSummaryWriter
+	originalReporter := newGitHubReporter
 	t.Cleanup(func() {
 		newRunner = originalNewRunner
-		newGitHubSummaryWriter = originalSummaryWriter
+		newGitHubReporter = originalReporter
 	})
 
 	newRunner = func(execution.Adapter) executionRunner {
@@ -132,8 +141,8 @@ func TestExecuteRequestSkipsSummaryWhenDisabled(t *testing.T) {
 			},
 		}
 	}
-	newGitHubSummaryWriter = func() githubExecutionSummaryWriter {
-		return fakeSummaryWriter{err: errors.New("should not be called")}
+	newGitHubReporter = func() githubExecutionReporter {
+		return fakeGitHubReporter{err: errors.New("should not be called")}
 	}
 
 	dir := t.TempDir()

--- a/doc/github-trigger.md
+++ b/doc/github-trigger.md
@@ -38,10 +38,18 @@ This command resolves the target from GitHub context and then follows the same d
 - `GITHUB_SHA`
 - `GITHUB_WORKSPACE`
 
+The GitHub workflow wrapper is also expected to wire Kaggle credentials from GitHub Actions secrets for live execution:
+
+- `KAGGLE_API_TOKEN`, or
+- both `KAGGLE_USERNAME` and `KAGGLE_KEY`
+
 For manual `workflow_dispatch` reruns, the GitHub workflow wrapper may also provide:
 
 - `KGH_TRIGGER_SHA`
 - `KGH_PULL_REQUEST_NUMBER`
+
+If Kaggle credentials are present, the wrapper runs `kgh github run --dry-run=false`.
+If Kaggle credentials are absent, the wrapper reports that live execution is unsafe and intentionally falls back to dry-run mode.
 
 Use built-in help to inspect the current contract:
 

--- a/doc/github-trigger.md
+++ b/doc/github-trigger.md
@@ -42,14 +42,16 @@ The GitHub workflow wrapper is also expected to wire Kaggle credentials from Git
 
 - `KAGGLE_API_TOKEN`, or
 - both `KAGGLE_USERNAME` and `KAGGLE_KEY`
+- `GITHUB_TOKEN` for PR comment reporting
 
 For manual `workflow_dispatch` reruns, the GitHub workflow wrapper may also provide:
 
 - `KGH_TRIGGER_SHA`
 - `KGH_PULL_REQUEST_NUMBER`
 
-If Kaggle credentials are present, the wrapper runs `kgh github run --dry-run=false`.
-If Kaggle credentials are absent, the wrapper reports that live execution is unsafe and intentionally falls back to dry-run mode.
+If the PR comes from the same repository and Kaggle credentials are present, the wrapper runs `kgh github run --dry-run=false`.
+If the PR comes from a fork, the wrapper runs `kgh github run` in dry-run mode for safety.
+If the PR comes from the same repository but Kaggle credentials are absent, the wrapper fails clearly instead of silently downgrading a live trigger to dry-run.
 
 Use built-in help to inspect the current contract:
 

--- a/doc/github-trigger.md
+++ b/doc/github-trigger.md
@@ -38,6 +38,11 @@ This command resolves the target from GitHub context and then follows the same d
 - `GITHUB_SHA`
 - `GITHUB_WORKSPACE`
 
+For manual `workflow_dispatch` reruns, the GitHub workflow wrapper may also provide:
+
+- `KGH_TRIGGER_SHA`
+- `KGH_PULL_REQUEST_NUMBER`
+
 Use built-in help to inspect the current contract:
 
 ```bash

--- a/doc/github-trigger.md
+++ b/doc/github-trigger.md
@@ -50,7 +50,7 @@ For manual `workflow_dispatch` reruns, the GitHub workflow wrapper may also prov
 - `KGH_PULL_REQUEST_NUMBER`
 
 If the PR comes from the same repository and Kaggle credentials are present, the wrapper runs `kgh github run --dry-run=false`.
-If the PR comes from a fork, the wrapper runs `kgh github run` in dry-run mode for safety.
+If the PR comes from a fork, the wrapper fails safely with a clear explanation instead of executing fork-controlled code.
 If the PR comes from the same repository but Kaggle credentials are absent, the wrapper fails clearly instead of silently downgrading a live trigger to dry-run.
 
 Use built-in help to inspect the current contract:

--- a/internal/github/comment.go
+++ b/internal/github/comment.go
@@ -1,0 +1,173 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const commentMarker = "<!-- kgh:run-report -->"
+
+type httpDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// PRCommentWriter upserts the kgh report comment onto a pull request.
+type PRCommentWriter struct {
+	Getenv     func(string) string
+	HTTPClient httpDoer
+}
+
+func NewPRCommentWriter() PRCommentWriter {
+	return PRCommentWriter{
+		Getenv:     os.Getenv,
+		HTTPClient: http.DefaultClient,
+	}
+}
+
+func (w PRCommentWriter) Write(ctx context.Context, reportCtx ReportContext, body string) error {
+	if !reportCtx.HasPullRequest() {
+		return nil
+	}
+
+	token := strings.TrimSpace(w.getenv("GITHUB_TOKEN"))
+	if token == "" {
+		return fmt.Errorf("upsert GitHub PR comment: GITHUB_TOKEN is required")
+	}
+	if reportCtx.RepositoryOwner == "" || reportCtx.RepositoryName == "" {
+		return fmt.Errorf("upsert GitHub PR comment: GITHUB_REPOSITORY must be owner/repo")
+	}
+
+	commentID, err := w.findExistingCommentID(ctx, reportCtx, token)
+	if err != nil {
+		return fmt.Errorf("upsert GitHub PR comment: %w", err)
+	}
+	if commentID == 0 {
+		if err := w.createComment(ctx, reportCtx, token, body); err != nil {
+			return fmt.Errorf("upsert GitHub PR comment: %w", err)
+		}
+		return nil
+	}
+	if err := w.updateComment(ctx, reportCtx, token, commentID, body); err != nil {
+		return fmt.Errorf("upsert GitHub PR comment: %w", err)
+	}
+	return nil
+}
+
+func (w PRCommentWriter) findExistingCommentID(ctx context.Context, reportCtx ReportContext, token string) (int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, w.apiURL()+"/repos/"+reportCtx.RepositoryOwner+"/"+reportCtx.RepositoryName+"/issues/"+fmt.Sprintf("%d", reportCtx.PullRequestNumber)+"/comments", nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	var comments []struct {
+		ID   int64  `json:"id"`
+		Body string `json:"body"`
+	}
+	if err := w.doJSON(req, &comments); err != nil {
+		return 0, err
+	}
+	for _, comment := range comments {
+		if strings.Contains(comment.Body, commentMarker) {
+			return comment.ID, nil
+		}
+	}
+	return 0, nil
+}
+
+func (w PRCommentWriter) createComment(ctx context.Context, reportCtx ReportContext, token, body string) error {
+	payload, err := json.Marshal(map[string]string{"body": body})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.apiURL()+"/repos/"+reportCtx.RepositoryOwner+"/"+reportCtx.RepositoryName+"/issues/"+fmt.Sprintf("%d", reportCtx.PullRequestNumber)+"/comments", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	return w.doNoContent(req)
+}
+
+func (w PRCommentWriter) updateComment(ctx context.Context, reportCtx ReportContext, token string, commentID int64, body string) error {
+	payload, err := json.Marshal(map[string]string{"body": body})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, w.apiURL()+"/repos/"+reportCtx.RepositoryOwner+"/"+reportCtx.RepositoryName+"/issues/comments/"+fmt.Sprintf("%d", commentID), bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	return w.doNoContent(req)
+}
+
+func (w PRCommentWriter) doJSON(req *http.Request, out any) error {
+	resp, err := w.client().Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return httpStatusError(resp)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func (w PRCommentWriter) doNoContent(req *http.Request) error {
+	resp, err := w.client().Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return httpStatusError(resp)
+	}
+	return nil
+}
+
+func (w PRCommentWriter) client() httpDoer {
+	if w.HTTPClient != nil {
+		return w.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+func (w PRCommentWriter) getenv(key string) string {
+	if w.Getenv != nil {
+		return w.Getenv(key)
+	}
+	return os.Getenv(key)
+}
+
+func (w PRCommentWriter) apiURL() string {
+	base := strings.TrimSpace(w.getenv("GITHUB_API_URL"))
+	if base == "" {
+		base = defaultGitHubAPIURL
+	}
+	return strings.TrimRight(base, "/")
+}
+
+func httpStatusError(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	text := strings.TrimSpace(string(body))
+	if text == "" {
+		return fmt.Errorf("GitHub API returned %s", resp.Status)
+	}
+	return fmt.Errorf("GitHub API returned %s: %s", resp.Status, text)
+}

--- a/internal/github/comment_test.go
+++ b/internal/github/comment_test.go
@@ -1,0 +1,151 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestPRCommentWriterCreatesCommentWhenMarkerMissing(t *testing.T) {
+	t.Parallel()
+
+	var requests []string
+	writer := PRCommentWriter{
+		Getenv: envMap(map[string]string{
+			"GITHUB_TOKEN": "token",
+		}),
+		HTTPClient: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requests = append(requests, req.Method+" "+req.URL.Path)
+			switch req.Method {
+			case http.MethodGet:
+				return jsonResponse(http.StatusOK, `[]`), nil
+			case http.MethodPost:
+				var payload struct {
+					Body string `json:"body"`
+				}
+				if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+					t.Fatalf("decode request body: %v", err)
+				}
+				if !strings.Contains(payload.Body, commentMarker) {
+					t.Fatalf("expected marker in body, got %s", payload.Body)
+				}
+				return jsonResponse(http.StatusCreated, `{}`), nil
+			default:
+				t.Fatalf("unexpected method %s", req.Method)
+				return nil, nil
+			}
+		}),
+	}
+
+	err := writer.Write(context.Background(), ReportContext{
+		RepositoryOwner:   "shotomorisk",
+		RepositoryName:    "kgh",
+		PullRequestNumber: 17,
+	}, commentMarker+"\nbody")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("expected 2 requests, got %v", requests)
+	}
+}
+
+func TestPRCommentWriterUpdatesExistingMarkerComment(t *testing.T) {
+	t.Parallel()
+
+	var patched bool
+	writer := PRCommentWriter{
+		Getenv: envMap(map[string]string{
+			"GITHUB_TOKEN": "token",
+		}),
+		HTTPClient: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.Method {
+			case http.MethodGet:
+				return jsonResponse(http.StatusOK, `[{"id":123,"body":"`+commentMarker+` old"}]`), nil
+			case http.MethodPatch:
+				patched = true
+				if got := req.URL.Path; got != "/repos/shotomorisk/kgh/issues/comments/123" {
+					t.Fatalf("unexpected patch path %q", got)
+				}
+				return jsonResponse(http.StatusOK, `{}`), nil
+			default:
+				t.Fatalf("unexpected method %s", req.Method)
+				return nil, nil
+			}
+		}),
+	}
+
+	err := writer.Write(context.Background(), ReportContext{
+		RepositoryOwner:   "shotomorisk",
+		RepositoryName:    "kgh",
+		PullRequestNumber: 17,
+	}, commentMarker+"\nbody")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !patched {
+		t.Fatal("expected patch request")
+	}
+}
+
+func TestPRCommentWriterRejectsMissingToken(t *testing.T) {
+	t.Parallel()
+
+	err := PRCommentWriter{
+		Getenv: envMap(map[string]string{}),
+	}.Write(context.Background(), ReportContext{
+		RepositoryOwner:   "shotomorisk",
+		RepositoryName:    "kgh",
+		PullRequestNumber: 17,
+	}, "body")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); got != "upsert GitHub PR comment: GITHUB_TOKEN is required" {
+		t.Fatalf("unexpected error %q", got)
+	}
+}
+
+func TestPRCommentWriterWrapsHTTPError(t *testing.T) {
+	t.Parallel()
+
+	writer := PRCommentWriter{
+		Getenv: envMap(map[string]string{
+			"GITHUB_TOKEN": "token",
+		}),
+		HTTPClient: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("boom")
+		}),
+	}
+
+	err := writer.Write(context.Background(), ReportContext{
+		RepositoryOwner:   "shotomorisk",
+		RepositoryName:    "kgh",
+		PullRequestNumber: 17,
+	}, "body")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); got != "upsert GitHub PR comment: boom" {
+		t.Fatalf("unexpected error %q", got)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}

--- a/internal/github/context.go
+++ b/internal/github/context.go
@@ -56,13 +56,25 @@ func (r ReportContextResolver) Resolve() (ReportContext, error) {
 		r.Getenv("GITHUB_RUN_ID"),
 	)
 
+	if override := strings.TrimSpace(r.Getenv("KGH_PULL_REQUEST_NUMBER")); override != "" {
+		number, err := strconv.Atoi(override)
+		if err != nil || number <= 0 {
+			return ReportContext{}, fmt.Errorf("KGH_PULL_REQUEST_NUMBER must be a positive integer")
+		}
+		ctx.PullRequestNumber = number
+	}
+
 	switch ctx.EventName {
 	case "pull_request", "pull_request_target":
+		if ctx.PullRequestNumber > 0 {
+			return ctx, nil
+		}
 		number, err := r.resolvePullRequestNumber()
 		if err != nil {
 			return ReportContext{}, err
 		}
 		ctx.PullRequestNumber = number
+	case "workflow_dispatch":
 	case "":
 		return ReportContext{}, fmt.Errorf("GITHUB_EVENT_NAME is required")
 	}

--- a/internal/github/context.go
+++ b/internal/github/context.go
@@ -1,0 +1,118 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const defaultGitHubAPIURL = "https://api.github.com"
+
+// ReportContext contains the GitHub metadata needed for result publication.
+type ReportContext struct {
+	EventName         string
+	Repository        string
+	RepositoryOwner   string
+	RepositoryName    string
+	PullRequestNumber int
+	RunURL            string
+}
+
+func (c ReportContext) HasPullRequest() bool {
+	return c.PullRequestNumber > 0
+}
+
+// ReportContextResolver resolves GitHub reporting metadata from environment and event payload.
+type ReportContextResolver struct {
+	Getenv   func(string) string
+	ReadFile func(string) ([]byte, error)
+}
+
+func NewReportContextResolver() ReportContextResolver {
+	return ReportContextResolver{
+		Getenv:   os.Getenv,
+		ReadFile: os.ReadFile,
+	}
+}
+
+func (r ReportContextResolver) Resolve() (ReportContext, error) {
+	if r.Getenv == nil {
+		r.Getenv = os.Getenv
+	}
+	if r.ReadFile == nil {
+		r.ReadFile = os.ReadFile
+	}
+
+	ctx := ReportContext{
+		EventName:  strings.TrimSpace(r.Getenv("GITHUB_EVENT_NAME")),
+		Repository: strings.TrimSpace(r.Getenv("GITHUB_REPOSITORY")),
+	}
+	ctx.RepositoryOwner, ctx.RepositoryName = splitRepository(ctx.Repository)
+	ctx.RunURL = buildRunURL(
+		r.Getenv("GITHUB_SERVER_URL"),
+		ctx.Repository,
+		r.Getenv("GITHUB_RUN_ID"),
+	)
+
+	switch ctx.EventName {
+	case "pull_request", "pull_request_target":
+		number, err := r.resolvePullRequestNumber()
+		if err != nil {
+			return ReportContext{}, err
+		}
+		ctx.PullRequestNumber = number
+	case "":
+		return ReportContext{}, fmt.Errorf("GITHUB_EVENT_NAME is required")
+	}
+
+	return ctx, nil
+}
+
+func (r ReportContextResolver) resolvePullRequestNumber() (int, error) {
+	eventPath := strings.TrimSpace(r.Getenv("GITHUB_EVENT_PATH"))
+	if eventPath == "" {
+		return 0, fmt.Errorf("GITHUB_EVENT_PATH is required for %s events", strings.TrimSpace(r.Getenv("GITHUB_EVENT_NAME")))
+	}
+
+	body, err := r.ReadFile(eventPath)
+	if err != nil {
+		return 0, fmt.Errorf("read GitHub event payload %q: %w", eventPath, err)
+	}
+
+	var payload struct {
+		Number int `json:"number"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return 0, fmt.Errorf("parse GitHub event payload %q: %w", eventPath, err)
+	}
+	if payload.Number <= 0 {
+		return 0, fmt.Errorf("pull request number is required for %s events", strings.TrimSpace(r.Getenv("GITHUB_EVENT_NAME")))
+	}
+	return payload.Number, nil
+}
+
+func splitRepository(repository string) (string, string) {
+	parts := strings.SplitN(strings.TrimSpace(repository), "/", 2)
+	if len(parts) != 2 {
+		return "", ""
+	}
+	return parts[0], parts[1]
+}
+
+func buildRunURL(serverURL, repository, runID string) string {
+	serverURL = strings.TrimSpace(serverURL)
+	repository = strings.TrimSpace(repository)
+	runID = strings.TrimSpace(runID)
+	if serverURL == "" {
+		serverURL = "https://github.com"
+	}
+	if repository == "" || runID == "" {
+		return ""
+	}
+	if _, err := strconv.ParseInt(runID, 10, 64); err != nil {
+		return ""
+	}
+	return strings.TrimRight(serverURL, "/") + "/" + repository + "/actions/runs/" + runID
+}

--- a/internal/github/context_test.go
+++ b/internal/github/context_test.go
@@ -1,0 +1,82 @@
+package github
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReportContextResolverResolvePullRequest(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	eventPath := filepath.Join(dir, "event.json")
+	if err := os.WriteFile(eventPath, []byte(`{"number":17}`), 0o644); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+
+	ctx, err := ReportContextResolver{
+		Getenv: envMap(map[string]string{
+			"GITHUB_EVENT_NAME": "pull_request",
+			"GITHUB_EVENT_PATH": eventPath,
+			"GITHUB_REPOSITORY": "shotomorisk/kgh",
+			"GITHUB_SERVER_URL": "https://github.example.com",
+			"GITHUB_RUN_ID":     "42",
+		}),
+		ReadFile: os.ReadFile,
+	}.Resolve()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if ctx.PullRequestNumber != 17 {
+		t.Fatalf("unexpected pull request number %d", ctx.PullRequestNumber)
+	}
+	if ctx.RepositoryOwner != "shotomorisk" || ctx.RepositoryName != "kgh" {
+		t.Fatalf("unexpected repository split %+v", ctx)
+	}
+	if ctx.RunURL != "https://github.example.com/shotomorisk/kgh/actions/runs/42" {
+		t.Fatalf("unexpected run url %q", ctx.RunURL)
+	}
+}
+
+func TestReportContextResolverResolveNonPullRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx, err := ReportContextResolver{
+		Getenv: envMap(map[string]string{
+			"GITHUB_EVENT_NAME": "push",
+			"GITHUB_REPOSITORY": "shotomorisk/kgh",
+		}),
+		ReadFile: os.ReadFile,
+	}.Resolve()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if ctx.HasPullRequest() {
+		t.Fatalf("expected no pull request context, got %+v", ctx)
+	}
+}
+
+func TestReportContextResolverRejectsMissingPullRequestNumber(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	eventPath := filepath.Join(dir, "event.json")
+	if err := os.WriteFile(eventPath, []byte(`{"number":0}`), 0o644); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+
+	_, err := ReportContextResolver{
+		Getenv: envMap(map[string]string{
+			"GITHUB_EVENT_NAME": "pull_request",
+			"GITHUB_EVENT_PATH": eventPath,
+		}),
+		ReadFile: os.ReadFile,
+	}.Resolve()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); got != "pull request number is required for pull_request events" {
+		t.Fatalf("unexpected error %q", got)
+	}
+}

--- a/internal/github/context_test.go
+++ b/internal/github/context_test.go
@@ -57,6 +57,48 @@ func TestReportContextResolverResolveNonPullRequest(t *testing.T) {
 	}
 }
 
+func TestReportContextResolverResolveWorkflowDispatchOverride(t *testing.T) {
+	t.Parallel()
+
+	ctx, err := ReportContextResolver{
+		Getenv: envMap(map[string]string{
+			"GITHUB_EVENT_NAME":       "workflow_dispatch",
+			"GITHUB_REPOSITORY":       "shotomorisk/kgh",
+			"KGH_PULL_REQUEST_NUMBER": "17",
+			"GITHUB_SERVER_URL":       "https://github.example.com",
+			"GITHUB_RUN_ID":           "42",
+		}),
+		ReadFile: os.ReadFile,
+	}.Resolve()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if ctx.PullRequestNumber != 17 {
+		t.Fatalf("unexpected pull request number %d", ctx.PullRequestNumber)
+	}
+	if ctx.RunURL != "https://github.example.com/shotomorisk/kgh/actions/runs/42" {
+		t.Fatalf("unexpected run url %q", ctx.RunURL)
+	}
+}
+
+func TestReportContextResolverRejectsInvalidPullRequestOverride(t *testing.T) {
+	t.Parallel()
+
+	_, err := ReportContextResolver{
+		Getenv: envMap(map[string]string{
+			"GITHUB_EVENT_NAME":       "workflow_dispatch",
+			"KGH_PULL_REQUEST_NUMBER": "abc",
+		}),
+		ReadFile: os.ReadFile,
+	}.Resolve()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); got != "KGH_PULL_REQUEST_NUMBER must be a positive integer" {
+		t.Fatalf("unexpected error %q", got)
+	}
+}
+
 func TestReportContextResolverRejectsMissingPullRequestNumber(t *testing.T) {
 	t.Parallel()
 

--- a/internal/github/reporter.go
+++ b/internal/github/reporter.go
@@ -1,0 +1,60 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/shotomorisk/kgh/internal/execution"
+	"github.com/shotomorisk/kgh/internal/reporting"
+)
+
+type commentWriter interface {
+	Write(context.Context, ReportContext, string) error
+}
+
+type reportContextResolver interface {
+	Resolve() (ReportContext, error)
+}
+
+// RunReporter publishes execution results to GitHub-facing surfaces.
+type RunReporter struct {
+	SummaryWriter   SummaryWriter
+	ContextResolver reportContextResolver
+	CommentWriter   commentWriter
+}
+
+func NewRunReporter() RunReporter {
+	return RunReporter{
+		SummaryWriter:   NewSummaryWriter(),
+		ContextResolver: NewReportContextResolver(),
+		CommentWriter:   NewPRCommentWriter(),
+	}
+}
+
+func (r RunReporter) WriteExecutionReport(ctx context.Context, result execution.Result) error {
+	var errs []error
+
+	if err := r.SummaryWriter.WriteExecutionSummary(result); err != nil {
+		errs = append(errs, fmt.Errorf("write GitHub summary: %w", err))
+	}
+
+	reportCtx, err := r.ContextResolver.Resolve()
+	if err != nil {
+		if len(errs) == 0 {
+			return fmt.Errorf("resolve GitHub reporting context: %w", err)
+		}
+		errs = append(errs, fmt.Errorf("resolve GitHub reporting context: %w", err))
+		return errors.Join(errs...)
+	}
+	if !reportCtx.HasPullRequest() {
+		return errors.Join(errs...)
+	}
+
+	if err := r.CommentWriter.Write(ctx, reportCtx, reporting.RenderGitHubPRComment(result, reporting.GitHubCommentOptions{
+		RunURL: reportCtx.RunURL,
+	})); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}

--- a/internal/github/reporter_test.go
+++ b/internal/github/reporter_test.go
@@ -1,0 +1,123 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/shotomorisk/kgh/internal/execution"
+	"github.com/shotomorisk/kgh/internal/spec"
+)
+
+type fakeCommentWriter struct {
+	calls int
+	body  string
+	err   error
+}
+
+type fakeReportContextResolver struct {
+	ctx ReportContext
+	err error
+}
+
+func (f *fakeCommentWriter) Write(_ context.Context, _ ReportContext, body string) error {
+	f.calls++
+	f.body = body
+	return f.err
+}
+
+func (f fakeReportContextResolver) Resolve() (ReportContext, error) {
+	return f.ctx, f.err
+}
+
+func TestRunReporterWritesPullRequestComment(t *testing.T) {
+	t.Parallel()
+
+	commentWriter := &fakeCommentWriter{}
+	reporter := RunReporter{
+		SummaryWriter: SummaryWriter{
+			Getenv: func(string) string { return "" },
+		},
+		ContextResolver: fakeReportContextResolver{
+			ctx: ReportContext{
+				PullRequestNumber: 17,
+				RunURL:            "https://github.com/shotomorisk/kgh/actions/runs/42",
+			},
+		},
+		CommentWriter: commentWriter,
+	}
+
+	err := reporter.WriteExecutionReport(context.Background(), execution.Result{
+		Execution: spec.ExecutionSpec{
+			TargetName:  "exp142",
+			Notebook:    "notebooks/exp142.ipynb",
+			KernelID:    "yourname/exp142",
+			KernelRef:   "yourname/exp142",
+			Competition: "playground-series-s6e2",
+			Submit:      true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if commentWriter.calls != 1 {
+		t.Fatalf("expected 1 comment write, got %d", commentWriter.calls)
+	}
+	if !strings.Contains(commentWriter.body, commentMarker) {
+		t.Fatalf("expected comment marker, got %q", commentWriter.body)
+	}
+	if !strings.Contains(commentWriter.body, "[workflow run](https://github.com/shotomorisk/kgh/actions/runs/42)") {
+		t.Fatalf("expected run URL in body, got %q", commentWriter.body)
+	}
+}
+
+func TestRunReporterSkipsCommentOutsidePullRequest(t *testing.T) {
+	t.Parallel()
+
+	commentWriter := &fakeCommentWriter{}
+	reporter := RunReporter{
+		SummaryWriter: SummaryWriter{
+			Getenv: func(string) string { return "" },
+		},
+		ContextResolver: fakeReportContextResolver{
+			ctx: ReportContext{EventName: "push"},
+		},
+		CommentWriter: commentWriter,
+	}
+
+	err := reporter.WriteExecutionReport(context.Background(), execution.Result{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if commentWriter.calls != 0 {
+		t.Fatalf("expected no comment writes, got %d", commentWriter.calls)
+	}
+}
+
+func TestRunReporterAggregatesErrors(t *testing.T) {
+	t.Parallel()
+
+	reporter := RunReporter{
+		SummaryWriter: SummaryWriter{
+			Getenv:     func(string) string { return "/tmp/summary" },
+			AppendFile: func(string, []byte) error { return errors.New("disk full") },
+		},
+		ContextResolver: fakeReportContextResolver{
+			err: fmt.Errorf("bad event payload"),
+		},
+		CommentWriter: &fakeCommentWriter{},
+	}
+
+	err := reporter.WriteExecutionReport(context.Background(), execution.Result{})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "write GitHub summary: disk full") {
+		t.Fatalf("expected summary error, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "resolve GitHub reporting context: bad event payload") {
+		t.Fatalf("expected context error, got %q", err.Error())
+	}
+}

--- a/internal/github/trigger.go
+++ b/internal/github/trigger.go
@@ -96,6 +96,12 @@ func (r TriggerResolver) resolveSHA(eventName string) (string, error) {
 			return "", fmt.Errorf("pull_request.head.sha is required for %s events", eventName)
 		}
 		return sha, nil
+	case "workflow_dispatch":
+		sha := strings.TrimSpace(r.Getenv("KGH_TRIGGER_SHA"))
+		if sha == "" {
+			return "", fmt.Errorf("KGH_TRIGGER_SHA is required for workflow_dispatch events")
+		}
+		return sha, nil
 	default:
 		return "", fmt.Errorf("unsupported GitHub event %q", eventName)
 	}

--- a/internal/github/trigger_test.go
+++ b/internal/github/trigger_test.go
@@ -85,7 +85,40 @@ func TestTriggerResolverResolvePullRequestEvent(t *testing.T) {
 	}
 }
 
-func TestTriggerResolverRejectsUnsupportedEvent(t *testing.T) {
+func TestTriggerResolverResolveWorkflowDispatchEvent(t *testing.T) {
+	t.Parallel()
+
+	resolver := TriggerResolver{
+		Getenv: envMap(map[string]string{
+			"GITHUB_EVENT_NAME": "workflow_dispatch",
+			"GITHUB_WORKSPACE":  "/tmp/workspace",
+			"KGH_TRIGGER_SHA":   "feedface",
+		}),
+		ReadFile: os.ReadFile,
+		Runner: fakeRunner{run: func(_ context.Context, cmd execx.Command, opts execx.Options) (execx.Result, error) {
+			if got := strings.Join(cmd.Args, " "); got != "show -s --format=%B --no-patch feedface" {
+				t.Fatalf("unexpected args %q", got)
+			}
+			if opts.Dir != "/tmp/workspace" {
+				t.Fatalf("unexpected workspace %q", opts.Dir)
+			}
+			return execx.Result{Stdout: "submit: exp142 internet=true\n"}, nil
+		}},
+	}
+
+	trigger, err := resolver.Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if trigger.Target != "exp142" {
+		t.Fatalf("unexpected target %q", trigger.Target)
+	}
+	if trigger.Internet == nil || *trigger.Internet != true {
+		t.Fatalf("expected internet override true, got %+v", trigger.Internet)
+	}
+}
+
+func TestTriggerResolverRejectsMissingWorkflowDispatchSHA(t *testing.T) {
 	t.Parallel()
 
 	_, err := TriggerResolver{
@@ -96,7 +129,23 @@ func TestTriggerResolverRejectsUnsupportedEvent(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error")
 	}
-	if got := err.Error(); !strings.Contains(got, `unsupported GitHub event "workflow_dispatch"`) {
+	if got := err.Error(); !strings.Contains(got, "KGH_TRIGGER_SHA is required for workflow_dispatch events") {
+		t.Fatalf("unexpected error %q", got)
+	}
+}
+
+func TestTriggerResolverRejectsUnsupportedEvent(t *testing.T) {
+	t.Parallel()
+
+	_, err := TriggerResolver{
+		Getenv: envMap(map[string]string{
+			"GITHUB_EVENT_NAME": "schedule",
+		}),
+	}.Resolve(context.Background())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); !strings.Contains(got, `unsupported GitHub event "schedule"`) {
 		t.Fatalf("unexpected error %q", got)
 	}
 }

--- a/internal/reporting/github_comment.go
+++ b/internal/reporting/github_comment.go
@@ -1,0 +1,119 @@
+package reporting
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/shotomorisk/kgh/internal/execution"
+)
+
+// GitHubCommentComparison is an optional comparison block for GitHub report surfaces.
+type GitHubCommentComparison struct {
+	Label         string
+	BaselineScore string
+	CurrentScore  string
+	Delta         string
+}
+
+// GitHubCommentOptions configures the GitHub PR comment renderer.
+type GitHubCommentOptions struct {
+	RunURL     string
+	Comparison *GitHubCommentComparison
+}
+
+// RenderGitHubPRComment renders a stable Markdown PR comment for a run result.
+func RenderGitHubPRComment(result execution.Result, opts GitHubCommentOptions) string {
+	var b strings.Builder
+
+	b.WriteString("<!-- kgh:run-report -->\n")
+	b.WriteString("## kgh run report\n")
+	b.WriteString("| Field | Value |\n")
+	b.WriteString("| --- | --- |\n")
+	writeCommentRow(&b, "Target", formatIdentifier(valueOr(result.Execution.TargetName, stateUnavailable)))
+	writeCommentRow(&b, "Run Status", resolveRunStatus(result))
+	writeCommentRow(&b, "Submission Result", resolveSubmissionResult(result))
+	writeCommentRow(&b, "Public Score", resolvePublicScore(result))
+	writeCommentRow(&b, "References", formatCommentReferences(result, opts.RunURL))
+
+	b.WriteString("\n### Resolved Configuration\n")
+	b.WriteString("| Field | Value |\n")
+	b.WriteString("| --- | --- |\n")
+	writeCommentRow(&b, "Notebook", formatIdentifier(valueOr(result.Execution.Notebook, stateUnavailable)))
+	writeCommentRow(&b, "Kernel ID", formatIdentifier(valueOr(result.Execution.KernelID, stateUnavailable)))
+	writeCommentRow(&b, "Kernel Ref", formatIdentifier(valueOr(result.Execution.KernelRef, stateUnavailable)))
+	writeCommentRow(&b, "Competition", formatIdentifier(valueOr(result.Execution.Competition, stateUnavailable)))
+	writeCommentRow(&b, "Submit", strconv.FormatBool(result.Execution.Submit))
+	writeCommentRow(&b, "GPU", strconv.FormatBool(result.Execution.Resources.GPU))
+	writeCommentRow(&b, "Internet", strconv.FormatBool(result.Execution.Resources.Internet))
+	writeCommentRow(&b, "Submission Output", formatIdentifier(valueOr(result.Execution.Outputs.Submission, stateUnavailable)))
+	writeCommentRow(&b, "Metrics Output", formatIdentifier(valueOr(result.Execution.Outputs.Metrics, stateUnavailable)))
+
+	if opts.Comparison != nil {
+		b.WriteString("\n### Comparison\n")
+		b.WriteString("| Field | Value |\n")
+		b.WriteString("| --- | --- |\n")
+		writeCommentRow(&b, "Baseline", formatIdentifier(valueOr(opts.Comparison.Label, stateUnavailable)))
+		writeCommentRow(&b, "Baseline Score", valueOr(strings.TrimSpace(opts.Comparison.BaselineScore), stateUnavailable))
+		writeCommentRow(&b, "Current Score", valueOr(strings.TrimSpace(opts.Comparison.CurrentScore), stateUnavailable))
+		writeCommentRow(&b, "Delta", valueOr(strings.TrimSpace(opts.Comparison.Delta), stateUnavailable))
+	}
+
+	return b.String()
+}
+
+func writeCommentRow(b *strings.Builder, field, value string) {
+	fmt.Fprintf(b, "| %s | %s |\n", escapeMarkdown(field), value)
+}
+
+func resolveSubmissionResult(result execution.Result) string {
+	if result.Mode == execution.ModeDryRun {
+		return stateDryRun
+	}
+	if !result.Execution.Submit {
+		return stateDisabled
+	}
+	if result.Submission == nil {
+		return stateNotSubmitted
+	}
+
+	parts := make([]string, 0, 3)
+	switch {
+	case result.Submission.Submitted:
+		parts = append(parts, "submitted")
+	case result.Submission.Attempted:
+		parts = append(parts, "attempted")
+	default:
+		parts = append(parts, stateNotSubmitted)
+	}
+	if status := strings.TrimSpace(result.Submission.Status); status != "" {
+		parts = append(parts, "status: "+escapeMarkdown(status))
+	}
+	if submissionID := strings.TrimSpace(result.Submission.SubmissionID); submissionID != "" {
+		parts = append(parts, "id: "+formatIdentifier(submissionID))
+	}
+	if message := strings.TrimSpace(result.Submission.Message); message != "" {
+		parts = append(parts, "message: "+escapeMarkdown(message))
+	}
+	return strings.Join(parts, "<br>")
+}
+
+func formatCommentReferences(result execution.Result, runURL string) string {
+	parts := make([]string, 0, 4)
+	if kernelRef := strings.TrimSpace(resolveKernelRef(result)); kernelRef != "" {
+		parts = append(parts, fmt.Sprintf("kernel: %s", formatIdentifier(kernelRef)))
+	}
+	if submissionID := strings.TrimSpace(resolveSubmissionID(result)); submissionID != "" {
+		parts = append(parts, fmt.Sprintf("submission: %s", formatIdentifier(submissionID)))
+	}
+	if competition := strings.TrimSpace(result.Execution.Competition); competition != "" {
+		parts = append(parts, fmt.Sprintf("competition: %s", formatIdentifier(competition)))
+	}
+	if runURL = strings.TrimSpace(runURL); runURL != "" {
+		parts = append(parts, fmt.Sprintf("[workflow run](%s)", escapeMarkdown(runURL)))
+	}
+	if len(parts) == 0 {
+		return stateUnavailable
+	}
+	return strings.Join(parts, "<br>")
+}

--- a/internal/reporting/github_summary_test.go
+++ b/internal/reporting/github_summary_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shotomorisk/kgh/internal/config"
 	"github.com/shotomorisk/kgh/internal/execution"
 	"github.com/shotomorisk/kgh/internal/kaggle"
 	"github.com/shotomorisk/kgh/internal/spec"
@@ -78,6 +79,43 @@ func TestRenderGitHubSummaryLiveSuccess(t *testing.T) {
 	assertContains(t, got, "| Submit Status | submitted |")
 	assertContains(t, got, "| Public Score | 0.12345 |")
 	assertContains(t, got, "submission: `123`")
+}
+
+func TestRenderGitHubPRComment(t *testing.T) {
+	t.Parallel()
+
+	got := RenderGitHubPRComment(execution.Result{
+		Execution: spec.ExecutionSpec{
+			TargetName:  "exp142",
+			Notebook:    "notebooks/exp142.ipynb",
+			KernelID:    "yourname/exp142",
+			KernelRef:   "yourname/exp142",
+			Competition: "playground-series-s6e2",
+			Submit:      true,
+			Resources: config.Resources{
+				GPU:      true,
+				Internet: false,
+			},
+		},
+		Submission: &execution.SubmissionResult{
+			Submitted:    true,
+			SubmissionID: "123",
+			Status:       "complete",
+		},
+		Score: &execution.ScoreResult{
+			State:       execution.ScoreStateReady,
+			PublicScore: "0.12345",
+		},
+	}, GitHubCommentOptions{
+		RunURL: "https://github.com/shotomorisk/kgh/actions/runs/42",
+	})
+
+	assertContains(t, got, "<!-- kgh:run-report -->")
+	assertContains(t, got, "## kgh run report")
+	assertContains(t, got, "| Submission Result | submitted<br>status: complete<br>id: `123` |")
+	assertContains(t, got, "### Resolved Configuration")
+	assertContains(t, got, "| Kernel Ref | `yourname/exp142` |")
+	assertContains(t, got, "[workflow run](https://github.com/shotomorisk/kgh/actions/runs/42)")
 }
 
 func TestRenderGitHubSummaryPendingScore(t *testing.T) {


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #67 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented the GitHub reporting layer for kgh github run. cmd/kgh now calls a combined reporter that writes the Actions summary and, when the event is a PR, upserts a single marker-based bot comment via the GitHub REST API. The new reporting code resolves PR/run context from GitHub env + event payload, renders a stable PR comment with target/config/run/submission/score details, skips comment publication outside PR context, and soft-fails reporting errors so execution results still surface normally. 

The workflow now also requests issues: write so comment upsert can succeed in CI. The main changes are in cmd/kgh/main.go, internal/github/reporter.go, internal/github/comment.go, internal/ github/context.go, and internal/reporting/github_comment.go. I added tests for the new context resolver, PR comment upsert path, renderer output, and command integration.

<!-- close -->