### PR TITLE
Early failures now return structured ErrorWithResult data

### DIFF
--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -27,6 +27,9 @@ const (
 type FailureStage string
 
 const (
+	FailureStageConfig           FailureStage = "config"
+	FailureStageTargetResolution FailureStage = "target-resolution"
+	FailureStageBundleStaging    FailureStage = "bundle-staging"
 	FailureStagePush             FailureStage = "push"
 	FailureStagePoll             FailureStage = "poll"
 	FailureStageOutputDir        FailureStage = "output-dir"
@@ -248,9 +251,11 @@ func (r *Runner) Execute(ctx context.Context, req Request) (Result, error) {
 		req.ConfigPath = DefaultConfigPath
 	}
 
+	report := baseResultFromRequest(req, r.pollInterval, r.pollTimeout)
+
 	cfg, err := r.loadConfig(req.ConfigPath)
 	if err != nil {
-		return Result{}, fmt.Errorf("load config %q: %w", req.ConfigPath, err)
+		return report, wrapErrorWithResult(report, FailureStageConfig, err, "load config %q: %w", req.ConfigPath)
 	}
 
 	trigger := parser.Trigger{
@@ -261,22 +266,28 @@ func (r *Runner) Execute(ctx context.Context, req Request) (Result, error) {
 
 	execSpec, err := planner.Resolve(cfg, trigger)
 	if err != nil {
-		return Result{}, err
+		return report, wrapErrorWithResult(report, FailureStageTargetResolution, err, "%w")
 	}
 
-	report := Result{
-		Mode:         ModeDryRun,
-		DryRun:       true,
-		ConfigPath:   req.ConfigPath,
-		PollInterval: Duration(effectivePollInterval(req.PollInterval, r.pollInterval)),
-		PollTimeout:  Duration(effectivePollTimeout(req.PollTimeout, r.pollTimeout)),
-		Execution:    execSpec,
-	}
+	report.Execution = execSpec
 	if !req.DryRun {
 		return r.executeLive(ctx, execSpec, report)
 	}
 
 	return report, nil
+}
+
+func baseResultFromRequest(req Request, defaultPollInterval, defaultPollTimeout time.Duration) Result {
+	return Result{
+		Mode:         ModeDryRun,
+		DryRun:       true,
+		ConfigPath:   req.ConfigPath,
+		PollInterval: Duration(effectivePollInterval(req.PollInterval, defaultPollInterval)),
+		PollTimeout:  Duration(effectivePollTimeout(req.PollTimeout, defaultPollTimeout)),
+		Execution: spec.ExecutionSpec{
+			TargetName: req.Target,
+		},
+	}
 }
 
 func wrapErrorWithResult(report Result, stage FailureStage, err error, format string, args ...any) error {
@@ -296,9 +307,12 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 		return Result{}, fmt.Errorf("live execution requires a Kaggle adapter")
 	}
 
+	report.Mode = ModeLive
+	report.DryRun = false
+
 	bundle, err := kaggle.StageKernelBundle(execSpec)
 	if err != nil {
-		return Result{}, fmt.Errorf("stage kaggle bundle: %w", err)
+		return report, wrapErrorWithResult(report, FailureStageBundleStaging, err, "stage kaggle bundle: %w")
 	}
 	defer func() {
 		if bundle.Cleanup != nil {
@@ -306,8 +320,6 @@ func (r *Runner) executeLive(ctx context.Context, execSpec spec.ExecutionSpec, r
 		}
 	}()
 
-	report.Mode = ModeLive
-	report.DryRun = false
 	report.Bundle = &BundleResult{
 		WorkDir:      bundle.WorkDir,
 		NotebookPath: bundle.NotebookPath,

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -125,6 +125,23 @@ targets:
 	if err == nil {
 		t.Fatal("expected an error")
 	}
+	var reportErr *ErrorWithResult
+	if !errors.As(err, &reportErr) {
+		t.Fatalf("expected error with partial result, got %T", err)
+	}
+	if reportErr.Stage != FailureStageTargetResolution {
+		t.Fatalf("expected target resolution stage, got %q", reportErr.Stage)
+	}
+	if reportErr.Result.Execution.TargetName != "missing" {
+		t.Fatalf("expected requested target in partial result, got %+v", reportErr.Result.Execution)
+	}
+	failure, ok := FailureSummaryFromError(err)
+	if !ok {
+		t.Fatalf("expected failure summary for target resolution error")
+	}
+	if failure.Stage != FailureStageTargetResolution {
+		t.Fatalf("expected failure summary stage %q, got %q", FailureStageTargetResolution, failure.Stage)
+	}
 	if got := err.Error(); !strings.Contains(got, `unknown target "missing"`) {
 		t.Fatalf("unexpected error %q", got)
 	}
@@ -133,15 +150,104 @@ targets:
 func TestRunnerExecuteConfigLoadFailure(t *testing.T) {
 	t.Parallel()
 
+	configPath := filepath.Join(t.TempDir(), "missing.yaml")
 	_, err := NewRunner(nil).Execute(context.Background(), Request{
 		Target:     "exp142",
 		DryRun:     true,
-		ConfigPath: filepath.Join(t.TempDir(), "missing.yaml"),
+		ConfigPath: configPath,
 	})
 	if err == nil {
 		t.Fatal("expected an error")
 	}
+	var reportErr *ErrorWithResult
+	if !errors.As(err, &reportErr) {
+		t.Fatalf("expected error with partial result, got %T", err)
+	}
+	if reportErr.Stage != FailureStageConfig {
+		t.Fatalf("expected config stage, got %q", reportErr.Stage)
+	}
+	if reportErr.Result.ConfigPath != configPath {
+		t.Fatalf("expected config path in partial result, got %+v", reportErr.Result)
+	}
+	if reportErr.Result.Execution.TargetName != "exp142" {
+		t.Fatalf("expected target name in partial result, got %+v", reportErr.Result.Execution)
+	}
+	if reportErr.Result.Mode != ModeDryRun || !reportErr.Result.DryRun {
+		t.Fatalf("expected dry-run partial result, got %+v", reportErr.Result)
+	}
+	failure, ok := FailureSummaryFromError(err)
+	if !ok {
+		t.Fatalf("expected failure summary for config error")
+	}
+	if failure.Stage != FailureStageConfig {
+		t.Fatalf("expected failure summary stage %q, got %q", FailureStageConfig, failure.Stage)
+	}
 	if got := err.Error(); !strings.Contains(got, "load config") {
+		t.Fatalf("unexpected error %q", got)
+	}
+}
+
+func TestRunnerExecuteLiveBundleStagingFailureReturnsErrorWithPartialResult(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	missingNotebook := filepath.Join(dir, "notebooks", "missing.ipynb")
+
+	configPath := filepath.Join(dir, ".kgh", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`
+targets:
+  exp142:
+    notebook: `+missingNotebook+`
+    kernel_id: yourname/exp142
+    competition: playground-series-s6e2
+    submit: true
+    resources:
+      private: true
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := NewRunner(&liveAdapter{t: t}).Execute(context.Background(), Request{
+		Target:     "exp142",
+		DryRun:     false,
+		ConfigPath: configPath,
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var reportErr *ErrorWithResult
+	if !errors.As(err, &reportErr) {
+		t.Fatalf("expected error with partial result, got %T", err)
+	}
+	if reportErr.Stage != FailureStageBundleStaging {
+		t.Fatalf("expected bundle staging stage, got %q", reportErr.Stage)
+	}
+	if reportErr.Result.Mode != ModeLive || reportErr.Result.DryRun {
+		t.Fatalf("expected live partial result, got %+v", reportErr.Result)
+	}
+	if reportErr.Result.Execution.TargetName != "exp142" {
+		t.Fatalf("expected target details in partial result, got %+v", reportErr.Result.Execution)
+	}
+	if reportErr.Result.Execution.KernelID != "yourname/exp142" {
+		t.Fatalf("expected resolved kernel id in partial result, got %+v", reportErr.Result.Execution)
+	}
+	if reportErr.Result.Execution.Competition != "playground-series-s6e2" {
+		t.Fatalf("expected resolved competition in partial result, got %+v", reportErr.Result.Execution)
+	}
+	if reportErr.Result.Bundle != nil {
+		t.Fatalf("expected no bundle details before successful staging, got %+v", reportErr.Result.Bundle)
+	}
+	failure, ok := FailureSummaryFromError(err)
+	if !ok {
+		t.Fatalf("expected failure summary for bundle staging error")
+	}
+	if failure.Stage != FailureStageBundleStaging {
+		t.Fatalf("expected failure summary stage %q, got %q", FailureStageBundleStaging, failure.Stage)
+	}
+	if got := err.Error(); !strings.Contains(got, "stage kaggle bundle") {
 		t.Fatalf("unexpected error %q", got)
 	}
 }

--- a/internal/reporting/github_summary_test.go
+++ b/internal/reporting/github_summary_test.go
@@ -178,6 +178,33 @@ func TestRenderGitHubSummaryLiveFailurePartialResult(t *testing.T) {
 	assertNotContains(t, got, "| Field | Value |")
 }
 
+func TestRenderGitHubSummaryEarlyFailurePartialResult(t *testing.T) {
+	t.Parallel()
+
+	got := RenderGitHubSummary(execution.Result{
+		Mode: execution.ModeLive,
+		Execution: spec.ExecutionSpec{
+			TargetName:  "exp142",
+			Notebook:    "notebooks/exp142.ipynb",
+			KernelID:    "yourname/exp142",
+			Competition: "playground-series-s6e2",
+			Submit:      true,
+		},
+	}, GitHubSummaryOptions{
+		Failure: &execution.FailureSummary{
+			Stage: execution.FailureStageBundleStaging,
+			Error: "stage kaggle bundle: prepare kaggle bundle: check notebook notebooks/exp142.ipynb: notebook file is missing",
+		},
+	})
+
+	assertContains(t, got, "### Failure")
+	assertContains(t, got, "- Stage: `bundle-staging`")
+	assertContains(t, got, "- Target: `exp142`")
+	assertContains(t, got, "- Kernel ID: `yourname/exp142`")
+	assertContains(t, got, "- References: competition: `playground-series-s6e2`")
+	assertNotContains(t, got, "unavailable")
+}
+
 func TestRenderGitHubSummarySubmissionDisabled(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #110 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->

Implemented the plan in internal/execution/execution.go, internal/execution/execution_test.go, and internal/
reporting/github_summary_test.go.

Early failures now return structured ErrorWithResult data with new stable stages: config, target-resolution, and
bundle-staging. Config-load and target-resolution failures preserve the requested target in the partial result,
and bundle-staging failures now correctly report live mode before staging starts. I also added regression
coverage to ensure FailureSummaryFromError works for those cases and that GitHub failure summaries render the
new early-stage output cleanly.

<!-- close -->