### PR TITLE
Github summary upsert comments

### DIFF
--- a/cmd/kgh/main.go
+++ b/cmd/kgh/main.go
@@ -26,12 +26,12 @@ var newRunner = func(adapter execution.Adapter) executionRunner {
 	return execution.NewRunner(adapter)
 }
 
-type githubExecutionSummaryWriter interface {
-	WriteExecutionSummary(execution.Result) error
+type githubExecutionReporter interface {
+	WriteExecutionReport(context.Context, execution.Result) error
 }
 
-var newGitHubSummaryWriter = func() githubExecutionSummaryWriter {
-	return ghctx.NewSummaryWriter()
+var newGitHubReporter = func() githubExecutionReporter {
+	return ghctx.NewRunReporter()
 }
 
 func main() {
@@ -138,7 +138,7 @@ func githubCommand(ctx context.Context, args []string, stdout, stderr io.Writer)
 	return executeRequest(ctx, requestFromTrigger(trigger, flags.sharedRunFlags), stdout, stderr, true)
 }
 
-func executeRequest(ctx context.Context, req execution.Request, stdout, stderr io.Writer, writeSummary bool) (int, error) {
+func executeRequest(ctx context.Context, req execution.Request, stdout, stderr io.Writer, writeGitHubReport bool) (int, error) {
 	runner := newRunner(nil)
 	report, err := runner.Execute(ctx, req)
 	if err != nil {
@@ -153,9 +153,9 @@ func executeRequest(ctx context.Context, req execution.Request, stdout, stderr i
 	if _, err := stdout.Write(append(payload, '\n')); err != nil {
 		return 1, err
 	}
-	if writeSummary {
-		if err := newGitHubSummaryWriter().WriteExecutionSummary(report); err != nil {
-			return 1, fmt.Errorf("write GitHub summary: %w", err)
+	if writeGitHubReport {
+		if err := newGitHubReporter().WriteExecutionReport(ctx, report); err != nil {
+			return 1, fmt.Errorf("write GitHub report: %w", err)
 		}
 	}
 	return 0, nil

--- a/cmd/kgh/main.go
+++ b/cmd/kgh/main.go
@@ -27,9 +27,7 @@ var newRunner = func(adapter execution.Adapter) executionRunner {
 }
 
 type githubExecutionReporter interface {
-	WriteExecutionReport(context.Context, execution.Result) error
-type githubExecutionSummaryWriter interface {
-	WriteExecutionSummary(execution.Result, *execution.FailureSummary) error
+	WriteExecutionReport(context.Context, execution.Result, *execution.FailureSummary) error
 }
 
 var newGitHubReporter = func() githubExecutionReporter {
@@ -161,9 +159,9 @@ func executeRequest(ctx context.Context, req execution.Request, stdout, stderr i
 	if _, err := stdout.Write(append(payload, '\n')); err != nil {
 		return 1, err
 	}
-	if writeSummary {
-		if err := newGitHubSummaryWriter().WriteExecutionSummary(report, failure); err != nil {
-			return 1, fmt.Errorf("write GitHub summary: %w", err)
+	if writeGitHubReport {
+		if err := newGitHubReporter().WriteExecutionReport(ctx, report, failure); err != nil {
+			return 1, fmt.Errorf("write GitHub report: %w", err)
 		}
 	}
 	if execErr != nil {

--- a/cmd/kgh/main_test.go
+++ b/cmd/kgh/main_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -18,22 +16,26 @@ type fakeExecutionRunner struct {
 	err    error
 }
 
-type fakeSummaryWriter struct {
-	err error
+type fakeGitHubReporter struct {
+	calls int
+	err   error
 }
 
 func (f fakeExecutionRunner) Execute(context.Context, execution.Request) (execution.Result, error) {
 	return f.result, f.err
 }
 
-func (f fakeSummaryWriter) WriteExecutionSummary(execution.Result) error {
+func (f *fakeGitHubReporter) WriteExecutionReport(context.Context, execution.Result) error {
+	f.calls++
 	return f.err
 }
 
-func TestExecuteRequestWritesJSONAndGitHubSummary(t *testing.T) {
+func TestExecuteRequestWritesJSONAndGitHubReport(t *testing.T) {
 	originalNewRunner := newRunner
+	originalGitHubReporter := newGitHubReporter
 	t.Cleanup(func() {
 		newRunner = originalNewRunner
+		newGitHubReporter = originalGitHubReporter
 	})
 
 	newRunner = func(execution.Adapter) executionRunner {
@@ -49,11 +51,10 @@ func TestExecuteRequestWritesJSONAndGitHubSummary(t *testing.T) {
 			},
 		}
 	}
-	dir := t.TempDir()
-	summaryPath := filepath.Join(dir, "summary.md")
-	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
-	t.Setenv("GITHUB_EVENT_NAME", "push")
-	t.Setenv("GITHUB_REPOSITORY", "shotomorisk/kgh")
+	reporter := &fakeGitHubReporter{}
+	newGitHubReporter = func() githubExecutionReporter {
+		return reporter
+	}
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -70,22 +71,17 @@ func TestExecuteRequestWritesJSONAndGitHubSummary(t *testing.T) {
 	if !strings.Contains(stdout.String(), `"target_name": "exp142"`) {
 		t.Fatalf("expected stdout JSON target, got %s", stdout.String())
 	}
-
-	body, err := os.ReadFile(summaryPath)
-	if err != nil {
-		t.Fatalf("read summary file: %v", err)
-	}
-	if !strings.Contains(string(body), "| Target | `exp142` |") {
-		t.Fatalf("unexpected summary body:\n%s", string(body))
+	if reporter.calls != 1 {
+		t.Fatalf("expected 1 GitHub report write, got %d", reporter.calls)
 	}
 }
 
-func TestExecuteRequestSummaryWriteFailureIsFatalAfterJSON(t *testing.T) {
+func TestExecuteRequestGitHubReportFailureIsFatalAfterJSON(t *testing.T) {
 	originalNewRunner := newRunner
-	originalSummaryWriter := newGitHubSummaryWriter
+	originalGitHubReporter := newGitHubReporter
 	t.Cleanup(func() {
 		newRunner = originalNewRunner
-		newGitHubSummaryWriter = originalSummaryWriter
+		newGitHubReporter = originalGitHubReporter
 	})
 
 	newRunner = func(execution.Adapter) executionRunner {
@@ -96,8 +92,8 @@ func TestExecuteRequestSummaryWriteFailureIsFatalAfterJSON(t *testing.T) {
 			},
 		}
 	}
-	newGitHubSummaryWriter = func() githubExecutionSummaryWriter {
-		return fakeSummaryWriter{err: errors.New("disk full")}
+	newGitHubReporter = func() githubExecutionReporter {
+		return &fakeGitHubReporter{err: errors.New("disk full")}
 	}
 
 	var stdout bytes.Buffer
@@ -109,8 +105,8 @@ func TestExecuteRequestSummaryWriteFailureIsFatalAfterJSON(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
 	}
-	if !strings.Contains(err.Error(), "write GitHub summary: disk full") {
-		t.Fatalf("expected wrapped summary error, got %q", err.Error())
+	if !strings.Contains(err.Error(), "write GitHub report: disk full") {
+		t.Fatalf("expected wrapped report error, got %q", err.Error())
 	}
 	if stdout.Len() == 0 {
 		t.Fatal("expected stdout JSON to still be written")
@@ -120,12 +116,12 @@ func TestExecuteRequestSummaryWriteFailureIsFatalAfterJSON(t *testing.T) {
 	}
 }
 
-func TestExecuteRequestSkipsSummaryWhenDisabled(t *testing.T) {
+func TestExecuteRequestSkipsGitHubReportWhenDisabled(t *testing.T) {
 	originalNewRunner := newRunner
-	originalSummaryWriter := newGitHubSummaryWriter
+	originalGitHubReporter := newGitHubReporter
 	t.Cleanup(func() {
 		newRunner = originalNewRunner
-		newGitHubSummaryWriter = originalSummaryWriter
+		newGitHubReporter = originalGitHubReporter
 	})
 
 	newRunner = func(execution.Adapter) executionRunner {
@@ -136,13 +132,9 @@ func TestExecuteRequestSkipsSummaryWhenDisabled(t *testing.T) {
 			},
 		}
 	}
-	newGitHubSummaryWriter = func() githubExecutionSummaryWriter {
-		return fakeSummaryWriter{err: errors.New("should not be called")}
+	newGitHubReporter = func() githubExecutionReporter {
+		return &fakeGitHubReporter{err: errors.New("should not be called")}
 	}
-
-	dir := t.TempDir()
-	summaryPath := filepath.Join(dir, "summary.md")
-	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -153,15 +145,14 @@ func TestExecuteRequestSkipsSummaryWhenDisabled(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("expected exit code 0, got %d", code)
 	}
-	if _, err := os.Stat(summaryPath); !os.IsNotExist(err) {
-		t.Fatalf("expected no summary file, stat err=%v", err)
-	}
 }
 
 func TestExecuteRequestIgnoresMissingGitHubStepSummaryEnv(t *testing.T) {
 	originalNewRunner := newRunner
+	originalGitHubReporter := newGitHubReporter
 	t.Cleanup(func() {
 		newRunner = originalNewRunner
+		newGitHubReporter = originalGitHubReporter
 	})
 
 	newRunner = func(execution.Adapter) executionRunner {
@@ -173,7 +164,10 @@ func TestExecuteRequestIgnoresMissingGitHubStepSummaryEnv(t *testing.T) {
 		}
 	}
 
-	t.Setenv("GITHUB_STEP_SUMMARY", "")
+	reporter := &fakeGitHubReporter{}
+	newGitHubReporter = func() githubExecutionReporter {
+		return reporter
+	}
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -186,6 +180,9 @@ func TestExecuteRequestIgnoresMissingGitHubStepSummaryEnv(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), `"target_name": "exp142"`) {
 		t.Fatalf("expected stdout JSON target, got %s", stdout.String())
+	}
+	if reporter.calls != 1 {
+		t.Fatalf("expected 1 GitHub report write, got %d", reporter.calls)
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())

--- a/cmd/kgh/main_test.go
+++ b/cmd/kgh/main_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -25,7 +27,8 @@ func (f fakeExecutionRunner) Execute(context.Context, execution.Request) (execut
 	return f.result, f.err
 }
 
-func (f fakeSummaryWriter) WriteExecutionSummary(execution.Result, *execution.FailureSummary) error {
+func (f *fakeGitHubReporter) WriteExecutionReport(context.Context, execution.Result, *execution.FailureSummary) error {
+	f.calls++
 	return f.err
 }
 
@@ -117,8 +120,10 @@ func TestExecuteRequestGitHubReportFailureIsFatalAfterJSON(t *testing.T) {
 
 func TestExecuteRequestWritesGitHubSummaryOnExecutionFailure(t *testing.T) {
 	originalNewRunner := newRunner
+	originalGitHubReporter := newGitHubReporter
 	t.Cleanup(func() {
 		newRunner = originalNewRunner
+		newGitHubReporter = originalGitHubReporter
 	})
 
 	newRunner = func(execution.Adapter) executionRunner {
@@ -157,6 +162,7 @@ func TestExecuteRequestWritesGitHubSummaryOnExecutionFailure(t *testing.T) {
 	dir := t.TempDir()
 	summaryPath := filepath.Join(dir, "summary.md")
 	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+	t.Setenv("GITHUB_EVENT_NAME", "workflow_dispatch")
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/github/comment.go
+++ b/internal/github/comment.go
@@ -12,6 +12,7 @@ import (
 )
 
 const commentMarker = "<!-- kgh:run-report -->"
+const commentsPageSize = 100
 
 type httpDoer interface {
 	Do(*http.Request) (*http.Response, error)
@@ -60,27 +61,31 @@ func (w PRCommentWriter) Write(ctx context.Context, reportCtx ReportContext, bod
 }
 
 func (w PRCommentWriter) findExistingCommentID(ctx context.Context, reportCtx ReportContext, token string) (int64, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, w.apiURL()+"/repos/"+reportCtx.RepositoryOwner+"/"+reportCtx.RepositoryName+"/issues/"+fmt.Sprintf("%d", reportCtx.PullRequestNumber)+"/comments", nil)
-	if err != nil {
-		return 0, err
-	}
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	for page := 1; ; page++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, w.apiURL()+"/repos/"+reportCtx.RepositoryOwner+"/"+reportCtx.RepositoryName+"/issues/"+fmt.Sprintf("%d", reportCtx.PullRequestNumber)+"/comments?per_page="+fmt.Sprintf("%d", commentsPageSize)+"&page="+fmt.Sprintf("%d", page), nil)
+		if err != nil {
+			return 0, err
+		}
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 
-	var comments []struct {
-		ID   int64  `json:"id"`
-		Body string `json:"body"`
-	}
-	if err := w.doJSON(req, &comments); err != nil {
-		return 0, err
-	}
-	for _, comment := range comments {
-		if strings.Contains(comment.Body, commentMarker) {
-			return comment.ID, nil
+		var comments []struct {
+			ID   int64  `json:"id"`
+			Body string `json:"body"`
+		}
+		if err := w.doJSON(req, &comments); err != nil {
+			return 0, err
+		}
+		for _, comment := range comments {
+			if strings.Contains(comment.Body, commentMarker) {
+				return comment.ID, nil
+			}
+		}
+		if len(comments) < commentsPageSize {
+			return 0, nil
 		}
 	}
-	return 0, nil
 }
 
 func (w PRCommentWriter) createComment(ctx context.Context, reportCtx ReportContext, token, body string) error {

--- a/internal/github/comment_test.go
+++ b/internal/github/comment_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -92,6 +94,72 @@ func TestPRCommentWriterUpdatesExistingMarkerComment(t *testing.T) {
 	}
 }
 
+func TestPRCommentWriterFindsExistingMarkerCommentAcrossPages(t *testing.T) {
+	t.Parallel()
+
+	var getPages []string
+	var patched bool
+	writer := PRCommentWriter{
+		Getenv: envMap(map[string]string{
+			"GITHUB_TOKEN": "token",
+		}),
+		HTTPClient: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.Method {
+			case http.MethodGet:
+				getPages = append(getPages, req.URL.RawQuery)
+				page := req.URL.Query().Get("page")
+				switch page {
+				case "1":
+					comments := make([]map[string]any, commentsPageSize)
+					for i := range comments {
+						comments[i] = map[string]any{"id": i + 1, "body": "other"}
+					}
+					payload, err := json.Marshal(comments)
+					if err != nil {
+						t.Fatalf("marshal page 1 comments: %v", err)
+					}
+					return jsonResponse(http.StatusOK, string(payload)), nil
+				case "2":
+					return jsonResponse(http.StatusOK, `[{"id":123,"body":"`+commentMarker+` old"}]`), nil
+				default:
+					t.Fatalf("unexpected page %q", page)
+					return nil, nil
+				}
+			case http.MethodPatch:
+				patched = true
+				if got := req.URL.Path; got != "/repos/shotomorisk/kgh/issues/comments/123" {
+					t.Fatalf("unexpected patch path %q", got)
+				}
+				return jsonResponse(http.StatusOK, `{}`), nil
+			default:
+				t.Fatalf("unexpected method %s", req.Method)
+				return nil, nil
+			}
+		}),
+	}
+
+	err := writer.Write(context.Background(), ReportContext{
+		RepositoryOwner:   "shotomorisk",
+		RepositoryName:    "kgh",
+		PullRequestNumber: 17,
+	}, commentMarker+"\nbody")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !patched {
+		t.Fatal("expected patch request")
+	}
+	if len(getPages) != 2 {
+		t.Fatalf("expected 2 comment list requests, got %v", getPages)
+	}
+	for i, rawQuery := range getPages {
+		values := mustParseQuery(t, rawQuery)
+		if values.Get("per_page") != strconv.Itoa(commentsPageSize) {
+			t.Fatalf("expected per_page=%d for request %d, got %q", commentsPageSize, i+1, values.Get("per_page"))
+		}
+	}
+}
+
 func TestPRCommentWriterRejectsMissingToken(t *testing.T) {
 	t.Parallel()
 
@@ -148,4 +216,23 @@ func jsonResponse(status int, body string) *http.Response {
 		Body:       io.NopCloser(strings.NewReader(body)),
 		Header:     make(http.Header),
 	}
+}
+
+func mustParseQuery(t *testing.T, rawQuery string) mapQuery {
+	t.Helper()
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		t.Fatalf("parse query %q: %v", rawQuery, err)
+	}
+	return mapQuery(values)
+}
+
+type mapQuery map[string][]string
+
+func (q mapQuery) Get(key string) string {
+	values := map[string][]string(q)
+	if len(values[key]) == 0 {
+		return ""
+	}
+	return values[key][0]
 }

--- a/internal/github/reporter.go
+++ b/internal/github/reporter.go
@@ -32,10 +32,10 @@ func NewRunReporter() RunReporter {
 	}
 }
 
-func (r RunReporter) WriteExecutionReport(ctx context.Context, result execution.Result) error {
+func (r RunReporter) WriteExecutionReport(ctx context.Context, result execution.Result, failure *execution.FailureSummary) error {
 	var errs []error
 
-	if err := r.SummaryWriter.WriteExecutionSummary(result, nil); err != nil {
+	if err := r.SummaryWriter.WriteExecutionSummary(result, failure); err != nil {
 		errs = append(errs, fmt.Errorf("write GitHub summary: %w", err))
 	}
 

--- a/internal/github/reporter_test.go
+++ b/internal/github/reporter_test.go
@@ -58,7 +58,7 @@ func TestRunReporterWritesPullRequestComment(t *testing.T) {
 			Competition: "playground-series-s6e2",
 			Submit:      true,
 		},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -87,7 +87,7 @@ func TestRunReporterSkipsCommentOutsidePullRequest(t *testing.T) {
 		CommentWriter: commentWriter,
 	}
 
-	err := reporter.WriteExecutionReport(context.Background(), execution.Result{})
+	err := reporter.WriteExecutionReport(context.Background(), execution.Result{}, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -110,7 +110,7 @@ func TestRunReporterAggregatesErrors(t *testing.T) {
 		CommentWriter: &fakeCommentWriter{},
 	}
 
-	err := reporter.WriteExecutionReport(context.Background(), execution.Result{})
+	err := reporter.WriteExecutionReport(context.Background(), execution.Result{}, nil)
 	if err == nil {
 		t.Fatal("expected an error")
 	}


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #65 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
• Implemented the plan in cmd/kgh/main.go, cmd/kgh/main_test.go, internal/github/ comment.go, and internal/github/comment_test.go. kgh github run now publishes through internal/github.RunReporter instead of calling only the summary writer, so the GitHub path can write both the Actions summary and the PR comment while preserving the existing stdout-first behavior. I also added pagination to PR comment lookup so reruns update the existing marker comment even when it is beyond the first comments page.

<!-- close -->