### PR TITLE
Github action summary when resolution failed

### DIFF
--- a/cmd/kgh/main.go
+++ b/cmd/kgh/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -31,8 +32,24 @@ type githubExecutionReporter interface {
 	WriteExecutionReport(context.Context, execution.Result, *execution.FailureSummary) error
 }
 
+type githubTriggerResolver interface {
+	Resolve(context.Context) (parser.Trigger, error)
+}
+
+type githubSummaryWriter interface {
+	WriteExecutionSummary(execution.Result, *execution.FailureSummary) error
+}
+
 var newGitHubReporter = func() githubExecutionReporter {
 	return ghctx.NewRunReporter()
+}
+
+var newTriggerResolver = func() githubTriggerResolver {
+	return ghctx.NewTriggerResolver()
+}
+
+var newGitHubSummaryWriter = func() githubSummaryWriter {
+	return ghctx.NewSummaryWriter()
 }
 
 func main() {
@@ -131,8 +148,11 @@ func githubCommand(ctx context.Context, args []string, stdout, stderr io.Writer)
 		return 1, err
 	}
 
-	trigger, err := ghctx.NewTriggerResolver().Resolve(ctx)
+	trigger, err := newTriggerResolver().Resolve(ctx)
 	if err != nil {
+		if summaryErr := writeGitHubTriggerFailureSummary(flags.sharedRunFlags, err); summaryErr != nil {
+			return 1, errors.Join(err, summaryErr)
+		}
 		return 1, err
 	}
 
@@ -201,6 +221,23 @@ func fallbackReport(req execution.Request) execution.Result {
 			TargetName: req.Target,
 		},
 	}
+}
+
+func writeGitHubTriggerFailureSummary(flags sharedRunFlags, triggerErr error) error {
+	report := fallbackReport(execution.Request{
+		DryRun:       flags.dryRun,
+		ConfigPath:   execution.DefaultConfigPath,
+		PollInterval: flags.pollInterval,
+		PollTimeout:  flags.timeout,
+	})
+	failure := &execution.FailureSummary{
+		Stage: execution.FailureStageGitHubTriggerResolution,
+		Error: triggerErr.Error(),
+	}
+	if err := newGitHubSummaryWriter().WriteExecutionSummary(report, failure); err != nil {
+		return fmt.Errorf("write GitHub summary: %w", err)
+	}
+	return nil
 }
 
 func parseRunFlags(args []string) (runFlags, error) {

--- a/cmd/kgh/main_test.go
+++ b/cmd/kgh/main_test.go
@@ -11,12 +11,18 @@ import (
 
 	"github.com/shotomorisk/kgh/internal/execution"
 	ghctx "github.com/shotomorisk/kgh/internal/github"
+	"github.com/shotomorisk/kgh/internal/parser"
 	"github.com/shotomorisk/kgh/internal/spec"
 )
 
 type fakeExecutionRunner struct {
 	result execution.Result
 	err    error
+}
+
+type fakeTriggerResolver struct {
+	trigger parser.Trigger
+	err     error
 }
 
 type fakeGitHubReporter struct {
@@ -26,6 +32,10 @@ type fakeGitHubReporter struct {
 
 func (f fakeExecutionRunner) Execute(context.Context, execution.Request) (execution.Result, error) {
 	return f.result, f.err
+}
+
+func (f fakeTriggerResolver) Resolve(context.Context) (parser.Trigger, error) {
+	return f.trigger, f.err
 }
 
 func (f *fakeGitHubReporter) WriteExecutionReport(context.Context, execution.Result, *execution.FailureSummary) error {
@@ -344,5 +354,59 @@ func TestExecuteRequestIgnoresMissingGitHubStepSummaryEnv(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunWithIOWritesGitHubSummaryOnTriggerResolutionFailure(t *testing.T) {
+	originalTriggerResolver := newTriggerResolver
+	originalGitHubReporter := newGitHubReporter
+	t.Cleanup(func() {
+		newTriggerResolver = originalTriggerResolver
+		newGitHubReporter = originalGitHubReporter
+	})
+
+	newTriggerResolver = func() githubTriggerResolver {
+		return fakeTriggerResolver{
+			err: errors.New("parse commit message for abc123: no submit trigger found"),
+		}
+	}
+	newGitHubReporter = func() githubExecutionReporter {
+		t.Fatal("expected execution reporter to be skipped on trigger resolution failure")
+		return nil
+	}
+
+	dir := t.TempDir()
+	summaryPath := filepath.Join(dir, "summary.md")
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runWithIO([]string{"github", "run", "--dry-run=false"}, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "parse commit message for abc123: no submit trigger found") {
+		t.Fatalf("unexpected stderr %q", stderr.String())
+	}
+
+	body, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatalf("read summary file: %v", err)
+	}
+	if !strings.Contains(string(body), "### Failure") {
+		t.Fatalf("unexpected summary body:\n%s", string(body))
+	}
+	if !strings.Contains(string(body), "- Stage: `github-trigger-resolution`") {
+		t.Fatalf("unexpected summary body:\n%s", string(body))
+	}
+	if !strings.Contains(string(body), "- Error: parse commit message for abc123: no submit trigger found") {
+		t.Fatalf("unexpected summary body:\n%s", string(body))
+	}
+	if strings.Contains(string(body), "Target:") {
+		t.Fatalf("expected no target in summary, got:\n%s", string(body))
 	}
 }

--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -27,16 +27,17 @@ const (
 type FailureStage string
 
 const (
-	FailureStageExecution        FailureStage = "execution"
-	FailureStageConfig           FailureStage = "config"
-	FailureStageTargetResolution FailureStage = "target-resolution"
-	FailureStageBundleStaging    FailureStage = "bundle-staging"
-	FailureStagePush             FailureStage = "push"
-	FailureStagePoll             FailureStage = "poll"
-	FailureStageOutputDir        FailureStage = "output-dir"
-	FailureStageDownloadOutput   FailureStage = "download-output"
-	FailureStageOutputValidation FailureStage = "output-validation"
-	FailureStageSubmit           FailureStage = "submit"
+	FailureStageExecution               FailureStage = "execution"
+	FailureStageConfig                  FailureStage = "config"
+	FailureStageTargetResolution        FailureStage = "target-resolution"
+	FailureStageGitHubTriggerResolution FailureStage = "github-trigger-resolution"
+	FailureStageBundleStaging           FailureStage = "bundle-staging"
+	FailureStagePush                    FailureStage = "push"
+	FailureStagePoll                    FailureStage = "poll"
+	FailureStageOutputDir               FailureStage = "output-dir"
+	FailureStageDownloadOutput          FailureStage = "download-output"
+	FailureStageOutputValidation        FailureStage = "output-validation"
+	FailureStageSubmit                  FailureStage = "submit"
 )
 
 type Request struct {

--- a/internal/reporting/github_summary_test.go
+++ b/internal/reporting/github_summary_test.go
@@ -256,6 +256,26 @@ func TestRenderGitHubSummaryFailureOmitsUnavailableOptionalFields(t *testing.T) 
 	assertNotContains(t, got, "unavailable")
 }
 
+func TestRenderGitHubSummaryGitHubTriggerResolutionFailure(t *testing.T) {
+	t.Parallel()
+
+	got := RenderGitHubSummary(execution.Result{
+		Mode: execution.ModeLive,
+	}, GitHubSummaryOptions{
+		Failure: &execution.FailureSummary{
+			Stage: execution.FailureStageGitHubTriggerResolution,
+			Error: "parse commit message for abc123: no submit trigger found",
+		},
+	})
+
+	assertContains(t, got, "### Failure")
+	assertContains(t, got, "- Stage: `github-trigger-resolution`")
+	assertContains(t, got, "- Error: parse commit message for abc123: no submit trigger found")
+	assertNotContains(t, got, "Target:")
+	assertNotContains(t, got, "Kernel ID:")
+	assertNotContains(t, got, "References:")
+}
+
 func assertContains(t *testing.T, got, want string) {
 	t.Helper()
 	if !strings.Contains(got, want) {


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #111 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->

Implemented the early GitHub-trigger failure summary path. kgh github run now writes a GitHub Actions failure summary even when trigger resolution fails before execution starts. 

The CLI uses a new trigger-resolver seam plus a direct summary-writer path in cmd/kgh/main.go, and the failure is labeled with the new github-trigger-resolution stage in internal/execution/execution.go. This keeps the original non-zero error behavior while making the workflow page informative. I added a CLI regression test in cmd/kgh/main_test.go and a rendering test in internal/reporting/ github_summary_test.go to pin the summary contract for this early-failure path.


<!-- close -->