### PR TITLE
Wire summary writing into the GitHub CLI path

### DIFF
--- a/cmd/kgh/main.go
+++ b/cmd/kgh/main.go
@@ -154,8 +154,8 @@ func executeRequest(ctx context.Context, req execution.Request, stdout, stderr i
 		return 1, err
 	}
 	if writeSummary {
-		if err := newGitHubSummaryWriter().WriteExecutionSummary(report); err != nil && stderr != nil {
-			fmt.Fprintf(stderr, "write GitHub summary: %v\n", err)
+		if err := newGitHubSummaryWriter().WriteExecutionSummary(report); err != nil {
+			return 1, fmt.Errorf("write GitHub summary: %w", err)
 		}
 	}
 	return 0, nil

--- a/cmd/kgh/main.go
+++ b/cmd/kgh/main.go
@@ -26,12 +26,12 @@ var newRunner = func(adapter execution.Adapter) executionRunner {
 	return execution.NewRunner(adapter)
 }
 
-type githubExecutionReporter interface {
-	WriteExecutionReport(context.Context, execution.Result) error
+type githubExecutionSummaryWriter interface {
+	WriteExecutionSummary(execution.Result) error
 }
 
-var newGitHubReporter = func() githubExecutionReporter {
-	return ghctx.NewRunReporter()
+var newGitHubSummaryWriter = func() githubExecutionSummaryWriter {
+	return ghctx.NewSummaryWriter()
 }
 
 func main() {
@@ -154,8 +154,8 @@ func executeRequest(ctx context.Context, req execution.Request, stdout, stderr i
 		return 1, err
 	}
 	if writeSummary {
-		if err := newGitHubReporter().WriteExecutionReport(ctx, report); err != nil && stderr != nil {
-			fmt.Fprintf(stderr, "%v\n", err)
+		if err := newGitHubSummaryWriter().WriteExecutionSummary(report); err != nil {
+			return 1, fmt.Errorf("write GitHub summary: %w", err)
 		}
 	}
 	return 0, nil

--- a/cmd/kgh/main_test.go
+++ b/cmd/kgh/main_test.go
@@ -79,7 +79,7 @@ func TestExecuteRequestWritesJSONAndGitHubSummary(t *testing.T) {
 	}
 }
 
-func TestExecuteRequestSummaryWriteFailureIsNonFatal(t *testing.T) {
+func TestExecuteRequestSummaryWriteFailureIsFatalAfterJSON(t *testing.T) {
 	originalNewRunner := newRunner
 	originalSummaryWriter := newGitHubSummaryWriter
 	t.Cleanup(func() {
@@ -102,17 +102,20 @@ func TestExecuteRequestSummaryWriteFailureIsNonFatal(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	code, err := executeRequest(context.Background(), execution.Request{Target: "exp142", DryRun: true}, &stdout, &stderr, true)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	if err == nil {
+		t.Fatal("expected an error")
 	}
-	if code != 0 {
-		t.Fatalf("expected exit code 0, got %d", code)
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
 	}
-	if !strings.Contains(stderr.String(), "write GitHub summary: disk full") {
-		t.Fatalf("expected summary warning on stderr, got %q", stderr.String())
+	if !strings.Contains(err.Error(), "write GitHub summary: disk full") {
+		t.Fatalf("expected wrapped summary error, got %q", err.Error())
 	}
 	if stdout.Len() == 0 {
 		t.Fatal("expected stdout JSON to still be written")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected executeRequest not to write stderr directly, got %q", stderr.String())
 	}
 }
 
@@ -151,5 +154,39 @@ func TestExecuteRequestSkipsSummaryWhenDisabled(t *testing.T) {
 	}
 	if _, err := os.Stat(summaryPath); !os.IsNotExist(err) {
 		t.Fatalf("expected no summary file, stat err=%v", err)
+	}
+}
+
+func TestExecuteRequestIgnoresMissingGitHubStepSummaryEnv(t *testing.T) {
+	originalNewRunner := newRunner
+	t.Cleanup(func() {
+		newRunner = originalNewRunner
+	})
+
+	newRunner = func(execution.Adapter) executionRunner {
+		return fakeExecutionRunner{
+			result: execution.Result{
+				Mode:      execution.ModeDryRun,
+				Execution: spec.ExecutionSpec{TargetName: "exp142"},
+			},
+		}
+	}
+
+	t.Setenv("GITHUB_STEP_SUMMARY", "")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code, err := executeRequest(context.Background(), execution.Request{Target: "exp142", DryRun: true}, &stdout, &stderr, true)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if !strings.Contains(stdout.String(), `"target_name": "exp142"`) {
+		t.Fatalf("expected stdout JSON target, got %s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
 	}
 }

--- a/cmd/kgh/main_test.go
+++ b/cmd/kgh/main_test.go
@@ -22,19 +22,11 @@ type fakeSummaryWriter struct {
 	err error
 }
 
-type fakeGitHubReporter struct {
-	err error
-}
-
 func (f fakeExecutionRunner) Execute(context.Context, execution.Request) (execution.Result, error) {
 	return f.result, f.err
 }
 
 func (f fakeSummaryWriter) WriteExecutionSummary(execution.Result) error {
-	return f.err
-}
-
-func (f fakeGitHubReporter) WriteExecutionReport(context.Context, execution.Result) error {
 	return f.err
 }
 
@@ -90,10 +82,10 @@ func TestExecuteRequestWritesJSONAndGitHubSummary(t *testing.T) {
 
 func TestExecuteRequestSummaryWriteFailureIsFatalAfterJSON(t *testing.T) {
 	originalNewRunner := newRunner
-	originalReporter := newGitHubReporter
+	originalSummaryWriter := newGitHubSummaryWriter
 	t.Cleanup(func() {
 		newRunner = originalNewRunner
-		newGitHubReporter = originalReporter
+		newGitHubSummaryWriter = originalSummaryWriter
 	})
 
 	newRunner = func(execution.Adapter) executionRunner {
@@ -104,8 +96,8 @@ func TestExecuteRequestSummaryWriteFailureIsFatalAfterJSON(t *testing.T) {
 			},
 		}
 	}
-	newGitHubReporter = func() githubExecutionReporter {
-		return fakeGitHubReporter{err: errors.New("write GitHub summary: disk full")}
+	newGitHubSummaryWriter = func() githubExecutionSummaryWriter {
+		return fakeSummaryWriter{err: errors.New("disk full")}
 	}
 
 	var stdout bytes.Buffer
@@ -117,8 +109,8 @@ func TestExecuteRequestSummaryWriteFailureIsFatalAfterJSON(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
 	}
-	if !strings.Contains(stderr.String(), "write GitHub summary: disk full") {
-		t.Fatalf("expected reporting warning on stderr, got %q", stderr.String())
+	if !strings.Contains(err.Error(), "write GitHub summary: disk full") {
+		t.Fatalf("expected wrapped summary error, got %q", err.Error())
 	}
 	if stdout.Len() == 0 {
 		t.Fatal("expected stdout JSON to still be written")
@@ -130,10 +122,10 @@ func TestExecuteRequestSummaryWriteFailureIsFatalAfterJSON(t *testing.T) {
 
 func TestExecuteRequestSkipsSummaryWhenDisabled(t *testing.T) {
 	originalNewRunner := newRunner
-	originalReporter := newGitHubReporter
+	originalSummaryWriter := newGitHubSummaryWriter
 	t.Cleanup(func() {
 		newRunner = originalNewRunner
-		newGitHubReporter = originalReporter
+		newGitHubSummaryWriter = originalSummaryWriter
 	})
 
 	newRunner = func(execution.Adapter) executionRunner {
@@ -144,8 +136,8 @@ func TestExecuteRequestSkipsSummaryWhenDisabled(t *testing.T) {
 			},
 		}
 	}
-	newGitHubReporter = func() githubExecutionReporter {
-		return fakeGitHubReporter{err: errors.New("should not be called")}
+	newGitHubSummaryWriter = func() githubExecutionSummaryWriter {
+		return fakeSummaryWriter{err: errors.New("should not be called")}
 	}
 
 	dir := t.TempDir()


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #95 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
kgh github run now treats step-summary write failures as fatal while still emitting the normal JSON payload first. The change is in cmd/kgh/main.go: after writing stdout JSON, executeRequest now returns 1 with write GitHub summary: ... if GITHUB_STEP_SUMMARY writing fails, instead of printing a warning and continuing. 

I updated cmd/kgh/main_test.go to lock in the new contract: success still writes JSON plus summary, missing GITHUB_STEP_SUMMARY is still a clean no-op, and summary write failures now return an error while preserving stdout JSON.

<!-- close -->