### PR TITLE
add: executeRequest in cmd/kgh/main.go no longer returns immediately …

### DIFF
--- a/cmd/kgh/main.go
+++ b/cmd/kgh/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shotomorisk/kgh/internal/execution"
 	ghctx "github.com/shotomorisk/kgh/internal/github"
 	"github.com/shotomorisk/kgh/internal/parser"
+	"github.com/shotomorisk/kgh/internal/spec"
 )
 
 var version = "dev"
@@ -141,14 +142,9 @@ func githubCommand(ctx context.Context, args []string, stdout, stderr io.Writer)
 func executeRequest(ctx context.Context, req execution.Request, stdout, stderr io.Writer, writeGitHubReport bool) (int, error) {
 	runner := newRunner(nil)
 	report, execErr := runner.Execute(ctx, req)
-	var failure *execution.FailureSummary
-	if execErr != nil {
-		if partial, ok := execution.ResultFromError(execErr); ok {
-			report = partial
-		} else {
-			return 1, execErr
-		}
-		failure, _ = execution.FailureSummaryFromError(execErr)
+	report, failure, ok := reportOutcome(req, report, execErr)
+	if execErr != nil && !ok {
+		return 1, execErr
 	}
 
 	payload, err := json.MarshalIndent(report, "", "  ")
@@ -168,6 +164,43 @@ func executeRequest(ctx context.Context, req execution.Request, stdout, stderr i
 		return 1, execErr
 	}
 	return 0, nil
+}
+
+func reportOutcome(req execution.Request, report execution.Result, execErr error) (execution.Result, *execution.FailureSummary, bool) {
+	if execErr == nil {
+		return report, nil, true
+	}
+
+	if partial, ok := execution.ResultFromError(execErr); ok {
+		report = partial
+		failure, _ := execution.FailureSummaryFromError(execErr)
+		return report, failure, true
+	}
+
+	return fallbackReport(req), &execution.FailureSummary{
+		Stage: execution.FailureStageExecution,
+		Error: execErr.Error(),
+	}, true
+}
+
+func fallbackReport(req execution.Request) execution.Result {
+	mode := execution.ModeDryRun
+	dryRun := true
+	if !req.DryRun {
+		mode = execution.ModeLive
+		dryRun = false
+	}
+
+	return execution.Result{
+		Mode:         mode,
+		DryRun:       dryRun,
+		ConfigPath:   req.ConfigPath,
+		PollInterval: execution.Duration(req.PollInterval),
+		PollTimeout:  execution.Duration(req.PollTimeout),
+		Execution: spec.ExecutionSpec{
+			TargetName: req.Target,
+		},
+	}
 }
 
 func parseRunFlags(args []string) (runFlags, error) {

--- a/cmd/kgh/main_test.go
+++ b/cmd/kgh/main_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/shotomorisk/kgh/internal/execution"
+	ghctx "github.com/shotomorisk/kgh/internal/github"
 	"github.com/shotomorisk/kgh/internal/spec"
 )
 
@@ -198,6 +199,75 @@ func TestExecuteRequestWritesGitHubSummaryOnExecutionFailure(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "- Kernel ID: `yourname/exp142`") {
 		t.Fatalf("unexpected summary body:\n%s", string(body))
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected executeRequest not to write stderr directly, got %q", stderr.String())
+	}
+}
+
+func TestExecuteRequestWritesGitHubSummaryOnExecutionFailureWithoutPartialResult(t *testing.T) {
+	originalNewRunner := newRunner
+	originalGitHubReporter := newGitHubReporter
+	t.Cleanup(func() {
+		newRunner = originalNewRunner
+		newGitHubReporter = originalGitHubReporter
+	})
+
+	newRunner = func(execution.Adapter) executionRunner {
+		return fakeExecutionRunner{
+			err: errors.New("bootstrap failed"),
+		}
+	}
+	newGitHubReporter = func() githubExecutionReporter {
+		return ghctx.NewRunReporter()
+	}
+
+	dir := t.TempDir()
+	summaryPath := filepath.Join(dir, "summary.md")
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+	t.Setenv("GITHUB_EVENT_NAME", "workflow_dispatch")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code, err := executeRequest(context.Background(), execution.Request{
+		Target:     "exp142",
+		DryRun:     false,
+		ConfigPath: ".kgh/config.yaml",
+	}, &stdout, &stderr, true)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(err.Error(), "bootstrap failed") {
+		t.Fatalf("expected wrapped execution error, got %q", err.Error())
+	}
+	if !strings.Contains(stdout.String(), `"target_name": "exp142"`) {
+		t.Fatalf("expected stdout JSON target, got %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), `"mode": "live"`) {
+		t.Fatalf("expected stdout JSON mode, got %s", stdout.String())
+	}
+
+	body, readErr := os.ReadFile(summaryPath)
+	if readErr != nil {
+		t.Fatalf("read summary file: %v", readErr)
+	}
+	if !strings.Contains(string(body), "### Failure") {
+		t.Fatalf("unexpected summary body:\n%s", string(body))
+	}
+	if !strings.Contains(string(body), "- Stage: `execution`") {
+		t.Fatalf("unexpected summary body:\n%s", string(body))
+	}
+	if !strings.Contains(string(body), "- Error: bootstrap failed") {
+		t.Fatalf("unexpected summary body:\n%s", string(body))
+	}
+	if !strings.Contains(string(body), "- Target: `exp142`") {
+		t.Fatalf("unexpected summary body:\n%s", string(body))
+	}
+	if strings.Contains(string(body), "Kernel ID:") {
+		t.Fatalf("expected no kernel id for fallback summary, got:\n%s", string(body))
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("expected executeRequest not to write stderr directly, got %q", stderr.String())

--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -27,6 +27,7 @@ const (
 type FailureStage string
 
 const (
+	FailureStageExecution        FailureStage = "execution"
 	FailureStageConfig           FailureStage = "config"
 	FailureStageTargetResolution FailureStage = "target-resolution"
 	FailureStageBundleStaging    FailureStage = "bundle-staging"


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #109 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
Implemented the pre-result failure fallback for kgh github run. 

executeRequest in cmd/kgh/main.go no longer returns immediately when runner.Execute fails without ErrorWithResult. It now synthesizes a minimal execution.Result, attaches a generic FailureStageExecution, writes the JSON payload, and still runs the GitHub reporter so the Actions summary gets a failure section. I also added the new failure stage constant in internal/execution/execution.go. 

The regression coverage is in cmd/kgh/main_test.go: there’s now a test proving a plain execution error still writes a summary with Stage: execution, the original error text, and request-level target context, while preserving the existing partial-result failure behavior.

<!-- close -->