### PR TITLE
Github summary failure

### DIFF
--- a/cmd/kgh/main.go
+++ b/cmd/kgh/main.go
@@ -140,9 +140,13 @@ func githubCommand(ctx context.Context, args []string, stdout, stderr io.Writer)
 
 func executeRequest(ctx context.Context, req execution.Request, stdout, stderr io.Writer, writeSummary bool) (int, error) {
 	runner := newRunner(nil)
-	report, err := runner.Execute(ctx, req)
-	if err != nil {
-		return 1, err
+	report, execErr := runner.Execute(ctx, req)
+	if execErr != nil {
+		if partial, ok := execution.ResultFromError(execErr); ok {
+			report = partial
+		} else {
+			return 1, execErr
+		}
 	}
 
 	payload, err := json.MarshalIndent(report, "", "  ")
@@ -157,6 +161,9 @@ func executeRequest(ctx context.Context, req execution.Request, stdout, stderr i
 		if err := newGitHubSummaryWriter().WriteExecutionSummary(report); err != nil {
 			return 1, fmt.Errorf("write GitHub summary: %w", err)
 		}
+	}
+	if execErr != nil {
+		return 1, execErr
 	}
 	return 0, nil
 }

--- a/cmd/kgh/main.go
+++ b/cmd/kgh/main.go
@@ -27,7 +27,7 @@ var newRunner = func(adapter execution.Adapter) executionRunner {
 }
 
 type githubExecutionSummaryWriter interface {
-	WriteExecutionSummary(execution.Result) error
+	WriteExecutionSummary(execution.Result, *execution.FailureSummary) error
 }
 
 var newGitHubSummaryWriter = func() githubExecutionSummaryWriter {
@@ -141,12 +141,14 @@ func githubCommand(ctx context.Context, args []string, stdout, stderr io.Writer)
 func executeRequest(ctx context.Context, req execution.Request, stdout, stderr io.Writer, writeSummary bool) (int, error) {
 	runner := newRunner(nil)
 	report, execErr := runner.Execute(ctx, req)
+	var failure *execution.FailureSummary
 	if execErr != nil {
 		if partial, ok := execution.ResultFromError(execErr); ok {
 			report = partial
 		} else {
 			return 1, execErr
 		}
+		failure, _ = execution.FailureSummaryFromError(execErr)
 	}
 
 	payload, err := json.MarshalIndent(report, "", "  ")
@@ -158,7 +160,7 @@ func executeRequest(ctx context.Context, req execution.Request, stdout, stderr i
 		return 1, err
 	}
 	if writeSummary {
-		if err := newGitHubSummaryWriter().WriteExecutionSummary(report); err != nil {
+		if err := newGitHubSummaryWriter().WriteExecutionSummary(report, failure); err != nil {
 			return 1, fmt.Errorf("write GitHub summary: %w", err)
 		}
 	}

--- a/cmd/kgh/main_test.go
+++ b/cmd/kgh/main_test.go
@@ -26,7 +26,7 @@ func (f fakeExecutionRunner) Execute(context.Context, execution.Request) (execut
 	return f.result, f.err
 }
 
-func (f fakeSummaryWriter) WriteExecutionSummary(execution.Result) error {
+func (f fakeSummaryWriter) WriteExecutionSummary(execution.Result, *execution.FailureSummary) error {
 	return f.err
 }
 
@@ -153,7 +153,8 @@ func TestExecuteRequestWritesGitHubSummaryOnExecutionFailure(t *testing.T) {
 						KernelRef: "yourname/exp142",
 					},
 				},
-				Err: errors.New("submit failed"),
+				Stage: execution.FailureStageSubmit,
+				Err:   errors.New("submit failed"),
 			},
 		}
 	}
@@ -182,10 +183,19 @@ func TestExecuteRequestWritesGitHubSummaryOnExecutionFailure(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("read summary file: %v", readErr)
 	}
-	if !strings.Contains(string(body), "| Target | `exp142` |") {
+	if !strings.Contains(string(body), "### Failure") {
 		t.Fatalf("unexpected summary body:\n%s", string(body))
 	}
-	if !strings.Contains(string(body), "| Kernel ID | `yourname/exp142` |") {
+	if !strings.Contains(string(body), "- Stage: `submit`") {
+		t.Fatalf("unexpected summary body:\n%s", string(body))
+	}
+	if !strings.Contains(string(body), "- Error: submit failed") {
+		t.Fatalf("unexpected summary body:\n%s", string(body))
+	}
+	if !strings.Contains(string(body), "- Target: `exp142`") {
+		t.Fatalf("unexpected summary body:\n%s", string(body))
+	}
+	if !strings.Contains(string(body), "- Kernel ID: `yourname/exp142`") {
 		t.Fatalf("unexpected summary body:\n%s", string(body))
 	}
 	if stderr.Len() != 0 {

--- a/cmd/kgh/main_test.go
+++ b/cmd/kgh/main_test.go
@@ -120,6 +120,79 @@ func TestExecuteRequestSummaryWriteFailureIsFatalAfterJSON(t *testing.T) {
 	}
 }
 
+func TestExecuteRequestWritesGitHubSummaryOnExecutionFailure(t *testing.T) {
+	originalNewRunner := newRunner
+	t.Cleanup(func() {
+		newRunner = originalNewRunner
+	})
+
+	newRunner = func(execution.Adapter) executionRunner {
+		return fakeExecutionRunner{
+			result: execution.Result{
+				Mode: execution.ModeLive,
+				Execution: spec.ExecutionSpec{
+					TargetName: "exp142",
+					Notebook:   "notebooks/exp142.ipynb",
+					KernelID:   "yourname/exp142",
+					KernelRef:  "yourname/exp142",
+				},
+				Push: &execution.PushResult{
+					KernelRef: "yourname/exp142",
+				},
+			},
+			err: &execution.ErrorWithResult{
+				Result: execution.Result{
+					Mode: execution.ModeLive,
+					Execution: spec.ExecutionSpec{
+						TargetName: "exp142",
+						Notebook:   "notebooks/exp142.ipynb",
+						KernelID:   "yourname/exp142",
+						KernelRef:  "yourname/exp142",
+					},
+					Push: &execution.PushResult{
+						KernelRef: "yourname/exp142",
+					},
+				},
+				Err: errors.New("submit failed"),
+			},
+		}
+	}
+
+	dir := t.TempDir()
+	summaryPath := filepath.Join(dir, "summary.md")
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code, err := executeRequest(context.Background(), execution.Request{Target: "exp142", DryRun: false}, &stdout, &stderr, true)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(err.Error(), "submit failed") {
+		t.Fatalf("expected wrapped execution error, got %q", err.Error())
+	}
+	if !strings.Contains(stdout.String(), `"target_name": "exp142"`) {
+		t.Fatalf("expected stdout JSON target, got %s", stdout.String())
+	}
+
+	body, readErr := os.ReadFile(summaryPath)
+	if readErr != nil {
+		t.Fatalf("read summary file: %v", readErr)
+	}
+	if !strings.Contains(string(body), "| Target | `exp142` |") {
+		t.Fatalf("unexpected summary body:\n%s", string(body))
+	}
+	if !strings.Contains(string(body), "| Kernel ID | `yourname/exp142` |") {
+		t.Fatalf("unexpected summary body:\n%s", string(body))
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected executeRequest not to write stderr directly, got %q", stderr.String())
+	}
+}
+
 func TestExecuteRequestSkipsSummaryWhenDisabled(t *testing.T) {
 	originalNewRunner := newRunner
 	originalSummaryWriter := newGitHubSummaryWriter

--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -3,6 +3,7 @@ package execution
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -133,6 +134,33 @@ const (
 
 type Duration time.Duration
 
+type ErrorWithResult struct {
+	Result Result
+	Err    error
+}
+
+func (e *ErrorWithResult) Error() string {
+	if e == nil || e.Err == nil {
+		return ""
+	}
+	return e.Err.Error()
+}
+
+func (e *ErrorWithResult) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func ResultFromError(err error) (Result, bool) {
+	var reportErr *ErrorWithResult
+	if !errors.As(err, &reportErr) || reportErr == nil {
+		return Result{}, false
+	}
+	return reportErr.Result, true
+}
+
 func (d Duration) String() string {
 	return time.Duration(d).String()
 }
@@ -220,6 +248,17 @@ func (r *Runner) Execute(ctx context.Context, req Request) (Result, error) {
 	return report, nil
 }
 
+func wrapErrorWithResult(report Result, err error, format string, args ...any) error {
+	if err == nil {
+		return nil
+	}
+	args = append(args, err)
+	return &ErrorWithResult{
+		Result: report,
+		Err:    fmt.Errorf(format, args...),
+	}
+}
+
 func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, report Result) (Result, error) {
 	if r.adapter == nil {
 		return Result{}, fmt.Errorf("live execution requires a Kaggle adapter")
@@ -247,7 +286,7 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 		WorkDir: bundle.WorkDir,
 	})
 	if err != nil {
-		return report, fmt.Errorf("push kaggle kernel: %w", err)
+		return report, wrapErrorWithResult(report, err, "push kaggle kernel: %w")
 	}
 	report.Push = &PushResult{
 		KernelRef: pushResp.KernelRef,
@@ -262,7 +301,7 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 		Timeout:   time.Duration(report.PollTimeout),
 	})
 	if err != nil {
-		return report, fmt.Errorf("poll kaggle kernel: %w", err)
+		return report, wrapErrorWithResult(report, err, "poll kaggle kernel: %w")
 	}
 	report.Poll = &PollResult{
 		KernelRef:  pollResp.KernelRef,
@@ -278,7 +317,7 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 
 	outputDir, err := createOutputDir()
 	if err != nil {
-		return report, fmt.Errorf("create output dir: %w", err)
+		return report, wrapErrorWithResult(report, err, "create output dir: %w")
 	}
 
 	downloadResp, err := r.adapter.DownloadKernelOutput(ctx, kaggle.DownloadKernelOutputRequest{
@@ -286,12 +325,12 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 		OutputDir: outputDir,
 	})
 	if err != nil {
-		return report, fmt.Errorf("download kaggle output: %w", err)
+		return report, wrapErrorWithResult(report, err, "download kaggle output: %w")
 	}
 
 	outputs, err := buildOutputsResult(execSpec, downloadResp.OutputDir)
 	if err != nil {
-		return report, fmt.Errorf("build output handoff: %w", err)
+		return report, wrapErrorWithResult(report, err, "build output handoff: %w")
 	}
 	report.Outputs = &outputs
 
@@ -299,7 +338,7 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 		return report, nil
 	}
 	if !outputs.Submission.Present {
-		return report, fmt.Errorf("submit enabled but submission artifact is missing: %s", outputs.Submission.Error)
+		return report, wrapErrorWithResult(report, errors.New(outputs.Submission.Error), "submit enabled but submission artifact is missing: %w")
 	}
 
 	submissionAttemptedAt := r.now().UTC()
@@ -310,7 +349,7 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 		Message:     submitMessage,
 	})
 	if err != nil {
-		return report, fmt.Errorf("submit kaggle competition: %w", err)
+		return report, wrapErrorWithResult(report, err, "submit kaggle competition: %w")
 	}
 	report.Submission = &SubmissionResult{
 		Attempted:   true,

--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -24,6 +24,17 @@ const (
 	ModeLive   = "live"
 )
 
+type FailureStage string
+
+const (
+	FailureStagePush             FailureStage = "push"
+	FailureStagePoll             FailureStage = "poll"
+	FailureStageOutputDir        FailureStage = "output-dir"
+	FailureStageDownloadOutput   FailureStage = "download-output"
+	FailureStageOutputValidation FailureStage = "output-validation"
+	FailureStageSubmit           FailureStage = "submit"
+)
+
 type Request struct {
 	Target       string
 	DryRun       bool
@@ -134,8 +145,14 @@ const (
 
 type Duration time.Duration
 
+type FailureSummary struct {
+	Stage FailureStage
+	Error string
+}
+
 type ErrorWithResult struct {
 	Result Result
+	Stage  FailureStage
 	Err    error
 }
 
@@ -159,6 +176,20 @@ func ResultFromError(err error) (Result, bool) {
 		return Result{}, false
 	}
 	return reportErr.Result, true
+}
+
+func FailureSummaryFromError(err error) (*FailureSummary, bool) {
+	var reportErr *ErrorWithResult
+	if !errors.As(err, &reportErr) || reportErr == nil {
+		return nil, false
+	}
+	if reportErr.Stage == "" || reportErr.Err == nil {
+		return nil, false
+	}
+	return &FailureSummary{
+		Stage: reportErr.Stage,
+		Error: reportErr.Err.Error(),
+	}, true
 }
 
 func (d Duration) String() string {
@@ -248,13 +279,14 @@ func (r *Runner) Execute(ctx context.Context, req Request) (Result, error) {
 	return report, nil
 }
 
-func wrapErrorWithResult(report Result, err error, format string, args ...any) error {
+func wrapErrorWithResult(report Result, stage FailureStage, err error, format string, args ...any) error {
 	if err == nil {
 		return nil
 	}
 	args = append(args, err)
 	return &ErrorWithResult{
 		Result: report,
+		Stage:  stage,
 		Err:    fmt.Errorf(format, args...),
 	}
 }
@@ -286,7 +318,7 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 		WorkDir: bundle.WorkDir,
 	})
 	if err != nil {
-		return report, wrapErrorWithResult(report, err, "push kaggle kernel: %w")
+		return report, wrapErrorWithResult(report, FailureStagePush, err, "push kaggle kernel: %w")
 	}
 	report.Push = &PushResult{
 		KernelRef: pushResp.KernelRef,
@@ -301,7 +333,7 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 		Timeout:   time.Duration(report.PollTimeout),
 	})
 	if err != nil {
-		return report, wrapErrorWithResult(report, err, "poll kaggle kernel: %w")
+		return report, wrapErrorWithResult(report, FailureStagePoll, err, "poll kaggle kernel: %w")
 	}
 	report.Poll = &PollResult{
 		KernelRef:  pollResp.KernelRef,
@@ -317,7 +349,7 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 
 	outputDir, err := createOutputDir()
 	if err != nil {
-		return report, wrapErrorWithResult(report, err, "create output dir: %w")
+		return report, wrapErrorWithResult(report, FailureStageOutputDir, err, "create output dir: %w")
 	}
 
 	downloadResp, err := r.adapter.DownloadKernelOutput(ctx, kaggle.DownloadKernelOutputRequest{
@@ -325,12 +357,12 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 		OutputDir: outputDir,
 	})
 	if err != nil {
-		return report, wrapErrorWithResult(report, err, "download kaggle output: %w")
+		return report, wrapErrorWithResult(report, FailureStageDownloadOutput, err, "download kaggle output: %w")
 	}
 
 	outputs, err := buildOutputsResult(execSpec, downloadResp.OutputDir)
 	if err != nil {
-		return report, wrapErrorWithResult(report, err, "build output handoff: %w")
+		return report, wrapErrorWithResult(report, FailureStageDownloadOutput, err, "build output handoff: %w")
 	}
 	report.Outputs = &outputs
 
@@ -338,7 +370,7 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 		return report, nil
 	}
 	if !outputs.Submission.Present {
-		return report, wrapErrorWithResult(report, errors.New(outputs.Submission.Error), "submit enabled but submission artifact is missing: %w")
+		return report, wrapErrorWithResult(report, FailureStageOutputValidation, errors.New(outputs.Submission.Error), "submit enabled but submission artifact is missing: %w")
 	}
 
 	submissionAttemptedAt := r.now().UTC()
@@ -349,7 +381,7 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 		Message:     submitMessage,
 	})
 	if err != nil {
-		return report, wrapErrorWithResult(report, err, "submit kaggle competition: %w")
+		return report, wrapErrorWithResult(report, FailureStageSubmit, err, "submit kaggle competition: %w")
 	}
 	report.Submission = &SubmissionResult{
 		Attempted:   true,

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -876,6 +876,9 @@ func TestRunnerExecuteLiveSubmitFailureReturnsErrorWithPartialResult(t *testing.
 	if !errors.As(err, &reportErr) {
 		t.Fatalf("expected error with partial result, got %T", err)
 	}
+	if reportErr.Stage != FailureStageSubmit {
+		t.Fatalf("expected submit stage, got %q", reportErr.Stage)
+	}
 	if reportErr.Result.Mode != ModeLive {
 		t.Fatalf("expected live result, got %+v", reportErr.Result)
 	}
@@ -1001,6 +1004,9 @@ targets:
 	var reportErr *ErrorWithResult
 	if !errors.As(err, &reportErr) {
 		t.Fatalf("expected error with partial result, got %T", err)
+	}
+	if reportErr.Stage != FailureStageOutputValidation {
+		t.Fatalf("expected output validation stage, got %q", reportErr.Stage)
 	}
 	if reportErr.Result.Outputs == nil {
 		t.Fatalf("expected outputs handoff, got %+v", reportErr.Result)

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -3,6 +3,7 @@ package execution
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -836,6 +837,59 @@ func TestRunnerExecuteLiveSubmitFailureReturnsError(t *testing.T) {
 	}
 }
 
+func TestRunnerExecuteLiveSubmitFailureReturnsErrorWithPartialResult(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeLiveConfig(t, true)
+
+	adapter := &liveAdapter{
+		t: t,
+		pushFn: func(_ context.Context, _ kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error) {
+			return kaggle.PushKernelResponse{KernelRef: "yourname/exp142"}, nil
+		},
+		pollFn: func(_ context.Context, _ kaggle.KernelPollRequest) (kaggle.KernelPollResult, error) {
+			return kaggle.KernelPollResult{
+				KernelStatusResponse: kaggle.KernelStatusResponse{KernelRef: "yourname/exp142", Status: "complete"},
+				Terminal:             kaggle.KernelPollTerminalStateSucceeded,
+			}, nil
+		},
+		downloadFn: func(_ context.Context, req kaggle.DownloadKernelOutputRequest) (kaggle.DownloadKernelOutputResponse, error) {
+			if err := os.WriteFile(filepath.Join(req.OutputDir, "submission.csv"), []byte("id,label\n1,0\n"), 0o644); err != nil {
+				t.Fatalf("write submission output: %v", err)
+			}
+			return kaggle.DownloadKernelOutputResponse{OutputDir: req.OutputDir}, nil
+		},
+		submitFn: func(_ context.Context, _ kaggle.CompetitionSubmitRequest) (kaggle.CompetitionSubmitResponse, error) {
+			return kaggle.CompetitionSubmitResponse{}, fmt.Errorf("submit failed")
+		},
+	}
+
+	_, err := NewRunner(adapter).Execute(context.Background(), Request{
+		Target:     "exp142",
+		DryRun:     false,
+		ConfigPath: configPath,
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var reportErr *ErrorWithResult
+	if !errors.As(err, &reportErr) {
+		t.Fatalf("expected error with partial result, got %T", err)
+	}
+	if reportErr.Result.Mode != ModeLive {
+		t.Fatalf("expected live result, got %+v", reportErr.Result)
+	}
+	if reportErr.Result.Push == nil || reportErr.Result.Push.KernelRef != "yourname/exp142" {
+		t.Fatalf("expected pushed kernel ref in partial result, got %+v", reportErr.Result.Push)
+	}
+	if reportErr.Result.Outputs == nil || !reportErr.Result.Outputs.Submission.Present {
+		t.Fatalf("expected outputs in partial result, got %+v", reportErr.Result.Outputs)
+	}
+	if reportErr.Result.Submission != nil {
+		t.Fatalf("expected no submission payload before failed submit, got %+v", reportErr.Result.Submission)
+	}
+}
+
 func TestRunnerExecuteLiveListSubmissionsFailureReturnsError(t *testing.T) {
 	t.Parallel()
 
@@ -879,6 +933,83 @@ func TestRunnerExecuteLiveListSubmissionsFailureReturnsError(t *testing.T) {
 	}
 	if report.Score == nil || report.Score.State != ScoreStateNotFound {
 		t.Fatalf("expected unavailable score result, got %+v", report.Score)
+	}
+}
+
+func TestRunnerExecuteLiveMissingRequiredSubmissionFailsValidationReturnsErrorWithPartialResult(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	notebook := filepath.Join(dir, "notebooks", "exp142.ipynb")
+	if err := os.MkdirAll(filepath.Dir(notebook), 0o755); err != nil {
+		t.Fatalf("mkdir notebook dir: %v", err)
+	}
+	if err := os.WriteFile(notebook, []byte(`{"cells":[]}`), 0o644); err != nil {
+		t.Fatalf("write notebook: %v", err)
+	}
+
+	configPath := filepath.Join(dir, ".kgh", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`
+targets:
+  exp142:
+    notebook: `+notebook+`
+    kernel_id: yourname/exp142
+    competition: playground-series-s6e2
+    submit: true
+    resources:
+      private: true
+    outputs:
+      submission: submission.csv
+      metrics: metrics.json
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	adapter := &liveAdapter{
+		t: t,
+		pushFn: func(_ context.Context, _ kaggle.PushKernelRequest) (kaggle.PushKernelResponse, error) {
+			return kaggle.PushKernelResponse{KernelRef: "yourname/exp142"}, nil
+		},
+		pollFn: func(_ context.Context, _ kaggle.KernelPollRequest) (kaggle.KernelPollResult, error) {
+			return kaggle.KernelPollResult{
+				KernelStatusResponse: kaggle.KernelStatusResponse{
+					KernelRef: "yourname/exp142",
+					Status:    "complete",
+				},
+				Terminal: kaggle.KernelPollTerminalStateSucceeded,
+			}, nil
+		},
+		downloadFn: func(_ context.Context, req kaggle.DownloadKernelOutputRequest) (kaggle.DownloadKernelOutputResponse, error) {
+			if err := os.WriteFile(filepath.Join(req.OutputDir, "metrics.json"), []byte(`{"score":0.5}`), 0o644); err != nil {
+				t.Fatalf("write metrics output: %v", err)
+			}
+			return kaggle.DownloadKernelOutputResponse{OutputDir: req.OutputDir}, nil
+		},
+	}
+
+	_, err := NewRunner(adapter).Execute(context.Background(), Request{
+		Target:     "exp142",
+		DryRun:     false,
+		ConfigPath: configPath,
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var reportErr *ErrorWithResult
+	if !errors.As(err, &reportErr) {
+		t.Fatalf("expected error with partial result, got %T", err)
+	}
+	if reportErr.Result.Outputs == nil {
+		t.Fatalf("expected outputs handoff, got %+v", reportErr.Result)
+	}
+	if reportErr.Result.Outputs.Validation.Valid {
+		t.Fatalf("expected invalid outputs in partial result, got %+v", reportErr.Result.Outputs.Validation)
+	}
+	if reportErr.Result.Outputs.Submission.Present {
+		t.Fatalf("expected missing submission in partial result, got %+v", reportErr.Result.Outputs.Submission)
 	}
 }
 

--- a/internal/github/reporter.go
+++ b/internal/github/reporter.go
@@ -35,7 +35,7 @@ func NewRunReporter() RunReporter {
 func (r RunReporter) WriteExecutionReport(ctx context.Context, result execution.Result) error {
 	var errs []error
 
-	if err := r.SummaryWriter.WriteExecutionSummary(result); err != nil {
+	if err := r.SummaryWriter.WriteExecutionSummary(result, nil); err != nil {
 		errs = append(errs, fmt.Errorf("write GitHub summary: %w", err))
 	}
 

--- a/internal/github/summary.go
+++ b/internal/github/summary.go
@@ -20,7 +20,7 @@ func NewSummaryWriter() SummaryWriter {
 	}
 }
 
-func (w SummaryWriter) Write(result execution.Result) error {
+func (w SummaryWriter) Write(result execution.Result, failure *execution.FailureSummary) error {
 	if w.Getenv == nil {
 		w.Getenv = os.Getenv
 	}
@@ -32,11 +32,13 @@ func (w SummaryWriter) Write(result execution.Result) error {
 	if path == "" {
 		return nil
 	}
-	return w.AppendFile(path, []byte(reporting.RenderGitHubSummary(result)))
+	return w.AppendFile(path, []byte(reporting.RenderGitHubSummary(result, reporting.GitHubSummaryOptions{
+		Failure: failure,
+	})))
 }
 
-func (w SummaryWriter) WriteExecutionSummary(result execution.Result) error {
-	return w.Write(result)
+func (w SummaryWriter) WriteExecutionSummary(result execution.Result, failure *execution.FailureSummary) error {
+	return w.Write(result, failure)
 }
 
 func appendFile(path string, body []byte) error {

--- a/internal/github/summary_test.go
+++ b/internal/github/summary_test.go
@@ -23,7 +23,7 @@ func TestSummaryWriterNoopWithoutEnv(t *testing.T) {
 		},
 	}
 
-	if err := writer.WriteExecutionSummary(execution.Result{}); err != nil {
+	if err := writer.WriteExecutionSummary(execution.Result{}, nil); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if called {
@@ -59,7 +59,7 @@ func TestSummaryWriterAppendsRenderedMarkdown(t *testing.T) {
 		Execution: spec.ExecutionSpec{
 			TargetName: "exp142",
 		},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -86,7 +86,7 @@ func TestSummaryWriterReturnsAppendError(t *testing.T) {
 		AppendFile: func(string, []byte) error { return wantErr },
 	}
 
-	err := writer.WriteExecutionSummary(execution.Result{})
+	err := writer.WriteExecutionSummary(execution.Result{}, nil)
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("expected append error, got %v", err)
 	}

--- a/internal/reporting/github_summary.go
+++ b/internal/reporting/github_summary.go
@@ -17,8 +17,16 @@ const (
 	stateSubmissionMetadataUnavailable = "submission metadata unavailable"
 )
 
+type GitHubSummaryOptions struct {
+	Failure *execution.FailureSummary
+}
+
 // RenderGitHubSummary renders an execution result into Markdown for GitHub step summaries.
-func RenderGitHubSummary(result execution.Result) string {
+func RenderGitHubSummary(result execution.Result, opts GitHubSummaryOptions) string {
+	if opts.Failure != nil {
+		return renderGitHubFailureSummary(result, *opts.Failure)
+	}
+
 	rows := []summaryRow{
 		{Field: "Target", Value: formatIdentifier(valueOr(result.Execution.TargetName, stateUnavailable))},
 		{Field: "Notebook Path", Value: formatIdentifier(resolveNotebookPath(result))},
@@ -35,6 +43,31 @@ func RenderGitHubSummary(result execution.Result) string {
 	b.WriteString("| --- | --- |\n")
 	for _, row := range rows {
 		fmt.Fprintf(&b, "| %s | %s |\n", escapeMarkdown(row.Field), row.Value)
+	}
+	return b.String()
+}
+
+func renderGitHubFailureSummary(result execution.Result, failure execution.FailureSummary) string {
+	rows := make([]summaryRow, 0, 5)
+	rows = append(rows,
+		summaryRow{Field: "Stage", Value: formatIdentifier(string(failure.Stage))},
+		summaryRow{Field: "Error", Value: escapeMarkdown(normalizeInlineText(failure.Error))},
+	)
+	if target := strings.TrimSpace(result.Execution.TargetName); target != "" {
+		rows = append(rows, summaryRow{Field: "Target", Value: formatIdentifier(target)})
+	}
+	if kernelID := strings.TrimSpace(resolveKernelID(result)); kernelID != "" && kernelID != stateUnavailable {
+		rows = append(rows, summaryRow{Field: "Kernel ID", Value: formatIdentifier(kernelID)})
+	}
+	if refs := formatReferences(result); refs != stateUnavailable {
+		rows = append(rows, summaryRow{Field: "References", Value: refs})
+	}
+
+	var b strings.Builder
+	b.WriteString("## kgh run summary\n")
+	b.WriteString("### Failure\n")
+	for _, row := range rows {
+		fmt.Fprintf(&b, "- %s: %s\n", escapeMarkdown(row.Field), row.Value)
 	}
 	return b.String()
 }
@@ -166,6 +199,10 @@ func normalizeStatus(value string) string {
 		return ""
 	}
 	return value
+}
+
+func normalizeInlineText(value string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
 }
 
 func valueOr(value, fallback string) string {

--- a/internal/reporting/github_summary_test.go
+++ b/internal/reporting/github_summary_test.go
@@ -145,6 +145,35 @@ func TestRenderGitHubSummaryPendingScore(t *testing.T) {
 	assertContains(t, got, "| Public Score | pending |")
 }
 
+func TestRenderGitHubSummaryLiveFailurePartialResult(t *testing.T) {
+	t.Parallel()
+
+	got := RenderGitHubSummary(execution.Result{
+		Mode: execution.ModeLive,
+		Execution: spec.ExecutionSpec{
+			TargetName:  "exp142",
+			Notebook:    "notebooks/exp142.ipynb",
+			KernelID:    "yourname/exp142",
+			KernelRef:   "yourname/exp142",
+			Competition: "playground-series-s6e2",
+			Submit:      true,
+		},
+		Push: &execution.PushResult{
+			KernelRef: "yourname/exp142",
+		},
+		Poll: &execution.PollResult{
+			Status:   "failed",
+			Terminal: kaggle.KernelPollTerminalStateFailed,
+		},
+	})
+
+	assertContains(t, got, "| Target | `exp142` |")
+	assertContains(t, got, "| Kernel ID | `yourname/exp142` |")
+	assertContains(t, got, "| Run Status | failed |")
+	assertContains(t, got, "| Submit Status | not submitted |")
+	assertContains(t, got, "kernel: `yourname/exp142`")
+}
+
 func TestRenderGitHubSummarySubmissionDisabled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/reporting/github_summary_test.go
+++ b/internal/reporting/github_summary_test.go
@@ -25,7 +25,7 @@ func TestRenderGitHubSummaryDryRun(t *testing.T) {
 			Competition: "playground-series-s6e2",
 			Submit:      true,
 		},
-	})
+	}, GitHubSummaryOptions{})
 
 	assertContains(t, got, "## kgh run summary")
 	assertContains(t, got, "| Target | `exp142` |")
@@ -72,7 +72,7 @@ func TestRenderGitHubSummaryLiveSuccess(t *testing.T) {
 		Outputs: &execution.OutputsResult{
 			Submission: execution.OutputFileResult{Path: "/tmp/output/submission.csv"},
 		},
-	})
+	}, GitHubSummaryOptions{})
 
 	assertContains(t, got, "| Notebook Path | `/tmp/bundle/notebooks/exp142.ipynb` |")
 	assertContains(t, got, "| Run Status | succeeded |")
@@ -138,7 +138,7 @@ func TestRenderGitHubSummaryPendingScore(t *testing.T) {
 		Score: &execution.ScoreResult{
 			State: execution.ScoreStatePending,
 		},
-	})
+	}, GitHubSummaryOptions{})
 
 	assertContains(t, got, "| Run Status | running |")
 	assertContains(t, got, "| Submit Status | submission metadata unavailable |")
@@ -161,17 +161,21 @@ func TestRenderGitHubSummaryLiveFailurePartialResult(t *testing.T) {
 		Push: &execution.PushResult{
 			KernelRef: "yourname/exp142",
 		},
-		Poll: &execution.PollResult{
-			Status:   "failed",
-			Terminal: kaggle.KernelPollTerminalStateFailed,
+	}, GitHubSummaryOptions{
+		Failure: &execution.FailureSummary{
+			Stage: execution.FailureStageSubmit,
+			Error: "submit kaggle competition:\nsubmit failed",
 		},
 	})
 
-	assertContains(t, got, "| Target | `exp142` |")
-	assertContains(t, got, "| Kernel ID | `yourname/exp142` |")
-	assertContains(t, got, "| Run Status | failed |")
-	assertContains(t, got, "| Submit Status | not submitted |")
-	assertContains(t, got, "kernel: `yourname/exp142`")
+	assertContains(t, got, "## kgh run summary")
+	assertContains(t, got, "### Failure")
+	assertContains(t, got, "- Stage: `submit`")
+	assertContains(t, got, "- Error: submit kaggle competition: submit failed")
+	assertContains(t, got, "- Target: `exp142`")
+	assertContains(t, got, "- Kernel ID: `yourname/exp142`")
+	assertContains(t, got, "- References: kernel: `yourname/exp142`<br>competition: `playground-series-s6e2`")
+	assertNotContains(t, got, "| Field | Value |")
 }
 
 func TestRenderGitHubSummarySubmissionDisabled(t *testing.T) {
@@ -182,7 +186,7 @@ func TestRenderGitHubSummarySubmissionDisabled(t *testing.T) {
 			TargetName: "exp142",
 			Submit:     false,
 		},
-	})
+	}, GitHubSummaryOptions{})
 
 	assertContains(t, got, "| Submit Status | disabled |")
 	assertContains(t, got, "| Public Score | unavailable |")
@@ -197,7 +201,7 @@ func TestRenderGitHubSummaryPartialResultFallbacks(t *testing.T) {
 			Submit:     true,
 		},
 		Push: &execution.PushResult{},
-	})
+	}, GitHubSummaryOptions{})
 
 	assertContains(t, got, "| Notebook Path | unavailable |")
 	assertContains(t, got, "| Kernel ID | unavailable |")
@@ -205,9 +209,36 @@ func TestRenderGitHubSummaryPartialResultFallbacks(t *testing.T) {
 	assertContains(t, got, "| References | unavailable |")
 }
 
+func TestRenderGitHubSummaryFailureOmitsUnavailableOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	got := RenderGitHubSummary(execution.Result{
+		Mode: execution.ModeLive,
+	}, GitHubSummaryOptions{
+		Failure: &execution.FailureSummary{
+			Stage: execution.FailureStagePush,
+			Error: "push kaggle kernel: auth failed",
+		},
+	})
+
+	assertContains(t, got, "- Stage: `push`")
+	assertContains(t, got, "- Error: push kaggle kernel: auth failed")
+	assertNotContains(t, got, "Target:")
+	assertNotContains(t, got, "Kernel ID:")
+	assertNotContains(t, got, "References:")
+	assertNotContains(t, got, "unavailable")
+}
+
 func assertContains(t *testing.T, got, want string) {
 	t.Helper()
 	if !strings.Contains(got, want) {
 		t.Fatalf("expected output to contain %q, got:\n%s", want, got)
+	}
+}
+
+func assertNotContains(t *testing.T, got, want string) {
+	t.Helper()
+	if strings.Contains(got, want) {
+		t.Fatalf("expected output not to contain %q, got:\n%s", want, got)
 	}
 }


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #104 
- [ ] Github issue: Closes: #105 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented the failed-run summary path. executeRequest now keeps emitting JSON and GitHub summary output when execution fails with a partial execution.Result, then still returns exit code 1 with the original error. In support of that, internal/ execution now exposes a result-carrying error contract via ErrorWithResult and ResultFromError, and the live execution failure paths that already had useful report state now wrap their errors with that partial result. 

I added regression coverage in cmd/kgh/main_test.go, internal/execution/ execution_test.go, and internal/reporting/github_summary_test.go. The production changes are in cmd/kgh/main.go and internal/execution/execution.go.
<!-- close -->